### PR TITLE
update toezicht with new definition

### DIFF
--- a/config/migrations/2022/20220719112423-update-toezicht.sparql
+++ b/config/migrations/2022/20220719112423-update-toezicht.sparql
@@ -1,0 +1,90 @@
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX locn: <http://www.w3.org/ns/locn#>
+PREFIX schema: <http://schema.org/>
+PREFIX regorg: <http://www.w3.org/ns/regorg#>
+PREFIX person: <http://www.w3.org/ns/person#>
+PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
+PREFIX dbpedia: <http://dbpedia.org/ontology/>
+PREFIX adms: <http://www.w3.org/ns/adms#>
+PREFIX euro: <http://data.europa.eu/m8g/>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX organisatie: <https://data.vlaanderen.be/ns/organisatie#>
+PREFIX persoon: <https://data.vlaanderen.be/ns/persoon#>
+PREFIX adres: <https://data.vlaanderen.be/ns/adres#>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX lblodlg: <https://data.lblod.info/vocabularies/leidinggevenden/>
+PREFIX dc_terms: <http://purl.org/dc/terms/>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX euvoc: <http://publications.europa.eu/ontology/euvoc#>
+PREFIX ere: <http://data.lblod.info/vocabularies/erediensten/>
+PREFIX ch: <http://data.lblod.info/vocabularies/contacthub/>    
+PREFIX code: <http://lblod.data.gift/vocabularies/organisatie/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX adres: <https://data.vlaanderen.be/ns/adres#>
+
+
+SELECT DISTINCT ?bestuur ?label ?typeEredienst ?provincie ?municipality ?betrokkenheid WHERE {
+  {
+    SELECT ?bestuur ?betrokkenheid (COUNT(DISTINCT ?betrokkenheid) as ?betrokkenheidCount)  WHERE {
+      ?bestuur
+        a
+          ?type.
+
+      FILTER (?type IN (
+        <http://data.lblod.info/vocabularies/erediensten/CentraalBestuurVanDeEredienst>,
+        <http://data.lblod.info/vocabularies/erediensten/BestuurVanDeEredienst>
+      ))
+
+       ?betrokkenheid
+          org:organization
+            ?bestuur;
+          ere:typebetrokkenheid <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+          a 
+            ere:BetrokkenLokaleBesturen.
+    }
+    GROUP BY ?bestuur ?betrokkenheid
+    HAVING(COUNT(DISTINCT ?betrokkenheid) > 1)
+    ORDER BY DESC(?betrokkenheidCount)
+  }
+  OPTIONAL {
+    ?bestuur
+      skos:prefLabel
+        ?label
+  }
+  OPTIONAL {
+  	?bestuur
+    	ere:typeEredienst
+     		?typeEredienstUri.
+    OPTIONAL {
+    	?typeEredienstUri
+       	skos:prefLabel
+        	?typeEredienst.
+	  }
+  }
+  OPTIONAL {
+    ?bestuur
+      org:hasPrimarySite
+        ?primarySite.
+	  OPTIONAL {    
+      ?primarySite
+        organisatie:bestaatUit
+          ?sa.
+		  OPTIONAL {
+        ?sa
+          locn:adminUnitL2
+            ?provincie.
+        }
+		  OPTIONAL {
+        ?sa
+          adres:gemeentenaam
+            ?municipality.
+        }
+      }
+    }
+}
+
+  

--- a/config/migrations/2022/20220719112423-update-toezicht.sparql
+++ b/config/migrations/2022/20220719112423-update-toezicht.sparql
@@ -20,71 +20,50 @@ PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX euvoc: <http://publications.europa.eu/ontology/euvoc#>
 PREFIX ere: <http://data.lblod.info/vocabularies/erediensten/>
-PREFIX ch: <http://data.lblod.info/vocabularies/contacthub/>    
+PREFIX ch: <http://data.lblod.info/vocabularies/contacthub/>
 PREFIX code: <http://lblod.data.gift/vocabularies/organisatie/>
 PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX adres: <https://data.vlaanderen.be/ns/adres#>
 
-
-SELECT DISTINCT ?bestuur ?label ?typeEredienst ?provincie ?municipality ?betrokkenheid WHERE {
-  {
-    SELECT ?bestuur ?betrokkenheid (COUNT(DISTINCT ?betrokkenheid) as ?betrokkenheidCount)  WHERE {
-      ?bestuur
-        a
-          ?type.
-
-      FILTER (?type IN (
-        <http://data.lblod.info/vocabularies/erediensten/CentraalBestuurVanDeEredienst>,
-        <http://data.lblod.info/vocabularies/erediensten/BestuurVanDeEredienst>
-      ))
-
-       ?betrokkenheid
-          org:organization
-            ?bestuur;
-          ere:typebetrokkenheid <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
-          a 
-            ere:BetrokkenLokaleBesturen.
-    }
-    GROUP BY ?bestuur ?betrokkenheid
-    HAVING(COUNT(DISTINCT ?betrokkenheid) > 1)
-    ORDER BY DESC(?betrokkenheidCount)
-  }
-  OPTIONAL {
-    ?bestuur
-      skos:prefLabel
-        ?label
-  }
-  OPTIONAL {
-  	?bestuur
-    	ere:typeEredienst
-     		?typeEredienstUri.
-    OPTIONAL {
-    	?typeEredienstUri
-       	skos:prefLabel
-        	?typeEredienst.
-	  }
-  }
-  OPTIONAL {
-    ?bestuur
-      org:hasPrimarySite
-        ?primarySite.
-	  OPTIONAL {    
-      ?primarySite
-        organisatie:bestaatUit
-          ?sa.
-		  OPTIONAL {
-        ?sa
-          locn:adminUnitL2
-            ?provincie.
+DELETE { GRAPH <http://mu.semte.ch/graphs/organisatieportaal> { ?betrokkenheid ere:typebetrokkenheid <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>. } }
+INSERT { GRAPH <http://mu.semte.ch/graphs/organisatieportaal> { ?betrokkenheid ere:typebetrokkenheid <http://lblod.data.gift/concepts/86fcbbbff764f1cba4c7e10dbbae578e>. } }
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/organisatieportaal> {
+    {
+      SELECT DISTINCT ?bestuur ?label ?typeEredienst ?provincie ?municipality ?betrokkenheidCount WHERE {
+        {
+          SELECT ?bestuur (COUNT(DISTINCT ?betrokkenheid) AS ?betrokkenheidCount) WHERE {
+            ?bestuur rdf:type ?type.
+            FILTER(?type IN(ere:CentraalBestuurVanDeEredienst, ere:BestuurVanDeEredienst))
+            ?betrokkenheid org:organization ?bestuur;
+              ere:typebetrokkenheid <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+              rdf:type ere:BetrokkenLokaleBesturen.
+          }
+          GROUP BY ?bestuur
+          HAVING ((COUNT(DISTINCT ?betrokkenheid)) > 1 )
+          ORDER BY DESC (?betrokkenheidCount)
         }
-		  OPTIONAL {
-        ?sa
-          adres:gemeentenaam
-            ?municipality.
+        OPTIONAL { ?bestuur skos:prefLabel ?label. }
+        OPTIONAL {
+          ?bestuur ere:typeEredienst ?typeEredienstUri.
+          OPTIONAL { ?typeEredienstUri skos:prefLabel ?typeEredienst. }
+        }
+        OPTIONAL {
+          ?bestuur org:hasPrimarySite ?primarySite.
+          OPTIONAL {
+            ?primarySite organisatie:bestaatUit ?sa.
+            OPTIONAL { ?sa locn:adminUnitL2 ?provincie. }
+            OPTIONAL { ?sa adres:gemeentenaam ?municipality. }
+          }
         }
       }
     }
+    ?betrokkenheid org:organization ?bestuur;
+      ere:typebetrokkenheid <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+      rdf:type ere:BetrokkenLokaleBesturen.
+    ?administrativeUnit ere:betrokkenBestuur ?betrokkenheid.
+    OPTIONAL { ?administrativeUnit skos:prefLabel ?administrativeUnitLabel. }
+    FILTER(?administrativeUnitLabel != ?municipality)
+  }
 }
-
-  


### PR DESCRIPTION
### OP-1606

**new definition:**

Toezichthouder: Kan slechts 1 gemeente/provincie zijn per eredienstbestuur. Dit is de hoofdgemeente/provincie zodat duidelijk is waarnaar de notulen moeten gezonden worden, wie de andere gemeentes/provincies moet betrekken etc. Bij de orthodoxe en de islamitische besturen zal hier dus de naam van een provincie moeten staan en niet de naam van een gemeente. Bijkomend wordt er een financieringspercentage vermeld.

 

**data changes:**

there are 119 worship services that have this relationship more than one. The local municipality that isn't the main "toezichthouder", need to get the role "mede-financierend" assigned.

**how to test**

- with prod data, this one seems to correspond to a case:

http://localhost:4200/bestuurseenheden/77fd7b2aeb6bcb3f7d80db6e25a98e41/betrokken-lokale-besturen

- run the migrations, restart the cache and check again; it should be:

![image](https://user-images.githubusercontent.com/3816305/179926975-04264946-5f98-4087-ba07-2a1c15805d5b.png)
