### PR TITLE
Replace dates by datetimes in the db for organen

### DIFF
--- a/config/migrations/2022/20221003102512-organen-start-and-end-should-be-datetimes-part-one.sparql
+++ b/config/migrations/2022/20221003102512-organen-start-and-end-should-be-datetimes-part-one.sparql
@@ -1,0 +1,50 @@
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX ere: <http://data.lblod.info/vocabularies/erediensten/>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+
+DELETE {
+  GRAPH ?g {
+    ?orgaanInTime mandaat:bindingEinde ?end .
+  }
+} INSERT {
+  GRAPH ?g {
+    ?orgaanInTime mandaat:bindingEinde ?endDateTime .
+  }
+} WHERE {
+  GRAPH ?g {
+    ?bestuurseenheid a ?type .
+
+    ?bestuursorgaan besluit:bestuurt ?bestuurseenheid .
+
+    ?orgaanInTime generiek:isTijdspecialisatieVan ?bestuursorgaan .
+
+    ?orgaanInTime mandaat:bindingEinde ?end .
+    FILTER (datatype(?end) = xsd:date)
+    BIND(strdt(concat(str(?end), 'T01:00:00'), xsd:dateTime) as ?endDateTime)
+  }
+}
+
+;
+
+DELETE {
+  GRAPH ?g {
+    ?orgaanInTime mandaat:bindingStart ?start .
+  }
+} INSERT {
+  GRAPH ?g {
+    ?orgaanInTime mandaat:bindingStart ?startDateTime .
+  }
+} WHERE {
+  GRAPH ?g {
+    ?bestuurseenheid a ?type .
+
+    ?bestuursorgaan besluit:bestuurt ?bestuurseenheid .
+
+    ?orgaanInTime generiek:isTijdspecialisatieVan ?bestuursorgaan .
+
+    ?orgaanInTime mandaat:bindingStart ?start .
+    FILTER (datatype(?start) = xsd:date)
+    BIND(strdt(concat(str(?start), 'T01:00:00'), xsd:dateTime) as ?startDateTime)
+  }
+}

--- a/config/migrations/2022/20221003102513-organen-start-and-end-should-be-datetimes-part-two.sparql
+++ b/config/migrations/2022/20221003102513-organen-start-and-end-should-be-datetimes-part-two.sparql
@@ -1,0 +1,52 @@
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX ere: <http://data.lblod.info/vocabularies/erediensten/>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+
+DELETE {
+  GRAPH ?g {
+    ?orgaanInTime mandaat:bindingEinde ?end .
+  }
+} INSERT {
+  GRAPH ?g {
+    ?orgaanInTime mandaat:bindingEinde ?endDateTime .
+  }
+} WHERE {
+  GRAPH ?g {
+    ?bestuurseenheid a ?type .
+
+    ?bestuursorgaan besluit:bestuurt ?bestuurseenheid .
+
+    ?orgaanInTime generiek:isTijdspecialisatieVan ?bestuursorgaan .
+
+    ?orgaanInTime mandaat:bindingEinde ?end .
+
+    FILTER (HOURS(?end) = 1)
+    BIND(strdt(concat(xsd:date(?end), 'T00:00:00'), xsd:dateTime) as ?endDateTime)
+  }
+}
+
+;
+
+DELETE {
+  GRAPH ?g {
+    ?orgaanInTime mandaat:bindingStart ?start .
+  }
+} INSERT {
+  GRAPH ?g {
+    ?orgaanInTime mandaat:bindingStart ?startDateTime .
+  }
+} WHERE {
+  GRAPH ?g {
+    ?bestuurseenheid a ?type .
+
+    ?bestuursorgaan besluit:bestuurt ?bestuurseenheid .
+
+    ?orgaanInTime generiek:isTijdspecialisatieVan ?bestuursorgaan .
+
+    ?orgaanInTime mandaat:bindingStart ?start .
+
+    FILTER (HOURS(?start) = 1)
+    BIND(strdt(concat(xsd:date(?start), 'T00:00:00'), xsd:dateTime) as ?startDateTime)
+  }
+}


### PR DESCRIPTION
Loket uses dates and OP datetimes for this data. We decided to delay the decision of which one we should pick, so i'm updating it in OP to be consistent with the rest of the app.

Had to do it in two parts because it doesn't want to update a date to the same value in a datetime format apparently :grimacing: 