### PR TITLE
normalize spaces

### DIFF
--- a/config/migrations/2022/202206131O4623-normalize-space.sparql
+++ b/config/migrations/2022/202206131O4623-normalize-space.sparql
@@ -12,8 +12,9 @@ INSERT {
 WHERE {
   graph <http://mu.semte.ch/graphs/organisatieportaal> {
     ?s ?p ?o.
-    BIND (replace(?o, "^(\\s+)|(\\s+)$", "") as ?removeTrailingSpace).
-    BIND (replace(?removeTrailingSpace, "\\s{2,}", " ") as ?normalize).
-    filter(isLITERAL(?o) && (regex(?o, "\\s{2,}") || regex(?o, "^(\\s+)|(\\s+)$")) )
+    BIND(replace(?o, "\\s+|\\t", " ") AS ?single_space)
+    BIND(replace(?single_space, "^(\\s+)|(\\s+)$|(\\t)$|(\\t)", "") AS ?normalize)
+
+    FILTER ( isLiteral(?o) && ( regex(?o, "\\s+|\\t") || regex(?o, "^(\\s+)|(\\s+)$|(\\t)$|(\\t)") ) )
   }
-}
+} 

--- a/config/migrations/2022/202206131O4623-normalize-space.sparql
+++ b/config/migrations/2022/202206131O4623-normalize-space.sparql
@@ -1,0 +1,19 @@
+DELETE {
+  graph <http://mu.semte.ch/graphs/organisatieportaal> {
+   ?s ?p ?o.
+  }
+
+}
+INSERT {
+  graph <http://mu.semte.ch/graphs/organisatieportaal> {
+    ?s ?p ?normalize.
+  }
+}
+WHERE {
+  graph <http://mu.semte.ch/graphs/organisatieportaal> {
+    ?s ?p ?o.
+    BIND (replace(?o, "^(\\s+)|(\\s+)$", "") as ?removeTrailingSpace).
+    BIND (replace(?removeTrailingSpace, "\\s{2,}", " ") as ?normalize).
+    filter(isLITERAL(?o) && (regex(?o, "\\s{2,}") || regex(?o, "^(\\s+)|(\\s+)$")) )
+  }
+}


### PR DESCRIPTION
OP-1495:

For some reasons there are few remainings after script runs, but it should be just a few.
```sparql
select ?o ?normalize  where {
  graph <http://mu.semte.ch/graphs/organisatieportaal> {
    ?s ?p ?o.
    BIND (replace(str(?o), "^(\\s+)|(\\s+)$", "") as ?removeTrailingSpace).
    BIND (replace(?removeTrailingSpace, "\\s{2,}", " ") as ?normalize).

    filter(isLITERAL(?o) && (regex(?o, "\\s{2,}") || regex(?o, "^(\\s+)|(\\s+)$")) )

  } 
}
```