### PR TITLE
Create and uniformize dates or organen before 2023

### DIFF
--- a/config/migrations/2022/20221004164323-uniformize-dates-or-organen-before-2023.sparql
+++ b/config/migrations/2022/20221004164323-uniformize-dates-or-organen-before-2023.sparql
@@ -1,0 +1,113 @@
+# Part 1: set dates for 2020-2023
+
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX ere: <http://data.lblod.info/vocabularies/erediensten/>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/organisatieportaal> {
+    ?orgaanInTime mandaat:bindingStart ?start .
+    ?orgaanInTime mandaat:bindingEinde ?end .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/organisatieportaal> {
+    ?orgaanInTime mandaat:bindingStart "2020-04-01T00:00:00"^^xsd:dateTime .
+    ?orgaanInTime mandaat:bindingEinde "2023-03-31T00:00:00"^^xsd:dateTime .
+  }
+} WHERE {
+  ?orgaanInTime generiek:isTijdspecialisatieVan ?bestuursorgaan .
+
+  OPTIONAL { ?orgaanInTime mandaat:bindingStart ?start . }
+  OPTIONAL { ?orgaanInTime mandaat:bindingEinde ?end . }
+
+  {
+    SELECT DISTINCT ?bestuursorgaan MAX(?end) as ?maxEnd WHERE {
+      GRAPH <http://mu.semte.ch/graphs/organisatieportaal> {
+        VALUES ?type {
+          ere:BestuurVanDeEredienst
+          ere:CentraalBestuurVanDeEredienst
+        }
+
+        ?bestuurseenheid a ?type .
+
+        FILTER NOT EXISTS {
+          ?bestuurseenheid <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311> .
+        }
+
+        ?bestuursorgaan besluit:bestuurt ?bestuurseenheid .
+
+        ?orgaanInTime generiek:isTijdspecialisatieVan ?bestuursorgaan .
+    
+        OPTIONAL { ?orgaanInTime mandaat:bindingStart ?start . }
+        OPTIONAL {
+          ?orgaanInTime mandaat:bindingEinde ?end .
+          FILTER( ?end != "2026-03-31T00:00:00"^^xsd:dateTime )
+          FILTER( ?end != "2029-03-31T00:00:00"^^xsd:dateTime )
+        }
+      }
+    }
+    GROUP BY ?bestuursorgaan
+    ORDER BY ?maxEnd
+  }
+
+  # If we have a maxEnd value from the subquery, we want the organ in time that has the same end value to update it
+  # If there is no maxEnd value, then we need the orgaan that has no end value set
+  FILTER( IF(bound(?maxEnd), ?maxEnd = ?end, !bound(?end)) )
+}
+
+;
+
+# Part 2: set dates for 2017-2020
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/organisatieportaal> {
+    ?orgaanInTime mandaat:bindingStart ?start .
+    ?orgaanInTime mandaat:bindingEinde ?end .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/organisatieportaal> {
+    ?orgaanInTime mandaat:bindingStart "2017-04-01T00:00:00"^^xsd:dateTime .
+    ?orgaanInTime mandaat:bindingEinde "2020-03-31T00:00:00"^^xsd:dateTime .
+  }
+} WHERE {
+  ?orgaanInTime generiek:isTijdspecialisatieVan ?bestuursorgaan .
+
+  OPTIONAL { ?orgaanInTime mandaat:bindingStart ?start . }
+  OPTIONAL { ?orgaanInTime mandaat:bindingEinde ?end . }
+
+  {
+    SELECT DISTINCT ?bestuursorgaan MAX(?end) as ?maxEnd WHERE {
+      GRAPH <http://mu.semte.ch/graphs/organisatieportaal> {
+        VALUES ?type {
+          ere:BestuurVanDeEredienst
+          ere:CentraalBestuurVanDeEredienst
+        }
+
+        ?bestuurseenheid a ?type .
+
+        FILTER NOT EXISTS {
+          ?bestuurseenheid <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311> .
+        }
+
+        ?bestuursorgaan besluit:bestuurt ?bestuurseenheid .
+
+        ?orgaanInTime generiek:isTijdspecialisatieVan ?bestuursorgaan .
+    
+        OPTIONAL { ?orgaanInTime mandaat:bindingStart ?start . }
+        OPTIONAL {
+          ?orgaanInTime mandaat:bindingEinde ?end .
+          FILTER( ?end != "2023-03-31T00:00:00"^^xsd:dateTime )
+          FILTER( ?end != "2026-03-31T00:00:00"^^xsd:dateTime )
+          FILTER( ?end != "2029-03-31T00:00:00"^^xsd:dateTime )
+        }
+      }
+    }
+    GROUP BY ?bestuursorgaan
+    ORDER BY ?maxEnd
+  }
+
+  # If we have a maxEnd value from the subquery, we want the organ in time that has the same end value to update it
+  # If there is no maxEnd value, then we need the orgaan that has no end value set
+  FILTER( IF(bound(?maxEnd), ?maxEnd = ?end, !bound(?end)) )
+}


### PR DESCRIPTION
OP-1821

This one is a bit tricky, I tried to check on multiple ways that it was correct but can you double check ? :sweat_smile: 

Here is a small query I used to control my results, it gives the options of start / end dates of organen:
```
PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
PREFIX ere: <http://data.lblod.info/vocabularies/erediensten/>
PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>

SELECT DISTINCT ?start ?end WHERE {
  GRAPH <http://mu.semte.ch/graphs/organisatieportaal> {
    VALUES ?type {
      ere:BestuurVanDeEredienst
      ere:CentraalBestuurVanDeEredienst
    }

    ?bestuurseenheid a ?type .

    FILTER NOT EXISTS {
      ?bestuurseenheid <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311> .
    }

    ?bestuursorgaan besluit:bestuurt ?bestuurseenheid .

    ?orgaanInTime generiek:isTijdspecialisatieVan ?bestuursorgaan .
    OPTIONAL { ?orgaanInTime mandaat:bindingStart ?start . }
    OPTIONAL { ?orgaanInTime mandaat:bindingEinde ?end . }
  }
}
```