### PR TITLE
disable cache for worship services

### DIFF
--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -77,7 +77,7 @@ defmodule Dispatcher do
   end
 
   match "/worship-services/*path", %{ accept: [:json], layer: :api} do
-    Proxy.forward conn, path, "http://resource/worship-services/"
+    Proxy.forward conn, path, "http://resource/worship-services/" # DISABLE CACHING FOR NOW (BUG OP-1404)
   end
 
   match "/recognized-worship-types/*path", %{ accept: [:json], layer: :api} do

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -77,7 +77,7 @@ defmodule Dispatcher do
   end
 
   match "/worship-services/*path", %{ accept: [:json], layer: :api} do
-    Proxy.forward conn, path, "http://cache/worship-services/"
+    Proxy.forward conn, path, "http://resource/worship-services/"
   end
 
   match "/recognized-worship-types/*path", %{ accept: [:json], layer: :api} do


### PR DESCRIPTION
fix OP-1394.

How to reproduce:

-  create a new bestuur (worship service)
- create a new position (bedinaer) with a new person
- once saved, click on edit the bedinaer then click annuleer
- => the position disappears from bedinaer
- refresh the page, the position is lost unless you restart the cache

Checkout the branch:

- do the same as above
- the position doesn't disappear now