### PR TITLE
Add missing betrokken lokale besturen links

### DIFF
--- a/config/migrations/2022/20221209093743-add-missing-betrokken-besturen.graph
+++ b/config/migrations/2022/20221209093743-add-missing-betrokken-besturen.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/organisatieportaal

--- a/config/migrations/2022/20221209093743-add-missing-betrokken-besturen.ttl
+++ b/config/migrations/2022/20221209093743-add-missing-betrokken-besturen.ttl
@@ -1,0 +1,3070 @@
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/39db6dfe-579c-4c1d-9851-f18547643a33>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "39db6dfe-579c-4c1d-9851-f18547643a33";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/c0dbefab60a716897974cfc8c761234e> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/14d5d68e-ac34-4793-8fde-e43569f0c37d>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "14d5d68e-ac34-4793-8fde-e43569f0c37d";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/ac63ea7e74aeadaf1ba2dd975d3a8e17> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/54281766-9fce-42be-9c83-b8d1ee171e74>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "54281766-9fce-42be-9c83-b8d1ee171e74";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/c6a9da77af05772a230a65d3433b7bd1> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/c0bcd3a6-517a-4669-a376-c31e3ae6cc17>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c0bcd3a6-517a-4669-a376-c31e3ae6cc17";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/11eb78e7063700deeac52f3216b04091> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/cd8d283b-7e5d-427a-be95-6ff9b87db757>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd8d283b-7e5d-427a-be95-6ff9b87db757";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/6650ca39f706d085529db9117532854d> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/86b1eac5-aa95-475c-93df-b9586eb077de>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "86b1eac5-aa95-475c-93df-b9586eb077de";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/988321712204bd0104fb62e6f5dbe104> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/15acbee6-a360-43ff-b5cc-fe5dc3bc03ce>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "15acbee6-a360-43ff-b5cc-fe5dc3bc03ce";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/0663f35b045b0844471f910569be9af1> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/296eff94-b3cc-473b-abef-5abf68590916>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "296eff94-b3cc-473b-abef-5abf68590916";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/6338b726369203c13e485eeeb8609a85> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/bba8e9b3-547d-4f52-88cf-36ba90b0cfd8>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bba8e9b3-547d-4f52-88cf-36ba90b0cfd8";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/67bb778cb5e46d1b6ec2c8bf5ce752df> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/e2dfa734-ed22-4109-bae1-979575030fbc>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2dfa734-ed22-4109-bae1-979575030fbc";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/d3db33b0a87518a0901529dfd381ef3c> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/291d611f-e5e8-4e65-b0d9-4ddd39026ce0>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "291d611f-e5e8-4e65-b0d9-4ddd39026ce0";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/1e79c9d4e55e620ab86d6557b581e4a5> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/34c15ea2-7347-4ad7-a3fe-4c0540e6a00b>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "34c15ea2-7347-4ad7-a3fe-4c0540e6a00b";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/a1ff2293a29e4153e3f8ce45b5f35cc7> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/fcb1b005-226d-4b9a-94ee-25bab1950a52>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fcb1b005-226d-4b9a-94ee-25bab1950a52";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/7e5d43f4b342abad639f2bbe1cdb577f> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/134dec04-7788-49af-b539-1b2a3b7b2f9b>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "134dec04-7788-49af-b539-1b2a3b7b2f9b";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/8bc752c3a306ef5a99a985e011bb3084> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/8f8d28c9-5776-4bb7-9da5-ca8498d36130>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8f8d28c9-5776-4bb7-9da5-ca8498d36130";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/16dd67b1eacdcafc5b0f5417c6513376> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/91d5cddd-2127-42c4-a14b-9ac09410d35f>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "91d5cddd-2127-42c4-a14b-9ac09410d35f";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/e1cd7c9c679c20f2d93ab8e0586826b3> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/8609c2af-ab32-4b1d-8166-5a8aa9549145>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8609c2af-ab32-4b1d-8166-5a8aa9549145";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/aaedd771300131f4a5ae19222d13750c> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/60535a06-07a0-4071-8a1b-f776f7d4d68d>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "60535a06-07a0-4071-8a1b-f776f7d4d68d";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/e52ba13f6d406f8d8b8516b7ae3457a8> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/a44ea2b7-65df-41ee-a747-7065a7f8df1a>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a44ea2b7-65df-41ee-a747-7065a7f8df1a";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/fb33941e06307ff7f7720e909a9f56be> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/339eb0e3-fbb1-4a6d-9284-e4b47c7afb82>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "339eb0e3-fbb1-4a6d-9284-e4b47c7afb82";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/5ed64ec4ad849d38ba0cc74fe57ccba1> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/206dfcd4-a6b2-4b04-b83a-3ef2b7a0d630>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "206dfcd4-a6b2-4b04-b83a-3ef2b7a0d630";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/ab81cc20a3b6a495192dd6bce6804d8a> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/744e85a0-5217-4f1e-a863-5845f7b19b5a>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "744e85a0-5217-4f1e-a863-5845f7b19b5a";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/b9ad1b63c76033e90ed0a3b3b1903e01> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/306b56d0-5294-4ee6-bf22-b62cfdda8d32>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "306b56d0-5294-4ee6-bf22-b62cfdda8d32";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/7599df3e813e98e768376858c0aa5725> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/7a4c7098-a524-4c1c-abdd-d674a31df7b1>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a4c7098-a524-4c1c-abdd-d674a31df7b1";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/ff3b6b1f52b9203adeeda0e391ff8d65> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/127859a0-41f8-4593-9e65-a0ecdc354bdc>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "127859a0-41f8-4593-9e65-a0ecdc354bdc";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/7c87f8d06e9a1ea5eced78ba2f3607b4> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/ce1026f8-7474-47f2-86bc-80851d14b15b>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce1026f8-7474-47f2-86bc-80851d14b15b";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/a37d869d25f4f0771e035612a2386171> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/77e4d005-5acc-45f7-ab52-c37cdbd27840>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "77e4d005-5acc-45f7-ab52-c37cdbd27840";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/e08a8bc5828bd44e735724a79b588b13> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/0e305e28-e4c8-485a-9d78-4c8a4932108d>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0e305e28-e4c8-485a-9d78-4c8a4932108d";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/6d4226a920cc47e4d4bbfddb451f4883> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/c86dfd33-5286-4981-911a-b14182685c0e>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c86dfd33-5286-4981-911a-b14182685c0e";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/23a81c1caca0dd05be50606e130e1ffa> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/f857ddda-4349-4918-9eb0-7fa95c82f903>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f857ddda-4349-4918-9eb0-7fa95c82f903";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/3e95fcbcdde9a46586f91b693985578f> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/d8d2a773-c569-4ac5-b0f4-f67560705124>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d8d2a773-c569-4ac5-b0f4-f67560705124";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/2d4cf19958d51cfa78c8f973aa0f72b2> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/90a72485-877d-428e-9b7a-41a5e282acf3>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "90a72485-877d-428e-9b7a-41a5e282acf3";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/ad7e54d4340f1ec44196fd7d8ef6a16f> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/a3dba296-e6a9-481c-b708-6c57b04c30e0>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a3dba296-e6a9-481c-b708-6c57b04c30e0";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/470e6c2ae3bd23ff19627de3db5acb5d> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/2fd9d299-0826-47ab-8a4d-e56247fe703a>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2fd9d299-0826-47ab-8a4d-e56247fe703a";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/8c33605cb031cc83d3eec5374486764f> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/04a73cb0-8e64-4609-804d-8d189f3e8ceb>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "04a73cb0-8e64-4609-804d-8d189f3e8ceb";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/1229a535965489c67fe06863d8499489> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/8fe7a0f7-767f-4fd2-94f0-8e4c0c3b529e>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8fe7a0f7-767f-4fd2-94f0-8e4c0c3b529e";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/00034fce426a0d8b29c04f0083bebdbc> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/7c989a6c-ef15-490c-a972-13b380892fb4>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7c989a6c-ef15-490c-a972-13b380892fb4";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/3c9e86c4e8bb96ebf62cb550ae27f8ec> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/18ad5664-1873-4ef1-8be0-7235f903d4c2>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "18ad5664-1873-4ef1-8be0-7235f903d4c2";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/aa540078b526c2b26fdb2cd64c6a23ca> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/8ebc757c-c4d8-486f-a01c-93e25c72708e>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8ebc757c-c4d8-486f-a01c-93e25c72708e";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/8228a9f0738d350cd5f9e1e6c786e2b7> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/7316fb2f-388b-40f8-b6fa-49a91255d6c4>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7316fb2f-388b-40f8-b6fa-49a91255d6c4";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/4ef7dc9c2640f979c6b920bf7b5883c1> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/6018fdd0-5588-4652-935f-72fb9f48a03b>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6018fdd0-5588-4652-935f-72fb9f48a03b";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/f7a23007e6facffd5a7e8ec1fb0d9ff9> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/5bbe9ad0-2066-4ae4-b893-301ae1a3c8b8>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5bbe9ad0-2066-4ae4-b893-301ae1a3c8b8";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/a5926d5d5615d19d42516708e57d6f9e> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/d2a63b79-a907-4e67-a283-dde537b38eca>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d2a63b79-a907-4e67-a283-dde537b38eca";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/763f504a83d90dbbf3e9a8c14ebf3d53> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/8c7ad881-4f96-4beb-b69a-0e4a9ac3048a>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8c7ad881-4f96-4beb-b69a-0e4a9ac3048a";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/e451786ef8b4c8a07f17026e7f1f2591> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/ad165bd6-0fb9-43df-8e74-28370f306aed>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad165bd6-0fb9-43df-8e74-28370f306aed";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/b0de52142409bb07460f83ca122a4065> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/2b5d3333-d0c0-4d56-9435-fa56b32bba7a>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2b5d3333-d0c0-4d56-9435-fa56b32bba7a";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/1664fd03363a8c8dffe3e15395d86793> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/c8a4618d-e6f8-4ed4-8dc0-0a1ebc19edf3>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c8a4618d-e6f8-4ed4-8dc0-0a1ebc19edf3";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/f4597237766ec48f09342376aa100ba6> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/992017f5-247b-4e02-acfd-e9882a336cef>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "992017f5-247b-4e02-acfd-e9882a336cef";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/f0806dfee551e542e1a19345039cce89> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/94ee9cd9-350e-4cf4-8037-d84e989b13cd>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "94ee9cd9-350e-4cf4-8037-d84e989b13cd";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/6c1f9b1bc84bde2580d7f0b6f99e161c> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/239249a4-1121-48fa-a4d2-99f57a1a6ffa>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "239249a4-1121-48fa-a4d2-99f57a1a6ffa";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/e2a89c5148497837231ca66f78c374e7> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/565404af-88c0-4005-a976-1fcd2f786e48>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "565404af-88c0-4005-a976-1fcd2f786e48";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/c6bd7b25845d090225a5f97028460db6> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/787879fb-d398-4cdf-9d3e-31bd3fcde711>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "787879fb-d398-4cdf-9d3e-31bd3fcde711";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/747adb4cc6e38669770483045a85fafe> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/13737cc0-59e5-439c-95b0-fddc4352a4dc>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "13737cc0-59e5-439c-95b0-fddc4352a4dc";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/4c03829486377310ada8bf402bb591be> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/ca1146a6-786d-4e67-897a-6f9be3a63f8d>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ca1146a6-786d-4e67-897a-6f9be3a63f8d";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/d796104dc81d31ae3f8ff11fa747fc1f> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/9dbc6857-0647-4e8c-85e9-83042bdc0e5c>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9dbc6857-0647-4e8c-85e9-83042bdc0e5c";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/12d5b21526cc13e0f93688f39d78a5c9> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/f83ee6da-c5c6-48cf-b47a-bd7cde8ef7d1>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f83ee6da-c5c6-48cf-b47a-bd7cde8ef7d1";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/3e3104151f00158c57143ee213c7c142> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/4219f672-aa0c-4d1e-97b0-ed779d14e390>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4219f672-aa0c-4d1e-97b0-ed779d14e390";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/7e8dd1a737cd74292b354d7462071967> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/6798d9cd-f314-4bca-8488-2f376439abdd>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6798d9cd-f314-4bca-8488-2f376439abdd";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/0ae8ca7fa946fb4a55ce13a3f11e6de3> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/428f7bb2-ec40-4ec8-be93-cc1f9cf118c2>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "428f7bb2-ec40-4ec8-be93-cc1f9cf118c2";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/ab9c349ad86afa91354403ebc83a209f> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/64d7773a-810b-4eee-9172-bffaa2946ee1>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "64d7773a-810b-4eee-9172-bffaa2946ee1";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/d5cae1ae4afe37b22883eb47d6a45f63> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/e088c7f4-b5b4-4f55-9815-43c1be94bd2f>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e088c7f4-b5b4-4f55-9815-43c1be94bd2f";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/89bddac0557f154bc1c8dad2a8a2c99c> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/83cff3a2-7ab0-4cb7-b9b1-01f88265817e>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "83cff3a2-7ab0-4cb7-b9b1-01f88265817e";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/68570ea78b2d92fbde2c5f44598aeb7b> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/d1917ea6-f1c5-41cf-b2af-447f1d370d01>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d1917ea6-f1c5-41cf-b2af-447f1d370d01";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/0b00afc27c26f56c3a0461da6edf85c6> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/64ae6d76-aa1c-4df7-99d3-4efd9a4320df>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "64ae6d76-aa1c-4df7-99d3-4efd9a4320df";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/8ba8822c3b00f03944595c8162f292c7> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/570ac453-b6b7-47ea-869e-2047b0f7906e>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "570ac453-b6b7-47ea-869e-2047b0f7906e";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/d119dfe1d065867b6cf324d855667e87> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/741ddc80-fdff-432f-895d-484ee3fb035c>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "741ddc80-fdff-432f-895d-484ee3fb035c";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/42dcb2faa3fb60b0fb2c4dde3b4f7049> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/f0c82c4c-e50d-4885-a769-3ecd1edd8ee7>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f0c82c4c-e50d-4885-a769-3ecd1edd8ee7";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/201bf3d0f24abc142839ab1975dce7ef> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/dc963735-8bb7-4faa-9c57-c2bcdbc9782a>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dc963735-8bb7-4faa-9c57-c2bcdbc9782a";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/f11ce4937c2ac92f8671b58e9ef06686> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/7a25c32f-e161-43da-af61-133179ff6fdf>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a25c32f-e161-43da-af61-133179ff6fdf";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/4c2f4b8767b40982182f4b58fd460c1f> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/25c11629-4084-42f8-94ac-918f3ef6cfd4>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "25c11629-4084-42f8-94ac-918f3ef6cfd4";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/e8dd320a92500a374af54ff245814751> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/61e30f3a-54b2-41fb-b2ff-f96207a98d8c>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "61e30f3a-54b2-41fb-b2ff-f96207a98d8c";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/f72d0ad2b8370122458bb034c8e9c92a> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/278ccdf8-5170-4501-9daa-d4a853de40cd>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "278ccdf8-5170-4501-9daa-d4a853de40cd";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/975d75b0f7da715627977acbc22ff787> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/cc97c7ae-8b3f-464d-89c9-30e74abaea79>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cc97c7ae-8b3f-464d-89c9-30e74abaea79";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/5256576d2ebf92fbbf6e90c5281726cb> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/9a3a5452-e626-4886-9499-d4826e70206c>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a3a5452-e626-4886-9499-d4826e70206c";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/c14766b3f2e581d18a3cf6fd8d66cad0> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/b7695bf9-8f3e-4a90-b029-230e069fc38e>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b7695bf9-8f3e-4a90-b029-230e069fc38e";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/c1d987352cd21c00872a3c5d6213564b> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/4ebb7193-400b-4415-9508-4a3af27a029a>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ebb7193-400b-4415-9508-4a3af27a029a";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/0a3d4c6033820af3cd9fd290357dcc80> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/31658bc3-3296-4f2f-9e91-0badefc5c790>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "31658bc3-3296-4f2f-9e91-0badefc5c790";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/29d12a3875be460c1efad5ec141c3a62> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/28246920-b91c-4321-8e10-65c1edc3c7ab>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "28246920-b91c-4321-8e10-65c1edc3c7ab";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/897d8d444870692b84355ba48cca2780> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/250a4a81-2394-4828-8aa8-3ec6e2625908>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "250a4a81-2394-4828-8aa8-3ec6e2625908";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/f49164351a0e8082a6b78213a3c8c008> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/868c83a4-bd00-436f-93a8-3fae5f32ccea>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "868c83a4-bd00-436f-93a8-3fae5f32ccea";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/4086f388462840015ebf122dfa8f357b> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/baa67736-47f5-4838-a5f0-3b2e50af4ae9>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "baa67736-47f5-4838-a5f0-3b2e50af4ae9";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/1303ba105368dfb4676789ba0bab3627> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/8e0e36f0-99fe-4a4f-af12-b0408163ce21>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8e0e36f0-99fe-4a4f-af12-b0408163ce21";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/0d5e0b8c59fce246f637e65ae61c58ff> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/f5413fe1-5117-473a-8f7f-d9da25e2f5a6>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f5413fe1-5117-473a-8f7f-d9da25e2f5a6";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/538208fd709fd5faf54f135662167870> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/e4455570-25ed-478e-8fa4-be7ecac66c11>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e4455570-25ed-478e-8fa4-be7ecac66c11";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/c3da61cd69677ef2e426844e47d1623b> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/50a9a3b9-a9ed-4d94-891d-4d70b8cc1a2a>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50a9a3b9-a9ed-4d94-891d-4d70b8cc1a2a";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/6dcc4f185d281bac86f33eb8e8d70ca5> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/62bd8d74-c266-4a42-8a43-bf8fb8887bf5>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "62bd8d74-c266-4a42-8a43-bf8fb8887bf5";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/e671f09baa23380ad78ba43246d8ee28> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/214bc598-39ea-496e-906b-60ec04543b08>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "214bc598-39ea-496e-906b-60ec04543b08";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/802b6e8a40d5b830347183421a916c43> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/49751f48-7076-40ac-8002-b0793aa4aa5d>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "49751f48-7076-40ac-8002-b0793aa4aa5d";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/5bd5798aaa8ee58aa34480e7125f25d8> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/68c31d29-4373-4215-a9dd-e26b90be567c>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "68c31d29-4373-4215-a9dd-e26b90be567c";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/4af77b9dd26ba78d11d475d9a7271cc7> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/d243b200-81a3-43d7-8dbf-df8f89fae3a3>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d243b200-81a3-43d7-8dbf-df8f89fae3a3";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/46394545d22b118af00ca47b458caaef> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/7bcd745d-6fa6-4a57-94ec-5aae6afd05a1>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7bcd745d-6fa6-4a57-94ec-5aae6afd05a1";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/653566b3d8701ef8469c3dc3b72306dd> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/62786f76-4e5d-46df-958f-b45c95e6aa03>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "62786f76-4e5d-46df-958f-b45c95e6aa03";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/0197b8fc2782a6d3230e011d1a78df0e> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/3c6efedb-efb6-4aaf-877d-7cbbe3bc9aa3>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3c6efedb-efb6-4aaf-877d-7cbbe3bc9aa3";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/10eb80ee6549660245c81adc23abc9a5> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/ed3bebca-9177-4e8c-8e65-27616d334a18>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ed3bebca-9177-4e8c-8e65-27616d334a18";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/aceac0637c572d19a36a7fc3899a5688> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/e9c7a18b-197c-401e-8239-14f990c950fa>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e9c7a18b-197c-401e-8239-14f990c950fa";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/80241fe959d2b3056b8b0da535f5f113> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/568e868f-7005-40b9-957c-9e02054b1a80>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "568e868f-7005-40b9-957c-9e02054b1a80";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/7b37addd68c8e6bc1f1cb4779c7acca1> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/162a3bc7-ec69-4dd2-b352-6848290f4f7a>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "162a3bc7-ec69-4dd2-b352-6848290f4f7a";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/05a52ca709a2c8bb3e3b14c421351ee2> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/12a63c62-dc35-40fa-a9c4-33890fb75b9e>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "12a63c62-dc35-40fa-a9c4-33890fb75b9e";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/64dcf0eaafd13dea75717d9014982106> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/fe93089a-d4c1-4dc7-a774-b3d01decb8c3>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fe93089a-d4c1-4dc7-a774-b3d01decb8c3";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/75876d213202754f3f29769e32bd3004> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/35c5df16-5ef4-43bf-97f0-681654a1549e>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "35c5df16-5ef4-43bf-97f0-681654a1549e";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/fcc582ce10c0275be72cbe8a3607f2d8> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/4ca67124-51c6-4c39-b2c2-76f332d74a90>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ca67124-51c6-4c39-b2c2-76f332d74a90";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/255b2ece2955c30b9f5988675374368b> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/ba45706a-e24e-4adc-96a1-f6475d9e72a0>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ba45706a-e24e-4adc-96a1-f6475d9e72a0";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/9d9f40aed88926475f0c8374e5615ef5> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/a1ffa407-3e09-4c59-8666-41e4d06c93c1>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a1ffa407-3e09-4c59-8666-41e4d06c93c1";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/44e123c39fb439274be6727eca6e1880> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/e894ea54-e3f5-497b-b2db-99244d7b8492>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e894ea54-e3f5-497b-b2db-99244d7b8492";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/2bb736a6ee74c6d3cc17a5bb6a58cf29> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/b6e810a9-565a-4157-b3bb-dcc88e8e5338>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b6e810a9-565a-4157-b3bb-dcc88e8e5338";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/8f62dfc1d963e12c1b17c28118a2ab7e> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/e6b76587-cb8c-4689-9f21-5cfb9f108f9d>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e6b76587-cb8c-4689-9f21-5cfb9f108f9d";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/f5c4c42180a0832e2870c48fbd22c398> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/9f0c28c3-6859-46b9-ac36-b53efaa333d7>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9f0c28c3-6859-46b9-ac36-b53efaa333d7";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/ecc95fff3d8cc7f89a72ffe116837d6e> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/4fb4a21b-74f0-4e98-afb3-62e32c03f793>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4fb4a21b-74f0-4e98-afb3-62e32c03f793";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/cafcd66194078483513960713fb54d1c> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/a11ea4bb-6f42-40b5-948f-2d4645e96b10>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a11ea4bb-6f42-40b5-948f-2d4645e96b10";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/c3e9511c92f8a447d816a354fdc98cde> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/aa9f88e5-132b-4bfa-9c5f-b226c6ef44f1>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aa9f88e5-132b-4bfa-9c5f-b226c6ef44f1";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/c038eb554aaac006ccae0ac48473b51c> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/d22dc214-5d35-46a8-85b6-8f0b2793b7eb>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d22dc214-5d35-46a8-85b6-8f0b2793b7eb";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/c2090bfc094e364c067f114870d68970> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/79c1a286-69a7-4c6d-bfd9-eb82749fd759>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "79c1a286-69a7-4c6d-bfd9-eb82749fd759";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/80c48a10fef7d201a647fcab17c1faaf> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/697412fc-de35-41ee-9786-81e62ef25f56>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "697412fc-de35-41ee-9786-81e62ef25f56";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/51ad7859c97933282619dd172cf4216a> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/207be3f8-e1fc-46f0-acfb-3e9f9660b344>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "207be3f8-e1fc-46f0-acfb-3e9f9660b344";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/d1dde124fb4c0934c7ce4554f48f74f2> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/2ac22503-9450-42c3-82a5-96cab6bd72d4>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ac22503-9450-42c3-82a5-96cab6bd72d4";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/7efe544dc9da3772ac86dc3e6e4a3ef4> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/6572b77d-be77-4c5f-b1fb-473f34ace8ac>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6572b77d-be77-4c5f-b1fb-473f34ace8ac";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/2d98ed47689ebe5f22f3e2e5d2850d0d> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/dd510104-5352-4a44-962f-0424c960c251>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd510104-5352-4a44-962f-0424c960c251";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/eb3d92cd27c3ee32898a5cd0ac6dcdd0> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/d02b415a-c66c-42b6-a15b-0e5101edf9cc>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d02b415a-c66c-42b6-a15b-0e5101edf9cc";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/8aeb4ef0026a4d71755897bffd9971c2> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/0632f407-2829-4a17-afb6-5725fbcf80db>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0632f407-2829-4a17-afb6-5725fbcf80db";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/faef605c68c715df879b3e722fa42c5c> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/f1dcd064-35aa-4d47-a8a9-5f3532e4787f>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f1dcd064-35aa-4d47-a8a9-5f3532e4787f";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/2a6e769bcc2e3aceb62b6dadb15fb444> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/e7c618b7-f47b-46cd-b081-59839d20398f>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e7c618b7-f47b-46cd-b081-59839d20398f";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/1afe711ae6253e8829b4007e92b32d24> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/ff579e0c-fce9-4855-8a06-ede8de9e9754>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ff579e0c-fce9-4855-8a06-ede8de9e9754";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/dec3bf4eba431f27b43a5ae2acbf980f> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/eb38cf59-77d6-4fb1-8912-183d90a6affb>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "eb38cf59-77d6-4fb1-8912-183d90a6affb";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/08cbc05d4ea2763cac5cb3d89e398ba2> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/87d179f6-7413-4137-bdf6-63ac9d4c16d7>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "87d179f6-7413-4137-bdf6-63ac9d4c16d7";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/6c8ed53924c8f453fac84cde0da67511> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/466e8074-bd15-46d7-95e1-02a03527948e>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "466e8074-bd15-46d7-95e1-02a03527948e";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/c41c203121acfef30f65fe321da8b8a4> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/8579babe-cfa9-4dc5-92ed-15044ef5a098>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8579babe-cfa9-4dc5-92ed-15044ef5a098";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/ea95493aefc01581e972145d49a402c8> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/71680486-630e-46a4-8325-37b3026b1385>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "71680486-630e-46a4-8325-37b3026b1385";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/36be04c052d2f62d97f46647acd5fe1b> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/6417268c-ec01-4873-89d1-7bb777ad1583>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6417268c-ec01-4873-89d1-7bb777ad1583";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/495619ac7ab1ff79146e5965de3a42c9> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/64128756-b6c8-4e0b-8fce-df7bbf327c0c>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "64128756-b6c8-4e0b-8fce-df7bbf327c0c";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/c3331e2c0564e1a5338046e8499a143f> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/9905d0ad-9ca5-4077-b5b5-452f207b45f7>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9905d0ad-9ca5-4077-b5b5-452f207b45f7";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/17ce00057e7d9a57b54a44465bea702d> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/77e1f4cb-1055-46d1-b052-852bdd79fe68>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "77e1f4cb-1055-46d1-b052-852bdd79fe68";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/7f6d41112bc738c1e91de38b800b6ec1> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/d19a92da-1ddc-4410-9188-9c3941f41173>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d19a92da-1ddc-4410-9188-9c3941f41173";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/5aa832a66faed51d2baaab795a47f367> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/e0c8b859-c442-4e0f-8735-160a95ba8ac3>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e0c8b859-c442-4e0f-8735-160a95ba8ac3";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/0082b38f2a1d8a5581cccb379afcf6dc> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/09dede7e-1e6e-4c0a-b0f6-2b3c52291d5b>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "09dede7e-1e6e-4c0a-b0f6-2b3c52291d5b";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/f32043e1e8c010305ec98720029f3f77> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/937533ac-0cb8-4e78-91f7-c23dfee89bb2>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "937533ac-0cb8-4e78-91f7-c23dfee89bb2";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/3fa1183fb9a93266f0d6fdce3703f6ee> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/f80a6a4c-9b90-42ae-ab5c-8ab9bbfe2724>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f80a6a4c-9b90-42ae-ab5c-8ab9bbfe2724";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/6021207714f38ae3c7fe2d363c95f6d6> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/089cb5a2-8b1c-4c5b-a49e-5a176a0d145a>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "089cb5a2-8b1c-4c5b-a49e-5a176a0d145a";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/0c88eb2e5090db71890d10bb01cc6d74> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/706b2012-3aba-477e-9c9c-ce47f29e3840>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "706b2012-3aba-477e-9c9c-ce47f29e3840";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/983c09feafcd1cfd402e0dd34ef2ed1c> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/b88e6c3d-21ac-4252-8526-a8fad885002e>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b88e6c3d-21ac-4252-8526-a8fad885002e";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/fd5d0ac7b41b6f0f564262a8b631d8a7> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/3611f01a-6439-4631-9ae1-da38a5ba83f0>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3611f01a-6439-4631-9ae1-da38a5ba83f0";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/7bd10d1872f0b4828adef848f3ae4daa> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/f74bebb6-1322-4d3d-b96c-acce0320ae36>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f74bebb6-1322-4d3d-b96c-acce0320ae36";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/57b73c030003b43a7d279b0b812a91ae> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/d915a89f-703d-49c0-9dc2-7eaf5c419a99>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d915a89f-703d-49c0-9dc2-7eaf5c419a99";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/d1e0e1831eb26a492fa21a1076e4c3b3> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/ce3cce03-8a26-4eb2-8b22-887c99dd27b9>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ce3cce03-8a26-4eb2-8b22-887c99dd27b9";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/b0ffe0e981a7e887a0b949d7ff77096b> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/213e15a7-e334-4aa3-ad36-8cded8a27157>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "213e15a7-e334-4aa3-ad36-8cded8a27157";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/3c92ae3c97f8810b4dfbbfe8a2b0bc3c> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/589e11e6-367b-4649-a15a-ac14ba1c4d8e>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "589e11e6-367b-4649-a15a-ac14ba1c4d8e";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/70f48954f519c0df3bbc492b7a63a253> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/9246c603-62b1-4984-a90b-4f1608b600e4>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9246c603-62b1-4984-a90b-4f1608b600e4";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/70e058024a3cd58f76005d645b892e01> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/35274e45-b5b6-46b2-afe1-98e0aaff5a58>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "35274e45-b5b6-46b2-afe1-98e0aaff5a58";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/bdb1ae37a77888f20019c993d7a76f5c> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/5fb9cd00-c6b5-49b5-8eb5-381bb8167446>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5fb9cd00-c6b5-49b5-8eb5-381bb8167446";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/5c59d93e7393ac84487853c177e8ac9e> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/c34307ad-7555-4140-827d-34f49191622a>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c34307ad-7555-4140-827d-34f49191622a";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/bbd8ec9c417a099257552aaaccca86f8> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/27a6cb6a-e17b-4f57-96e4-b3ff6f783e5a>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "27a6cb6a-e17b-4f57-96e4-b3ff6f783e5a";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/81ce1997d5c9348b5543d72c1a524546> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/128b0d77-a84f-404b-87c7-8a979cbfac44>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "128b0d77-a84f-404b-87c7-8a979cbfac44";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/f0d77710da9a4bd332db6b0e2f0f78e8> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/70e8bbcc-3fec-45fb-855a-f10029468a19>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "70e8bbcc-3fec-45fb-855a-f10029468a19";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/c981f51ab527babbb9d7952c02a78fa4> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/9cba7852-98c8-4e71-b702-4d4057b8f2c5>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9cba7852-98c8-4e71-b702-4d4057b8f2c5";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/3861f2b7f454cb802db4943b8ef09330> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/b0a6cc03-f5d0-4232-89ed-9c9d4a82f211>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b0a6cc03-f5d0-4232-89ed-9c9d4a82f211";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/e176c3b55e1e6e6a2a7ed515bb219982> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/7ad2d2ad-c003-472d-a9d3-cc0217e8244c>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ad2d2ad-c003-472d-a9d3-cc0217e8244c";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/1a6962ee2e6b79600a750e3e21d76b3d> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/4a062eeb-8a0c-4fee-9d65-95ee2201f2a6>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4a062eeb-8a0c-4fee-9d65-95ee2201f2a6";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/96eac10ad5481ab620d4d6186bee6dd4> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/01a80a07-f933-4eb3-ad55-abbce96232f1>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "01a80a07-f933-4eb3-ad55-abbce96232f1";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/127e0ae361b620f3fb27cc80aee0cd9f> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/b7bbabee-aaea-4380-a6ea-ef80450a5419>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b7bbabee-aaea-4380-a6ea-ef80450a5419";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/cbe6c0b85901c6dec358d48edb61a673> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/50ae7530-3c5c-47c5-a4c3-e867f7b8d913>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "50ae7530-3c5c-47c5-a4c3-e867f7b8d913";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/dbfd705f3dcc4eff2c9ccc70b77e9d93> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/b91371e9-96fd-40e7-94ac-2dff4b25bf94>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b91371e9-96fd-40e7-94ac-2dff4b25bf94";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/be81b3003bfe0188c8f3bc21ef031bcc> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/8a01e75c-a469-484c-b16a-925066ce84f6>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8a01e75c-a469-484c-b16a-925066ce84f6";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/de884828657e9919fedb020020b89e5e> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/fa7e9864-e350-4183-adb1-c448689fdc10>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fa7e9864-e350-4183-adb1-c448689fdc10";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/e79c5c4ab8795855f1bdaae3222d50ca> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/77bf3b5f-3f68-429a-885e-d88dbfefb3d2>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "77bf3b5f-3f68-429a-885e-d88dbfefb3d2";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/6feb0705cf70ef3e37b11727e092954c> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/c53d5dba-3877-43fd-9d41-d73b92549174>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c53d5dba-3877-43fd-9d41-d73b92549174";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/cf4add06db226861767559753fb50206> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/58808ab5-24a8-413b-80fb-68972c666bdd>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "58808ab5-24a8-413b-80fb-68972c666bdd";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/e813d1c8ae86cbb7b155b38dafa3ae5f> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/3a91c63a-e100-49f8-9385-89c08c87675a>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a91c63a-e100-49f8-9385-89c08c87675a";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/beb62d806eeba5a9f30f6bb8e09a82ce> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/cabaeee7-baa5-453c-85c5-64b797f74734>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cabaeee7-baa5-453c-85c5-64b797f74734";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/c5908a253d1aa2fccb75e6fff439c93a> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/2a51b7c0-2708-4c9b-9ce8-8eb2c1c16b11>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2a51b7c0-2708-4c9b-9ce8-8eb2c1c16b11";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/475f1b734fd0148a63367193fb9b6d8d> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/0b24ff63-9e02-4149-b0da-5795de03ae6f>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0b24ff63-9e02-4149-b0da-5795de03ae6f";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/2e983d3542aa450ff510531a6a1865f0> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/5464eefb-2fb0-4737-9304-466669a5ddc3>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5464eefb-2fb0-4737-9304-466669a5ddc3";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/9a439921dbe783f7209d608346914c1e> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/047418fa-8aa8-4524-a4a3-65fdde2bd492>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "047418fa-8aa8-4524-a4a3-65fdde2bd492";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/60883d6a112f31548cfe324911c68f4f> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/b09b6515-5781-48cc-ba0b-2d22e765b432>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b09b6515-5781-48cc-ba0b-2d22e765b432";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/620b14fc6901e59c49b3021ae1810d86> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/fadbd6f2-0118-43a8-9eb7-e8d4a91bc8ed>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fadbd6f2-0118-43a8-9eb7-e8d4a91bc8ed";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/ea59523ed7c187de85a88b6f2cb4b8c9> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/80f91b42-8387-40e3-a57d-682f35b5954d>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "80f91b42-8387-40e3-a57d-682f35b5954d";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/9f3736d8bac59e6f7fb4a134cf5ee325> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/df27db01-f88c-4c60-988b-74fec112c8b4>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "df27db01-f88c-4c60-988b-74fec112c8b4";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/dae560dd1aae31e6ca33450ae7799027> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/81da9158-07fa-44bb-b598-31ad4ac20dc6>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "81da9158-07fa-44bb-b598-31ad4ac20dc6";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/5d9e649fde106e771ddcc451e39f56be> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/bfabc47a-37f0-4ed5-b4ba-70052e83d135>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bfabc47a-37f0-4ed5-b4ba-70052e83d135";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/f22aa2b9fa5a48b3f8501d68191eb86b> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/a259314c-5931-4122-bac1-e7f9813cc10c>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a259314c-5931-4122-bac1-e7f9813cc10c";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/ba082958698d4b725cba1b4a388f5aed> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/16243d63-2cfd-42a4-834a-3ccb9a01a2f6>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "16243d63-2cfd-42a4-834a-3ccb9a01a2f6";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/90204e358bb945737a4a48ae02907b3d> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/6a929c1b-82e4-4d93-a3fe-d91a75217f46>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6a929c1b-82e4-4d93-a3fe-d91a75217f46";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/5339c5c7337455ed161b34be49ef1356> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/7ff5d6d2-d991-486a-ad03-2beba2a88f68>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ff5d6d2-d991-486a-ad03-2beba2a88f68";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/113b721f636fc02ae69db4182ae07430> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/28b914fa-0e7d-47e2-99fa-9fa3a409be54>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "28b914fa-0e7d-47e2-99fa-9fa3a409be54";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/36efb2a7175d4bd52d064d52f5da5c90> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/8b4a085c-99a1-4789-b566-b6ad837bcd44>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8b4a085c-99a1-4789-b566-b6ad837bcd44";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/6634a068558738b1c989a883a3b8b074> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/ad535a13-cff6-422b-a083-c827cd77f232>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad535a13-cff6-422b-a083-c827cd77f232";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/3b31b8ffefe7dfc0aebf2ec5926fb410> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/709b701c-573c-42b3-ae08-4db84215308b>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "709b701c-573c-42b3-ae08-4db84215308b";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/e4e5143dd31f18e6b08f9c8a441516f3> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/cb8b230f-f1e4-4992-981d-e4d0ecf889a3>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cb8b230f-f1e4-4992-981d-e4d0ecf889a3";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/3c3edf1656eb02ec2e1c94427ee96482> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/c345fbfc-ab9b-4211-a032-e41753da5288>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c345fbfc-ab9b-4211-a032-e41753da5288";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/4a84f2aebf323fa94046c7cf70d7da11> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/9a7efbb9-d5ff-418d-b02e-f9c09d8489f5>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9a7efbb9-d5ff-418d-b02e-f9c09d8489f5";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/732c004dab61a434a06ffb3fb49faf41> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/d7565813-18f0-4dad-b6b8-41b91947f105>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7565813-18f0-4dad-b6b8-41b91947f105";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/203429fa110020c33f7e8ff59a47c5e5> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/f7054ad2-b4e6-4117-9f8a-d40e03da4ce5>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f7054ad2-b4e6-4117-9f8a-d40e03da4ce5";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/e2c87681854ea74f01cdbd7cacb03c5f> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/5ec8ca42-4386-4888-a875-f2175106a813>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5ec8ca42-4386-4888-a875-f2175106a813";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/0cf41785e54b3e73cb241698e69a69e4> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/4baf611b-0850-4c92-9dd2-8872c5c4f629>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4baf611b-0850-4c92-9dd2-8872c5c4f629";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/a18dc4665f6fd62fe17b256f5a22e286> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/93db383d-b5f2-4bde-bf0e-2d36c5d2efa0>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "93db383d-b5f2-4bde-bf0e-2d36c5d2efa0";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/dfb648f5a9efc1ba805a0c4bfe0a3a40> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/d2398702-63bf-498d-870d-6060cb716bc4>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d2398702-63bf-498d-870d-6060cb716bc4";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/f6235732fffb2cca34d2a2d7e737680e> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/1047d898-f0a3-4f45-ae81-ea8e44e1599d>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1047d898-f0a3-4f45-ae81-ea8e44e1599d";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/72b349af735a8a256be176372884565d> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/88a03a37-2ff7-47e5-a79b-9dc6e5b99a50>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "88a03a37-2ff7-47e5-a79b-9dc6e5b99a50";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/8c429e4896a24be9ca842e970f1a8b8f> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/0206d727-0cf5-4cb7-bc80-9af44cb205e2>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0206d727-0cf5-4cb7-bc80-9af44cb205e2";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/754e8383ec997629d05a398f53e75160> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/9985cafe-8eeb-4ca0-bdea-6f644f1466a1>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9985cafe-8eeb-4ca0-bdea-6f644f1466a1";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/9a7abcb272446809bcad1b4f9aa2d897> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/54958763-5035-4429-a978-2f390c5e2b6f>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "54958763-5035-4429-a978-2f390c5e2b6f";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/a997d97be3b9c80f06a17c6ebe07a4a0> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/d09c807b-a88a-452e-8522-ab1192e4c14f>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d09c807b-a88a-452e-8522-ab1192e4c14f";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/e12c4f9f7167cd0074a97a2f658d1d51> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/2feff2ed-ea4d-451e-b128-de14e7c2327e>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2feff2ed-ea4d-451e-b128-de14e7c2327e";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/e54e073b8fa2ddb3c45a4e21eae67798> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/2ed9ac9d-5131-40aa-9881-c23860283973>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2ed9ac9d-5131-40aa-9881-c23860283973";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/0f0d22da247abc6b52cd30c3df26d884> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/dfa69fc9-3739-4e65-9d18-1c8fd7721e34>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dfa69fc9-3739-4e65-9d18-1c8fd7721e34";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/17b0501bf9632542e9b0475667171ef0> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/fe97d33f-d6f9-45c4-9526-caac68f2e880>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fe97d33f-d6f9-45c4-9526-caac68f2e880";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/fda278c449963ced5275dfd69ef8776e> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/7d22ca2f-1203-4333-bc93-f8e7826dfbf9>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d22ca2f-1203-4333-bc93-f8e7826dfbf9";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/9cc324fb5b120d5625a9b2b1b97519c8> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/935cc3be-c4e1-4b3f-9aaf-c12c2b294b3d>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "935cc3be-c4e1-4b3f-9aaf-c12c2b294b3d";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/ab92fa8efd6b706e699d3f23e8bba499> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/b37752e5-6010-4bde-9528-d75267568b46>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b37752e5-6010-4bde-9528-d75267568b46";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/7f5475cfb202d12f54779f046441c9e1> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/fd55d258-10c1-41fc-8158-ebe18ef9a3cf>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fd55d258-10c1-41fc-8158-ebe18ef9a3cf";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/03e9a966a2ee34b82127a5f6576c0948> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/b02539bd-7de9-4b53-914d-b77a0b70b346>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b02539bd-7de9-4b53-914d-b77a0b70b346";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/9bdf13b476fc4514d8b116effd4225e2> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/c4ea099a-26b3-4a6c-8d81-6b7985579499>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4ea099a-26b3-4a6c-8d81-6b7985579499";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/d689e774de665f48e80db2262b1bbd7a> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/3440173c-27e5-4f0d-8f02-be3b91f605be>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3440173c-27e5-4f0d-8f02-be3b91f605be";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/3d3109817aca699f3fcc6e2abc399e55> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/c4c82ddf-4cd4-4e82-8976-45987e24c0fe>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c4c82ddf-4cd4-4e82-8976-45987e24c0fe";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/fd97b6f96a3179ae0249f08d6e742a96> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/7f467c15-7ac5-4fc5-92af-83aa20bc920b>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7f467c15-7ac5-4fc5-92af-83aa20bc920b";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/fae79bc3e07dcc8268cc54515fa15141> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/ba677230-e9bd-4902-b763-7672e5a3a979>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ba677230-e9bd-4902-b763-7672e5a3a979";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/7954c9d6ecfb417eab99bda5ebfe1840> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/d8dfe222-6a06-4b8c-a925-84bbc1d1cace>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d8dfe222-6a06-4b8c-a925-84bbc1d1cace";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/c58bc71404d1ac24f4e9a79bbd711412> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/efea1be4-8f83-41d3-a3b1-44aa09d1e258>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "efea1be4-8f83-41d3-a3b1-44aa09d1e258";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/60e71f844295a0521f6fdd234b5ccb5a> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/509a0e42-bc30-442f-a872-d39fe8388f33>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "509a0e42-bc30-442f-a872-d39fe8388f33";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/042781be03f2fa63ee1ccb27b4ada636> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/74abb738-8f89-413b-81b6-bc7f461b278a>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "74abb738-8f89-413b-81b6-bc7f461b278a";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/51e3c4229f00c09f89fa0bf27498bdfd> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/bf6ecbe4-7ce3-4711-918f-04f498367d47>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bf6ecbe4-7ce3-4711-918f-04f498367d47";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/2b149a43d431b110132e2ab3b90a246e> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/78aa54ff-a9ef-47d9-81d0-9266cb8ef940>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "78aa54ff-a9ef-47d9-81d0-9266cb8ef940";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/42f99fa2e425580e6a539c2d24b0fa1a> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/e2620be3-8f6c-4dee-a0ef-ed02009aa7dc>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e2620be3-8f6c-4dee-a0ef-ed02009aa7dc";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/d6c6dd518cc5df076a35959d811fa67c> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/5ed9eb05-627f-4b28-8ed5-813e4b3dbf38>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5ed9eb05-627f-4b28-8ed5-813e4b3dbf38";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/6988a68d98db71b193d1a9c2e8af6402> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/cb597309-1b3e-41e2-8798-1670b0b3c2ad>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cb597309-1b3e-41e2-8798-1670b0b3c2ad";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/992cc01ac966ed85d3e6526c7a8c0d14> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/a215fa25-a829-48b2-b40c-6edea1494795>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a215fa25-a829-48b2-b40c-6edea1494795";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/b0b461ab7f4c02c56f575380b74111a1> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/a6309fc7-47e5-48a8-882b-2995f54463ad>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a6309fc7-47e5-48a8-882b-2995f54463ad";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/5442c1374ed159347bc0c64518a9b1a9> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/961861e5-a0a8-4591-b50a-815de0c98136>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "961861e5-a0a8-4591-b50a-815de0c98136";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/cd892f00e74e6a5f6acd31a1a7807aec> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/bf59dce8-dc6d-4cd6-a47a-aebc02e50e5b>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "bf59dce8-dc6d-4cd6-a47a-aebc02e50e5b";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/7c397b883bf42c9bda2f9e34c598b81d> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/0ccd39a1-6007-49d8-b4a3-57b5ec6cfc3b>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ccd39a1-6007-49d8-b4a3-57b5ec6cfc3b";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/1a7cc9c0b2e125cd5f7a15f711b4e70e> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/65771337-68d9-4e12-821f-21e8bb2f3cdf>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65771337-68d9-4e12-821f-21e8bb2f3cdf";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/62323be43c4384b45f9905419001fac4> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/5890a48a-bff5-4dce-869a-64f386827dc1>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5890a48a-bff5-4dce-869a-64f386827dc1";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/f24e09d78e0541f37e03ced635022cc8> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/4c2744fb-08d7-4be9-8392-d1fdf4664095>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c2744fb-08d7-4be9-8392-d1fdf4664095";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/c0916729a896db2a6947027182bb1128> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/5572181b-d91c-4258-828f-372ae64f10e9>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5572181b-d91c-4258-828f-372ae64f10e9";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/710c7fb0b0ac58e1c90702e22a8998c8> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/1a01900a-a9ce-4d10-87aa-df79e0d529ad>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "1a01900a-a9ce-4d10-87aa-df79e0d529ad";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/95af606b73d590024edb64a2506d4137> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/cb39f5f3-ca4e-4d17-b9f2-9cd0b9a5cfdc>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cb39f5f3-ca4e-4d17-b9f2-9cd0b9a5cfdc";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/065a05cc3b8375ffe4f0369f5fe1f08e> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/e356d500-f70b-4f96-b2aa-030331b3368c>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e356d500-f70b-4f96-b2aa-030331b3368c";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/8d7fb064535448b990505c8895bdc27e> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/f62426cf-e089-49f3-8222-7e5af777ad0a>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f62426cf-e089-49f3-8222-7e5af777ad0a";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/d2d6bb67f6b1f782666ea1b569f3f5fb> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/af47b89b-a457-43c8-aad3-d0c2f03b097b>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af47b89b-a457-43c8-aad3-d0c2f03b097b";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/ed0914f40dfed83ca44af845a2bf4d81> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/e19033b0-8f1e-4f67-b2b4-a293a59f4aab>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e19033b0-8f1e-4f67-b2b4-a293a59f4aab";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/51b9dfcc65b28446df67e9dde63c8f86> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/af5ff968-30f0-48c6-80bd-17c56501ed60>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "af5ff968-30f0-48c6-80bd-17c56501ed60";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/8a60f9b1086633558fa81426e142fd12> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/84b30cfb-94c9-419a-8bf7-041a1ab94ac4>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "84b30cfb-94c9-419a-8bf7-041a1ab94ac4";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/2bd169e89ed45593f3e280fd791a407f> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/b96042b6-bfbb-4187-803d-6661675958c3>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b96042b6-bfbb-4187-803d-6661675958c3";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/708d3d50cb0d04b088c1d21300a45e3d> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/0ac22758-7380-46be-b881-cb962acbcc4f>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "0ac22758-7380-46be-b881-cb962acbcc4f";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/cb4a58c98fe794e9f52b9402c01ef9e3> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/d119dc08-213d-4030-ab98-fdbe796d4667>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d119dc08-213d-4030-ab98-fdbe796d4667";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/79f98e1ff1c0179885f12821cafdf8e6> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/9fffe76f-9cfb-4e91-8408-d70c4feb75bc>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9fffe76f-9cfb-4e91-8408-d70c4feb75bc";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/c1691a136fe141a6311a746b046b36d9> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/64c9f77a-5078-449e-966d-10de580ae689>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "64c9f77a-5078-449e-966d-10de580ae689";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/3cb510ba831dc762f3a1bd39cafde84b> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/be57a498-43d8-4c3a-8a5e-a1dc5f9d1fc3>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "be57a498-43d8-4c3a-8a5e-a1dc5f9d1fc3";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/ff0ca0bc918f33f0b9ce7fe7973d2f67> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/06d5bcbe-7917-48f8-9e55-3a24a632b627>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "06d5bcbe-7917-48f8-9e55-3a24a632b627";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/681d68e96a751e66aa9e5a660d5a659d> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/a242d7d2-ab33-4cb6-8490-22584778764c>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a242d7d2-ab33-4cb6-8490-22584778764c";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/783c47ac1ccb71aa070ebe6203aa4b8b> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/714a2f24-e9ba-4219-89ab-49129fba7986>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "714a2f24-e9ba-4219-89ab-49129fba7986";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/eecf014a2106f005378fcebd376512ba> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/8daf621b-766d-45d0-b071-9ca71bcb4ff5>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8daf621b-766d-45d0-b071-9ca71bcb4ff5";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/d8e56c67610e154b6df7af09be7a5cc2> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/a8f2b132-4257-422e-9bd0-0f8081311fef>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a8f2b132-4257-422e-9bd0-0f8081311fef";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/1c30ef6d2af97569088ad2a72b707ffa> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/65163706-f40e-4944-9f18-ac0bdc51a368>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "65163706-f40e-4944-9f18-ac0bdc51a368";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/df5e0e0f87b547e668402d33dd6936be> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/273f3fe0-fd88-4c20-9674-de1ac7a598f8>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "273f3fe0-fd88-4c20-9674-de1ac7a598f8";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/c5320eea40f5ce65da55e1a3e26cf497> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/f1819db5-b9b5-45a2-9897-3fd3e551e0c3>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f1819db5-b9b5-45a2-9897-3fd3e551e0c3";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/b93ae92a8eb4912125094d98b8b4841d> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/281edce4-7008-4464-8ad5-18e74b878124>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "281edce4-7008-4464-8ad5-18e74b878124";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/ec09f8187f707863e5c236b56276f3ef> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/b663f2e9-22c5-4308-82da-668b33efbb2d>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b663f2e9-22c5-4308-82da-668b33efbb2d";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/4dce19011e5b534dc7ea461acf9493a7> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/fba041d9-1d8b-4c86-8454-6ba72da0db82>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "fba041d9-1d8b-4c86-8454-6ba72da0db82";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/2a00aa9057f5c3d4c36b13f8b37e2642> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/c8dc25bf-8622-4f53-a61e-f2a852b8f441>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c8dc25bf-8622-4f53-a61e-f2a852b8f441";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/4e6d2b248253087f888299ba975269fd> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/7ec382e1-fb93-4fb8-8a33-35491e963ad1>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7ec382e1-fb93-4fb8-8a33-35491e963ad1";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/22f4e67aafd774124e8b192f5301a25f> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/14c3966b-ab20-4c0d-b61d-04c386072052>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "14c3966b-ab20-4c0d-b61d-04c386072052";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/aef7adf9b18862b95c3f0c32442f3b84> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/3a2fff57-3aca-4278-a7cc-c44ce6504d99>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a2fff57-3aca-4278-a7cc-c44ce6504d99";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/ccf52a23fbdb6201661cc7aee20d3d8e> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/ae1fb5b6-b210-4b1a-81e7-429cfa4c6321>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ae1fb5b6-b210-4b1a-81e7-429cfa4c6321";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/e36f548efb073b0066baf5d2d3244a99> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/a3b5ba49-7826-4221-afbe-58ea09f7e9ae>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a3b5ba49-7826-4221-afbe-58ea09f7e9ae";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/de54606308bc963d07fc0f386441ce78> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/a96b574f-354e-45b5-b5c7-323c3686b20f>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a96b574f-354e-45b5-b5c7-323c3686b20f";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/225ed0af8a544e57b0d52e954a92ec51> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/d7cd7da2-d97c-4496-9ed3-c423a0db4292>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7cd7da2-d97c-4496-9ed3-c423a0db4292";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/8513ee2703aebb0caf9f2875d81479b9> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/c9fd8612-c459-40e7-bff9-de204a9e4733>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c9fd8612-c459-40e7-bff9-de204a9e4733";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/1ab85652faaddd4675b3e9f293e3534c> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/6462d6a9-604d-4860-a480-06de8ab88488>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "6462d6a9-604d-4860-a480-06de8ab88488";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/8413e604e237de63067a30cd8c658f6b> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/5d2b4250-0927-4c24-aab7-08ba65a4f56a>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5d2b4250-0927-4c24-aab7-08ba65a4f56a";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/08223304e42d99067f54a753f8c685fe> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/cd84600f-5d7a-43c8-b971-8285b67ae173>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "cd84600f-5d7a-43c8-b971-8285b67ae173";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/b1ed5ef1f421bc0c42aa29190d562286> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/d7672d1f-893b-496d-ae39-55fa40ab99b6>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d7672d1f-893b-496d-ae39-55fa40ab99b6";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/776d0d0b71b0d55e10ac4a507897ba90> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/7a1bc677-2030-48fb-85c3-7633a5c6a0a6>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7a1bc677-2030-48fb-85c3-7633a5c6a0a6";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/d663bcc6cb58cbc280b52194e7125826> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/4dd4ef9f-36cd-4a40-a16d-1cd65bbaf3ec>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4dd4ef9f-36cd-4a40-a16d-1cd65bbaf3ec";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/a3aaa37623ea7a54b47a0316e852e903> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/4bdbb2b6-3ce4-41c7-b05a-10867a142668>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4bdbb2b6-3ce4-41c7-b05a-10867a142668";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/686519e683a16ccbe788c1b7acc92740> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/ec55bfbc-67cd-41d9-8823-3aca1d4c959b>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ec55bfbc-67cd-41d9-8823-3aca1d4c959b";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/7f5d5a122385bb566f88ceb2201260f0> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/8d13312e-69c3-4284-b371-737b58be2361>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "8d13312e-69c3-4284-b371-737b58be2361";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/74af6c24e0ade8a214d1eeca67907bc3> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/3a1038f8-6e42-49b2-9f25-3bab894414f1>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "3a1038f8-6e42-49b2-9f25-3bab894414f1";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/be3ab3ae99e55f4e9afcdba360754ebf> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/4c392c17-bff7-4f24-b288-99e3df00b589>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4c392c17-bff7-4f24-b288-99e3df00b589";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/2fe1c4a98f45e6910c61d8f4f70331a6> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/213df356-1b68-45c0-a1db-8feab78aec81>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "213df356-1b68-45c0-a1db-8feab78aec81";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/9bde6213ed1dff945fb57fb58c183b0c> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/692921a6-2465-47eb-8e04-2c29b49f50de>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "692921a6-2465-47eb-8e04-2c29b49f50de";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/4b1a8c1cef81097034cfa1ca569ff2e2> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/dcb29e8e-263d-490a-97ef-b312252822d8>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dcb29e8e-263d-490a-97ef-b312252822d8";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/a53967075b94252b6d26af42b34b62b9> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/4dc96030-88e8-4748-adbf-1aebdc2ea2b3>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4dc96030-88e8-4748-adbf-1aebdc2ea2b3";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/cfb7c17c2677082a54bb7d53bca769ba> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/ad539bb3-f41a-44a9-947f-0dc6ecb29fea>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ad539bb3-f41a-44a9-947f-0dc6ecb29fea";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/fcb5c0e6949dec963ee768d2d12e2aaf> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/03ddc34f-7990-4bb2-888b-37bce5ce044e>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "03ddc34f-7990-4bb2-888b-37bce5ce044e";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/1847ee636fa50dd56d2e197c295ed6c0> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/9773c47e-4206-44cd-81ac-a437e080b9d0>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9773c47e-4206-44cd-81ac-a437e080b9d0";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/8e527295897b2dce9e1d1b7512d85771> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/637812c3-34c4-4339-8618-bcc2675d83d4>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "637812c3-34c4-4339-8618-bcc2675d83d4";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/327ec658e6ff35911bbd20b0c61b44c1> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/94f23563-6df6-4808-8324-5924c86b4f25>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "94f23563-6df6-4808-8324-5924c86b4f25";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/97cab99594240eec18d05853e491f825> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/dd898f3b-87e5-432e-9e00-5d0d3fa54b05>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "dd898f3b-87e5-432e-9e00-5d0d3fa54b05";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/c2263c3cd938a4ed1a72cefcba4ac200> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/849f49cf-bd09-4f88-96ea-e1bd702a94ca>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "849f49cf-bd09-4f88-96ea-e1bd702a94ca";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/5200d338dbe39d5367fb1e76f6c30206> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/5e40cc59-194b-4b42-b64a-6a53a8cb1152>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "5e40cc59-194b-4b42-b64a-6a53a8cb1152";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/4acb3358a747fb875c1017d1dc592ff2> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/37b2f71b-c14f-4fa5-ba7d-8a765c87859e>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "37b2f71b-c14f-4fa5-ba7d-8a765c87859e";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/959070eda47c03a190fd3e132ed80de7> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/4ba2e1d8-fa5d-4002-9d1b-c168a2a84045>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "4ba2e1d8-fa5d-4002-9d1b-c168a2a84045";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/c6bd840990186e4e398a4b7fcb67fdc1> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/34837fc6-c5f9-424e-8d9e-b9fef8751a8a>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "34837fc6-c5f9-424e-8d9e-b9fef8751a8a";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/643ddbd9448ca43828702527af7bfbb8> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/aeeed194-f748-4ec1-a2c8-c54e8fd60545>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "aeeed194-f748-4ec1-a2c8-c54e8fd60545";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/622B64E8B72F9F4B33507E78> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/b8d72a74-90c1-4241-8b3f-9df3abb6299b>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "b8d72a74-90c1-4241-8b3f-9df3abb6299b";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/c75a398f08f0585532656a038441564b> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/d5f854b4-0751-4a3a-8f4b-227e3dd8252e>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "d5f854b4-0751-4a3a-8f4b-227e3dd8252e";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/e17dabfaf8f562ad181f422006c42e97> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/e395419c-b06e-484e-8302-cd2d1011601f>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "e395419c-b06e-484e-8302-cd2d1011601f";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/bf952a7aeaff9fce530e4ace0a3e2c45> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/2924cc14-f51c-4692-ae4b-84f886d4daf9>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2924cc14-f51c-4692-ae4b-84f886d4daf9";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/5d8280bbc6866d230786ac56a3d0d253> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/c6e14db2-95da-4189-9d60-051164b5e0b5>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "c6e14db2-95da-4189-9d60-051164b5e0b5";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/254b195cfd015e88cad0bf899fdd51c9> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/9ae6d05c-a9db-429b-8c7c-65367ff00fcb>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "9ae6d05c-a9db-429b-8c7c-65367ff00fcb";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/20cd95d5ff712b0ecb387183559d7225> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/49d534b3-50ca-41ed-9fea-80cd49f67454>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "49d534b3-50ca-41ed-9fea-80cd49f67454";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/551027a285f1a06b0733caec473ce054> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/ef6637fa-f831-4c6a-92c7-2f8a1c29e383>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ef6637fa-f831-4c6a-92c7-2f8a1c29e383";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/0345017c53333eab62bc5aa88c8e3d16> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/7d08085a-3e2a-46ba-9347-8681b8173137>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "7d08085a-3e2a-46ba-9347-8681b8173137";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/36a2d9e4351847d15ad7364795999cf1> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/ade9acde-d2e6-4ae3-b733-733d8465e83b>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "ade9acde-d2e6-4ae3-b733-733d8465e83b";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/f781943151cb63210b54fbf7140e3490> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/44d35426-24a8-4516-b9bb-6c8b56417e85>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "44d35426-24a8-4516-b9bb-6c8b56417e85";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/2ce1628f97d31705a703fbc699c71774> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/2e60a1c4-358c-409f-94ab-cbf817d55569>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "2e60a1c4-358c-409f-94ab-cbf817d55569";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/aa6976a5f6eed5901699a54b5d7e6487> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/626974f2-ad28-4a67-a59c-a60cd0c0ab77>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "626974f2-ad28-4a67-a59c-a60cd0c0ab77";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/e0c7f21963b018698417ce44ef097582> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/a03b1945-3232-4561-b719-78b3e77b366e>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "a03b1945-3232-4561-b719-78b3e77b366e";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/fa51c0cd4530f0db4caea031f75305d3> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/40e1c80d-17ab-47ce-ba7c-bfcb39e7cd57>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "40e1c80d-17ab-47ce-ba7c-bfcb39e7cd57";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/9e0e8f060ca954da6263243642433f44> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/f09f7a20-5c11-4277-902c-851c1f98e031>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f09f7a20-5c11-4277-902c-851c1f98e031";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/07cd3481fd07e179b8861532560f4084> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/f28864b3-d734-4c52-bf0c-e6335be2f714>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "f28864b3-d734-4c52-bf0c-e6335be2f714";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/971166dc370ef91d8abe58766602f61b> .
+
+<http://data.lblod.info/id/betrokkenLokaleBesturen/12451bc0-ed31-4c6b-9d1e-0c68ec2d23b5>
+  a <http://data.lblod.info/vocabularies/erediensten/BetrokkenLokaleBesturen>;
+	<http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100;
+  <http://data.lblod.info/vocabularies/erediensten/typebetrokkenheid> <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1>;
+  <http://mu.semte.ch/vocabularies/core/uuid> "12451bc0-ed31-4c6b-9d1e-0c68ec2d23b5";
+  <http://www.w3.org/ns/org#organization> <http://data.lblod.info/id/centraleBesturenVanDeEredienst/84fcba4c456333a57cec239825596ce2> .
+
+<http://data.lblod.info/id/bestuurseenheden/3f1ec7f1afc4cc466bb3a7fe5bc43199bf600963ec3231e1480a23d103a438a7>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/39db6dfe-579c-4c1d-9851-f18547643a33> .
+
+<http://data.lblod.info/id/bestuurseenheden/1086df7c6c150e427fc56e2239eed2b7e2d9d4a97abb24c00e951ec89f9bcbec>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/14d5d68e-ac34-4793-8fde-e43569f0c37d> .
+
+<http://data.lblod.info/id/bestuurseenheden/0327a51548f73607f8a5ec11b36711a3c96703686ad93a3d632718c135c295db>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/54281766-9fce-42be-9c83-b8d1ee171e74> .
+
+<http://data.lblod.info/id/bestuurseenheden/08e1b1e460bc9a9dfbd6570ab96a6b4813fbd4d9df2294dad86b11d9e4093d32>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/c0bcd3a6-517a-4669-a376-c31e3ae6cc17> .
+
+<http://data.lblod.info/id/bestuurseenheden/01f5df79d1c889c5fb42592a72d7aa50bcfc77a8d04c7f2015df993b0e479835>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/cd8d283b-7e5d-427a-be95-6ff9b87db757> .
+
+<http://data.lblod.info/id/bestuurseenheden/00eb231f51bd6b4f5dcc6536b2d09a174ea8583f5bf28b10bc4fc769a07e511d>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/86b1eac5-aa95-475c-93df-b9586eb077de> .
+
+<http://data.lblod.info/id/bestuurseenheden/11e23f966461f4740579b5ac2745421c6a3c3f42a9dbd4df7bd3d3f21e44f129>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/15acbee6-a360-43ff-b5cc-fe5dc3bc03ce> .
+
+<http://data.lblod.info/id/bestuurseenheden/2f980d9d54c35e0a61137da4eacfe4bef20246e18983449ce15dcd3d2a83f509>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/296eff94-b3cc-473b-abef-5abf68590916> .
+
+<http://data.lblod.info/id/bestuurseenheden/156dad76d5d8e30d26b501d715fd237b38cbae60e76753a09d897fd317ab914c>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/bba8e9b3-547d-4f52-88cf-36ba90b0cfd8> .
+
+<http://data.lblod.info/id/bestuurseenheden/09f5b10fbd078fcb1e0e4910d32e47146a5eb31d8138dcbaec798309e64dd059>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/e2dfa734-ed22-4109-bae1-979575030fbc> .
+
+<http://data.lblod.info/id/bestuurseenheden/1cb4914d7d6a57869d4d9cf68abe20151334b30694e6a7546c155c5beaa6ac8a>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/291d611f-e5e8-4e65-b0d9-4ddd39026ce0> .
+
+<http://data.lblod.info/id/bestuurseenheden/0c4cf1788b1bf8838ed9c7fe9839e49a1120b2dd1d005a52bc4f718c25ca06fb>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/34c15ea2-7347-4ad7-a3fe-4c0540e6a00b> .
+
+<http://data.lblod.info/id/bestuurseenheden/03ff483dadbae6e23f785f5b428248911bec4f5b3ce2559e960d0d8f32f15619>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/fcb1b005-226d-4b9a-94ee-25bab1950a52> .
+
+<http://data.lblod.info/id/bestuurseenheden/1b983548dc44e39bc920a7a8ec1901b692a664865d5fee5133ae96e7281eca6f>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/134dec04-7788-49af-b539-1b2a3b7b2f9b> .
+
+<http://data.lblod.info/id/bestuurseenheden/1d43739442010a95b1910af237a4f6aa9a26ca6c9c83f646bad44a8181d407c7>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/8f8d28c9-5776-4bb7-9da5-ca8498d36130> .
+
+<http://data.lblod.info/id/bestuurseenheden/2ad0d123f4a81787572342c394a1917b81752f42d802d1e013941f56b53bdd2a>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/91d5cddd-2127-42c4-a14b-9ac09410d35f> .
+
+<http://data.lblod.info/id/bestuurseenheden/0fa622b92c507c69fa6d4aa4ab8fc79eac8f841b4fecfb1ad27245bfb6310f50>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/8609c2af-ab32-4b1d-8166-5a8aa9549145> .
+
+<http://data.lblod.info/id/bestuurseenheden/003e84121111866af60611a59e13d4c478718f60472655936edec1e352a34c5f>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/60535a06-07a0-4071-8a1b-f776f7d4d68d> .
+
+<http://data.lblod.info/id/bestuurseenheden/2564e21e3650f91625189ccb7eb055e47754a0633c54c7582a899171fef60c52>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/a44ea2b7-65df-41ee-a747-7065a7f8df1a> .
+
+<http://data.lblod.info/id/bestuurseenheden/0a71e2b47c58e6d13ac628f733863543b791869395afcfe5b5c82c98ff894e3d>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/339eb0e3-fbb1-4a6d-9284-e4b47c7afb82> .
+
+<http://data.lblod.info/id/bestuurseenheden/6eb63a95ebb0e5fcb9e59b25a264977107e690a46a89755da1637d1427693560>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/206dfcd4-a6b2-4b04-b83a-3ef2b7a0d630> .
+
+<http://data.lblod.info/id/bestuurseenheden/b80c00718ab23cc3676202e24a5ec9a92823d38ca970c0fd4ff6e3754b721d36>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/744e85a0-5217-4f1e-a863-5845f7b19b5a> .
+
+<http://data.lblod.info/id/bestuurseenheden/42887f141929197c227828071ec7dec4cb5435794fedfc7fcf901648e0ea4742>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/306b56d0-5294-4ee6-bf22-b62cfdda8d32> .
+
+<http://data.lblod.info/id/bestuurseenheden/8af37430f91603017873dbc1390eccf364bf82854f7358e9c9845498b184660f>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/7a4c7098-a524-4c1c-abdd-d674a31df7b1> .
+
+<http://data.lblod.info/id/bestuurseenheden/bd2cfcb37561afe84b4f8b1894bf7e0f204b21931b6f9ae1d5dbbafcb6681c9b>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/127859a0-41f8-4593-9e65-a0ecdc354bdc> .
+
+<http://data.lblod.info/id/bestuurseenheden/5efa0b9c06f5b70b071e539047bd847dff555b9ce51c1b86b263018a610f5820>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/ce1026f8-7474-47f2-86bc-80851d14b15b> .
+
+<http://data.lblod.info/id/bestuurseenheden/5116efa8-e96e-46a2-aba6-c077e9056a96>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/0e305e28-e4c8-485a-9d78-4c8a4932108d>,
+    <http://data.lblod.info/id/betrokkenLokaleBesturen/77e4d005-5acc-45f7-ab52-c37cdbd27840> .
+
+<http://data.lblod.info/id/bestuurseenheden/47368dce85e1d529ee837f53d1822243e7c235f0a9cac6ffe5620bb1d6758a31>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/c86dfd33-5286-4981-911a-b14182685c0e> .
+
+<http://data.lblod.info/id/bestuurseenheden/f4641f7ba21f1a575993f1b523fb581af12269164006abeab121886037ac0cad>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/f857ddda-4349-4918-9eb0-7fa95c82f903> .
+
+<http://data.lblod.info/id/bestuurseenheden/54c9a2a4a577fc2f6888bdf2b43d439ae59ae26a3db344546c7a713f2aab2bce>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/d8d2a773-c569-4ac5-b0f4-f67560705124> .
+
+<http://data.lblod.info/id/bestuurseenheden/8ed14ecd083fb231f9af0f2698de728bba3f11deb0f4ea4caf9d5c1f9e3a771b>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/90a72485-877d-428e-9b7a-41a5e282acf3> .
+
+<http://data.lblod.info/id/bestuurseenheden/8df96cc548c53410332620ec1adae4591bd5340127b1332c4b902c5c3afe260d>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/a3dba296-e6a9-481c-b708-6c57b04c30e0> .
+
+<http://data.lblod.info/id/bestuurseenheden/842737db3afe0bad6a72bbbdeee376fe49abe721975d549d81bb22c70bc7002d>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/2fd9d299-0826-47ab-8a4d-e56247fe703a> .
+
+<http://data.lblod.info/id/bestuurseenheden/e58e47292d23dc83547f3f272c6018439290d988dcab6d352215bad91751e1b7>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/04a73cb0-8e64-4609-804d-8d189f3e8ceb> .
+
+<http://data.lblod.info/id/bestuurseenheden/3e58880a542424b73f85c9ffba8837b0da40d8c43e936c92603cde2015f5cdae>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/8fe7a0f7-767f-4fd2-94f0-8e4c0c3b529e> .
+
+<http://data.lblod.info/id/bestuurseenheden/bf2ed8893d2ec4689b4c60b0b236edf11f381e247c535f0b12d132fc80ca1ad0>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/7c989a6c-ef15-490c-a972-13b380892fb4> .
+
+<http://data.lblod.info/id/bestuurseenheden/5a4b2b4f1de1f3b91b0348a7eb6d6aa0ef9420b8ec31374970c9ffe933a79515>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/18ad5664-1873-4ef1-8be0-7235f903d4c2> .
+
+<http://data.lblod.info/id/bestuurseenheden/e41ffa04f94bb450a79793020e70d55b5fee5033a5280277998608a9d0913117>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/8ebc757c-c4d8-486f-a01c-93e25c72708e> .
+
+<http://data.lblod.info/id/bestuurseenheden/ccda2ffa758045bf3a9df27463b2a0bb12da6324f5f40ba7691e14932ebfa638>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/7316fb2f-388b-40f8-b6fa-49a91255d6c4> .
+
+<http://data.lblod.info/id/bestuurseenheden/26721daac0558a8a9efee4fc9d1141733844b3a6eb0813401546eb805a978182>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/6018fdd0-5588-4652-935f-72fb9f48a03b> .
+
+<http://data.lblod.info/id/bestuurseenheden/b456cda7fa9b2b176adb216e5598aeeb60ff19753a5a08ade6ffd32e9a0ead89>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/5bbe9ad0-2066-4ae4-b893-301ae1a3c8b8> .
+
+<http://data.lblod.info/id/bestuurseenheden/800ce18716ba451af47c2e05c2a7bdd29ab9305eaa61068629c1ea2ae6c08f4c>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/d2a63b79-a907-4e67-a283-dde537b38eca> .
+
+<http://data.lblod.info/id/bestuurseenheden/2f003f9d0696af25e0864d01b3a40d3d38249d14f253edbafe2ff106237abf1c>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/8c7ad881-4f96-4beb-b69a-0e4a9ac3048a> .
+
+<http://data.lblod.info/id/bestuurseenheden/b4aa8ca2a4daa74ef8297b0b4dba2ad292e73da5337e20c65066860279751307>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/ad165bd6-0fb9-43df-8e74-28370f306aed> .
+
+<http://data.lblod.info/id/bestuurseenheden/698c9e2b9495736610180524294fa5f583cc9fd9da535aa6caba1cb29f0e53b0>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/2b5d3333-d0c0-4d56-9435-fa56b32bba7a> .
+
+<http://data.lblod.info/id/bestuurseenheden/5d6fcfda3248cb295893be604a9d3e31f0899b2daebb3bd3b30b371d098ee635>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/c8a4618d-e6f8-4ed4-8dc0-0a1ebc19edf3> .
+
+<http://data.lblod.info/id/bestuurseenheden/4b93b99b2a80c6ce4e64850589a8c0163fc055b074b061a64add3e1af303f1fe>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/992017f5-247b-4e02-acfd-e9882a336cef> .
+
+<http://data.lblod.info/id/bestuurseenheden/b070cde79629e0c3c5ed3d693fe06b6b066f75299244c224edb42a54fdfad265>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/94ee9cd9-350e-4cf4-8037-d84e989b13cd> .
+
+<http://data.lblod.info/id/bestuurseenheden/d9f7c0ab4920fdecf3f9a60b92e921b5ca07248fcb0eac2113eb97392ddd6c6c>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/239249a4-1121-48fa-a4d2-99f57a1a6ffa> .
+
+<http://data.lblod.info/id/bestuurseenheden/51689560fe677738ed03e8a14dc01723d0f865c488f5f47c388622f332241e2d>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/565404af-88c0-4005-a976-1fcd2f786e48> .
+
+<http://data.lblod.info/id/bestuurseenheden/69e815e62d4698903b7db1df39f372317439cb28a8c4ca62aa6bfd1acaa62266>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/787879fb-d398-4cdf-9d3e-31bd3fcde711> .
+
+<http://data.lblod.info/id/bestuurseenheden/d760812063231cc45ced3fa65a7cd54920329178c8df7e891aa12db442e6606a>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/13737cc0-59e5-439c-95b0-fddc4352a4dc> .
+
+<http://data.lblod.info/id/bestuurseenheden/e3fc7eb1c6f50aa4277e0ae180b002eddf243dab630e9278996df9951316da68>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/ca1146a6-786d-4e67-897a-6f9be3a63f8d> .
+
+<http://data.lblod.info/id/bestuurseenheden/8fd5ea9aeb61c45ec79986650bee55142b2f8a599d5d611dd578114216a58430>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/9dbc6857-0647-4e8c-85e9-83042bdc0e5c>,
+    <http://data.lblod.info/id/betrokkenLokaleBesturen/f83ee6da-c5c6-48cf-b47a-bd7cde8ef7d1> .
+
+<http://data.lblod.info/id/bestuurseenheden/a71e8220eac329de3fca638aa1b8236309730ef15de41e7f84820d50b582a5ca>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/4219f672-aa0c-4d1e-97b0-ed779d14e390> .
+
+<http://data.lblod.info/id/bestuurseenheden/05441122597e0b20b61a8968ea1247c07f9014aad1f1f0709d0b1234e3dfbc2f>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/6798d9cd-f314-4bca-8488-2f376439abdd> .
+
+<http://data.lblod.info/id/bestuurseenheden/a0393ba99ecc1a0e05d93966aaad42b07980efa5dc90f72106f3fb5954215e18>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/428f7bb2-ec40-4ec8-be93-cc1f9cf118c2> .
+
+<http://data.lblod.info/id/bestuurseenheden/25fc615f81f2032ee7126108474e842b418c890c3755f9e1efc58ac6dc59d1fc>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/64d7773a-810b-4eee-9172-bffaa2946ee1> .
+
+<http://data.lblod.info/id/bestuurseenheden/cd64084b7a4eed361bc4f6194a95a708564b6962f068a68d2e535c7d2dcb4820>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/e088c7f4-b5b4-4f55-9815-43c1be94bd2f> .
+
+<http://data.lblod.info/id/bestuurseenheden/bb749fce340952ed57a7055edbec4c7a0aec9b2623ab5c41997eb4b013287997>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/83cff3a2-7ab0-4cb7-b9b1-01f88265817e> .
+
+<http://data.lblod.info/id/bestuurseenheden/d2ddbbea9b30242eedb334f9729dc9f9b31c9c0496009a474b407393b383ef53>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/d1917ea6-f1c5-41cf-b2af-447f1d370d01> .
+
+<http://data.lblod.info/id/bestuurseenheden/ce5950d88624248728b62bb587d934da5aee55f5fd5a9d3f569b3a1310390395>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/64ae6d76-aa1c-4df7-99d3-4efd9a4320df> .
+
+<http://data.lblod.info/id/bestuurseenheden/99da98a7a0087d3429b084ebfc4eb5d488c593790d4d5af7253982a2e21a6a5f>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/570ac453-b6b7-47ea-869e-2047b0f7906e> .
+
+<http://data.lblod.info/id/bestuurseenheden/e84ba36959d82fc95bb17b25d2e70c135d8805737ba27bab572af670a2768338>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/741ddc80-fdff-432f-895d-484ee3fb035c> .
+
+<http://data.lblod.info/id/bestuurseenheden/dbf74e8b71e474626b7a7566e6b74db3a73790e8b991a385d404e2267378635e>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/f0c82c4c-e50d-4885-a769-3ecd1edd8ee7> .
+
+<http://data.lblod.info/id/bestuurseenheden/304af9edc6185856c8b005c8d33276581b84b2c90cb2a48a0584e3802b7a9813>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/dc963735-8bb7-4faa-9c57-c2bcdbc9782a> .
+
+<http://data.lblod.info/id/bestuurseenheden/99ed6eee81a7aca47517cbffb46eaba38f3987eeb4ad32c020898644769eb615>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/7a25c32f-e161-43da-af61-133179ff6fdf> .
+
+<http://data.lblod.info/id/bestuurseenheden/4adb22348ac4f9e8aa3872c9366df56df12fcb49a854eac06b4c6ab3625bb75f>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/25c11629-4084-42f8-94ac-918f3ef6cfd4> .
+
+<http://data.lblod.info/id/bestuurseenheden/b2ee8ae754844119d83712a384587b6086358c0673645a27bca3a66e845bce84>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/61e30f3a-54b2-41fb-b2ff-f96207a98d8c> .
+
+<http://data.lblod.info/id/bestuurseenheden/e40c7c891fb462d2128235f88fede078846d942da5688e4f9cdfb5bb04844d84>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/278ccdf8-5170-4501-9daa-d4a853de40cd> .
+
+<http://data.lblod.info/id/bestuurseenheden/6cec176758a515b339ebca3b863b8f2b7caf7da58d329ebceee830ab6518bd86>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/cc97c7ae-8b3f-464d-89c9-30e74abaea79> .
+
+<http://data.lblod.info/id/bestuurseenheden/353234a365664e581db5c2f7cc07add2534b47b8e1ab87c821fc6e6365e6bef5>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/9a3a5452-e626-4886-9499-d4826e70206c>,
+    <http://data.lblod.info/id/betrokkenLokaleBesturen/b7695bf9-8f3e-4a90-b029-230e069fc38e>,
+    <http://data.lblod.info/id/betrokkenLokaleBesturen/c9fd8612-c459-40e7-bff9-de204a9e4733> .
+
+<http://data.lblod.info/id/bestuurseenheden/f881bb13d3a1ae27056d085fc041792beb3b4b3d1adf1ee3399a7184b71f6863>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/4ebb7193-400b-4415-9508-4a3af27a029a> .
+
+<http://data.lblod.info/id/bestuurseenheden/9574bd4a68b1f9243f10b6e5e5c973f4e957c96cd15f57057d2966036fb1a7fd>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/31658bc3-3296-4f2f-9e91-0badefc5c790> .
+
+<http://data.lblod.info/id/bestuurseenheden/78ea1cc22fb4b7760f81755a9a6b0de8daf21268c91ff44bdbec308d514cb88c>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/28246920-b91c-4321-8e10-65c1edc3c7ab> .
+
+<http://data.lblod.info/id/bestuurseenheden/6adc5e4321b234c5e026c9b785435c791733fe13655cb3dad402af6b73534516>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/250a4a81-2394-4828-8aa8-3ec6e2625908> .
+
+<http://data.lblod.info/id/bestuurseenheden/2fb596ee22eb20999478e63cfb8f270ab00e4336e34442c031471293ca6f92e8>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/868c83a4-bd00-436f-93a8-3fae5f32ccea> .
+
+<http://data.lblod.info/id/bestuurseenheden/92349192bc0054f415dc7dddabcd0effd189279fb0e7a0e2b9ab8b1aa8bf73ee>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/baa67736-47f5-4838-a5f0-3b2e50af4ae9> .
+
+<http://data.lblod.info/id/bestuurseenheden/7aa957d6377d45bf9e2a1dbaf7524d01b1999cf0cc5bc8c4f4a2380e13ef096e>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/8e0e36f0-99fe-4a4f-af12-b0408163ce21> .
+
+<http://data.lblod.info/id/bestuurseenheden/243e6582a03e891c3a30a3e5db7552c83e703a609f82e1c5db8844a7ad1c8924>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/f5413fe1-5117-473a-8f7f-d9da25e2f5a6> .
+
+<http://data.lblod.info/id/bestuurseenheden/514bd3d6ba551d4b2a7e866c7dafd65e371acd75240dc92610590c5804c641df>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/e4455570-25ed-478e-8fa4-be7ecac66c11> .
+
+<http://data.lblod.info/id/bestuurseenheden/5679c9292547a19a6186dfccb4047045f8a9c4d24435a6daf45226b3d675558f>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/50a9a3b9-a9ed-4d94-891d-4d70b8cc1a2a> .
+
+<http://data.lblod.info/id/bestuurseenheden/0c2d775df43f87d2048eb26c322d1bc9423e0a3f0ee7ceefd2011cdb077f12df>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/62bd8d74-c266-4a42-8a43-bf8fb8887bf5> .
+
+<http://data.lblod.info/id/bestuurseenheden/0a3ba641d653b436b14fde37bb6eab4f1054aa0586eb98021b723d58f6ce82fb>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/214bc598-39ea-496e-906b-60ec04543b08> .
+
+<http://data.lblod.info/id/bestuurseenheden/13eec34a405a478eab20b99eb813f2d0f409c0f8b28960b229637b394b82f880>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/49751f48-7076-40ac-8002-b0793aa4aa5d> .
+
+<http://data.lblod.info/id/bestuurseenheden/011a6ad0efca0b7e03ca9b99bd6c636a26cbde49aa0d6844b9ebc434dc58216c>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/68c31d29-4373-4215-a9dd-e26b90be567c> .
+
+<http://data.lblod.info/id/bestuurseenheden/0bb11f642e87a81479446ebe4938947cbc35da5f7516a3d5a9667b67d5024574>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/d243b200-81a3-43d7-8dbf-df8f89fae3a3> .
+
+<http://data.lblod.info/id/bestuurseenheden/644341a5338a39472f7d096f3c1619ca0e8325a560f681f58896fa843cb17d2c>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/7bcd745d-6fa6-4a57-94ec-5aae6afd05a1> .
+
+<http://data.lblod.info/id/bestuurseenheden/f4a187c72e551b9d7745e3b8602b11f12ce0fd5399c7f8aebbd4f8f42dc9c028>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/62786f76-4e5d-46df-958f-b45c95e6aa03> .
+
+<http://data.lblod.info/id/bestuurseenheden/b85b33fb0ce57e2b332599d2aaafcab35a3560b709add3cec98e21dca6cdc210>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/3c6efedb-efb6-4aaf-877d-7cbbe3bc9aa3> .
+
+<http://data.lblod.info/id/bestuurseenheden/79606fdb21535301a493afb83e18758d21f6499355beab0099a6265fbdc700d3>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/ed3bebca-9177-4e8c-8e65-27616d334a18> .
+
+<http://data.lblod.info/id/bestuurseenheden/3499c07d07336622b8880bd8fd9bd49667f88d6998755cb1dc31f58012248b43>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/e9c7a18b-197c-401e-8239-14f990c950fa> .
+
+<http://data.lblod.info/id/bestuurseenheden/72f67d3444ab98d389f85fa57939aad373269bfe15dd47aa6c1a9a24ce1a746b>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/568e868f-7005-40b9-957c-9e02054b1a80> .
+
+<http://data.lblod.info/id/bestuurseenheden/920b64f03ced3fc044fcdf5493bbb99573a4213f921dc92509581cea87d7a80f>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/162a3bc7-ec69-4dd2-b352-6848290f4f7a> .
+
+<http://data.lblod.info/id/bestuurseenheden/db046b577b77c00cc82b51b1cdf14396364cbe1ebc0f4cfee09619bec9b0bd5e>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/12a63c62-dc35-40fa-a9c4-33890fb75b9e> .
+
+<http://data.lblod.info/id/bestuurseenheden/70b79f6678036bf05e970aa3885d1779f143d4eab63ecf339ea6263e7e76ad1d>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/fe93089a-d4c1-4dc7-a774-b3d01decb8c3> .
+
+<http://data.lblod.info/id/bestuurseenheden/d168033a9bac278fa744c425e078eeabd304397f953feaaf5327b4e039aecacb>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/35c5df16-5ef4-43bf-97f0-681654a1549e> .
+
+<http://data.lblod.info/id/bestuurseenheden/25c9ed309395f3dafc25ae14e5fd515a729f260eda74fa2ab8b3cb02adb85c84>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/4ca67124-51c6-4c39-b2c2-76f332d74a90> .
+
+<http://data.lblod.info/id/bestuurseenheden/319db6e275f281d0280da90d6f6aba3462f4e47b6f53a34639feb91015a5822b>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/ba45706a-e24e-4adc-96a1-f6475d9e72a0> .
+
+<http://data.lblod.info/id/bestuurseenheden/38dc63f50a4f7ea61ef741d8944a874a59ba84b69b9ff3e73f69680da2c6ef37>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/a1ffa407-3e09-4c59-8666-41e4d06c93c1> .
+
+<http://data.lblod.info/id/bestuurseenheden/e580b3ee33ff28d93f803e7f70cdb1d99bf6ae9d56b0f630fd7b6837adf8cd4c>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/e894ea54-e3f5-497b-b2db-99244d7b8492> .
+
+<http://data.lblod.info/id/bestuurseenheden/5ee75cb5b6f031391189ad0f6ce6fefbc35f7fbfe1e50b7ab57dcab25ccfa139>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/b6e810a9-565a-4157-b3bb-dcc88e8e5338> .
+
+<http://data.lblod.info/id/bestuurseenheden/7d457bc3985fbb70ba748c121043c89d498a3926e8c59ffdf9438c2896791248>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/e6b76587-cb8c-4689-9f21-5cfb9f108f9d> .
+
+<http://data.lblod.info/id/bestuurseenheden/14278813524c762255aeba149e7d7134ddecfbb43e7d56910731bd4e13e34f39>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/9f0c28c3-6859-46b9-ac36-b53efaa333d7>,
+    <http://data.lblod.info/id/betrokkenLokaleBesturen/d5f854b4-0751-4a3a-8f4b-227e3dd8252e> .
+
+<http://data.lblod.info/id/bestuurseenheden/0916618d3560fe5a168ef536c25ffaddb15ef6ce43105d3ed20df38615803c77>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/4fb4a21b-74f0-4e98-afb3-62e32c03f793> .
+
+<http://data.lblod.info/id/bestuurseenheden/d7d9ef5babd2876ad492a71c2019f02cf90c813c00befcf3682ba49186d0f4b1>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/a11ea4bb-6f42-40b5-948f-2d4645e96b10> .
+
+<http://data.lblod.info/id/bestuurseenheden/d82b46992186c404b09e13b47502a8ab420c8f72316f1819847b1be44ba6314e>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/aa9f88e5-132b-4bfa-9c5f-b226c6ef44f1> .
+
+<http://data.lblod.info/id/bestuurseenheden/6377f53f54990033c90de6101e263f4d9e41eb7c3e4f70dec48caccefc253760>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/d22dc214-5d35-46a8-85b6-8f0b2793b7eb> .
+
+<http://data.lblod.info/id/bestuurseenheden/73840d393bd94828f0903e8357c7f328d4bf4b8fbd63adbfa443e784f056a589>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/79c1a286-69a7-4c6d-bfd9-eb82749fd759> .
+
+<http://data.lblod.info/id/bestuurseenheden/20b0849eb27533844f4f6c7acb3b8a5bee02a6d2dd5abbc74e07dcfb720716a2>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/697412fc-de35-41ee-9786-81e62ef25f56> .
+
+<http://data.lblod.info/id/bestuurseenheden/8c1b2274fccbaac94935cb2ae499430bddc052c3982a425a77c454cb615dea2d>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/207be3f8-e1fc-46f0-acfb-3e9f9660b344> .
+
+<http://data.lblod.info/id/bestuurseenheden/856cbc8af3fbe7390d43420e249c288596e87fbc069c601751d5c5fcd52c543b>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/2ac22503-9450-42c3-82a5-96cab6bd72d4> .
+
+<http://data.lblod.info/id/bestuurseenheden/416aada66520f1b6f4eb79177cefa7c5815bfb85fd455431c1ef91fd333769fd>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/6572b77d-be77-4c5f-b1fb-473f34ace8ac> .
+
+<http://data.lblod.info/id/bestuurseenheden/c94741a612946db4bffa00439a515a831c7d4de0d09d79538af2a1dd781500ca>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/dd510104-5352-4a44-962f-0424c960c251> .
+
+<http://data.lblod.info/id/bestuurseenheden/69af2347b1d0a9a39dbcf0ea4d94b9eaa15edb0c7d2dba56bbd9c39ab1c80e9f>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/d02b415a-c66c-42b6-a15b-0e5101edf9cc> .
+
+<http://data.lblod.info/id/bestuurseenheden/8fd72c4cd5f095c508af05e3406aa63114279e8bde54e9f5b83a59c7794dac72>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/0632f407-2829-4a17-afb6-5725fbcf80db> .
+
+<http://data.lblod.info/id/bestuurseenheden/476ddecbaf169d4c9af3ca8ed6725f4efebdfdb9647fe82ec4406496c6e930d9>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/f1dcd064-35aa-4d47-a8a9-5f3532e4787f> .
+
+<http://data.lblod.info/id/bestuurseenheden/763adc09114dd8d54a1c8bfabeaec5e5ce543d858c3dff057a1c39f9103249a0>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/e7c618b7-f47b-46cd-b081-59839d20398f> .
+
+<http://data.lblod.info/id/bestuurseenheden/985774e5593009ffa08804ffad482f0dee8490f1cdfde072116cd60e4528892e>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/ff579e0c-fce9-4855-8a06-ede8de9e9754> .
+
+<http://data.lblod.info/id/bestuurseenheden/cf8131ac6fcc41224b895fde6e18def464a16012f05d3c078da2637e0f1674ee>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/eb38cf59-77d6-4fb1-8912-183d90a6affb> .
+
+<http://data.lblod.info/id/bestuurseenheden/bab5de8f12aa24ded31c67cc00b626705d1336a63f5711c1c70a8438daa6da1b>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/87d179f6-7413-4137-bdf6-63ac9d4c16d7> .
+
+<http://data.lblod.info/id/bestuurseenheden/3b6163727a5930106e631885999aa8e1dbd24eaf1931367b7f38123a89f14f10>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/466e8074-bd15-46d7-95e1-02a03527948e> .
+
+<http://data.lblod.info/id/bestuurseenheden/f6b131de5e40a0dfd4fc93fedf3b95c9bf156ece718b87fe00469dea2564b3fb>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/8579babe-cfa9-4dc5-92ed-15044ef5a098> .
+
+<http://data.lblod.info/id/bestuurseenheden/6463c55877def582f642cb5b3b4a7eab60d8d8dd9779fc45d87e4c8aa5d9a07e>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/71680486-630e-46a4-8325-37b3026b1385> .
+
+<http://data.lblod.info/id/bestuurseenheden/d8f7f1849303f3bd250d476ee5b44456d42b4d2f79f8f72b0be754484cb5fda4>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/6417268c-ec01-4873-89d1-7bb777ad1583> .
+
+<http://data.lblod.info/id/bestuurseenheden/19537690173d82d774bf34abaa07f3b1af78139014e53aa8f172a0a558bc5e09>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/64128756-b6c8-4e0b-8fce-df7bbf327c0c> .
+
+<http://data.lblod.info/id/bestuurseenheden/a10d7dc2599e3ab6854fc83d1023224eda8cfbc62017d4a1a82bedef7a03b8e4>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/9905d0ad-9ca5-4077-b5b5-452f207b45f7> .
+
+<http://data.lblod.info/id/bestuurseenheden/23bb41cfe7b4cb3af101ef96bf9ef0466d19997c0e100123722371d369d580b1>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/77e1f4cb-1055-46d1-b052-852bdd79fe68> .
+
+<http://data.lblod.info/id/bestuurseenheden/7269d3607a761c9ce0e226e0b7ea5687324230b65a568d48c81a7acba53998fd>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/d19a92da-1ddc-4410-9188-9c3941f41173> .
+
+<http://data.lblod.info/id/bestuurseenheden/4968b47120d51c329a12c6bd6742ab220cbef8f6720da3ad8e6a499150a1168d>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/e0c8b859-c442-4e0f-8735-160a95ba8ac3> .
+
+<http://data.lblod.info/id/bestuurseenheden/bfdf2304f758f547ffb7c7afd4e6358290778642104f73910eadb0fb103152fe>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/09dede7e-1e6e-4c0a-b0f6-2b3c52291d5b> .
+
+<http://data.lblod.info/id/bestuurseenheden/670db1d66c0de3b931962e1044033ccfa9d6e3023aa9828a5f252c3bc69bd32c>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/089cb5a2-8b1c-4c5b-a49e-5a176a0d145a>,
+    <http://data.lblod.info/id/betrokkenLokaleBesturen/3611f01a-6439-4631-9ae1-da38a5ba83f0>,
+    <http://data.lblod.info/id/betrokkenLokaleBesturen/4bdbb2b6-3ce4-41c7-b05a-10867a142668>,
+    <http://data.lblod.info/id/betrokkenLokaleBesturen/4dd4ef9f-36cd-4a40-a16d-1cd65bbaf3ec>,
+    <http://data.lblod.info/id/betrokkenLokaleBesturen/706b2012-3aba-477e-9c9c-ce47f29e3840>,
+    <http://data.lblod.info/id/betrokkenLokaleBesturen/937533ac-0cb8-4e78-91f7-c23dfee89bb2>,
+    <http://data.lblod.info/id/betrokkenLokaleBesturen/b88e6c3d-21ac-4252-8526-a8fad885002e>,
+    <http://data.lblod.info/id/betrokkenLokaleBesturen/ec55bfbc-67cd-41d9-8823-3aca1d4c959b>,
+    <http://data.lblod.info/id/betrokkenLokaleBesturen/f74bebb6-1322-4d3d-b96c-acce0320ae36>,
+    <http://data.lblod.info/id/betrokkenLokaleBesturen/f80a6a4c-9b90-42ae-ab5c-8ab9bbfe2724> .
+
+<http://data.lblod.info/id/bestuurseenheden/b942231860865ab0c4108651b117f69a755a04186df97e767707e5d95955ebbd>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/d915a89f-703d-49c0-9dc2-7eaf5c419a99> .
+
+<http://data.lblod.info/id/bestuurseenheden/104f32d7fb8d4b8b61b71717301656f136fe046eabaf126fb3325896b5c2d625>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/ce3cce03-8a26-4eb2-8b22-887c99dd27b9> .
+
+<http://data.lblod.info/id/bestuurseenheden/be278471a2a318edba32e7ac4294c0eafbe4c8077a34dcbb9c2e43211d4a78a6>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/213e15a7-e334-4aa3-ad36-8cded8a27157> .
+
+<http://data.lblod.info/id/bestuurseenheden/71e6c6f58d20f6db457245a70394f2d63f601a32f8ccbc7e443e98f8d06b0b0e>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/589e11e6-367b-4649-a15a-ac14ba1c4d8e> .
+
+<http://data.lblod.info/id/bestuurseenheden/c69192b973a3ca11531b9657b3ee20aa6688fa33ea1ef1392310fec751980ab2>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/9246c603-62b1-4984-a90b-4f1608b600e4> .
+
+<http://data.lblod.info/id/bestuurseenheden/6d323b27377e803eccb4261e8014f5198bba924b7ec3d7d7fa2d2a3a41f7e0f2>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/35274e45-b5b6-46b2-afe1-98e0aaff5a58> .
+
+<http://data.lblod.info/id/bestuurseenheden/28346950e285b8b816133fece5ac9408097c3f190c7f32573cf0c640d6c34b1a>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/27a6cb6a-e17b-4f57-96e4-b3ff6f783e5a>,
+    <http://data.lblod.info/id/betrokkenLokaleBesturen/5fb9cd00-c6b5-49b5-8eb5-381bb8167446>,
+    <http://data.lblod.info/id/betrokkenLokaleBesturen/c34307ad-7555-4140-827d-34f49191622a> .
+
+<http://data.lblod.info/id/bestuurseenheden/a1f8ddebe40f6a09270fbe460e71ebb7adda7b1ac2e5c4ccb3fd6e9dda2162b6>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/128b0d77-a84f-404b-87c7-8a979cbfac44> .
+
+<http://data.lblod.info/id/bestuurseenheden/764a0c6bbc866153ae70cf75d745b9477fa010567246cfe6683b7bb8aec541b4>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/70e8bbcc-3fec-45fb-855a-f10029468a19> .
+
+<http://data.lblod.info/id/bestuurseenheden/ca02bb76e04d7d3ac3282e39ec861a89f8a8c6c7e0d907373953fa8001c9c35b>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/9cba7852-98c8-4e71-b702-4d4057b8f2c5> .
+
+<http://data.lblod.info/id/bestuurseenheden/92fd2a12bdcc24f8e6ef34de765d54b3d7a0412b69c0877836cbe3098a5caf57>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/b0a6cc03-f5d0-4232-89ed-9c9d4a82f211> .
+
+<http://data.lblod.info/id/bestuurseenheden/d408e63f6ebbdfb20dbc63f8f8a4f91f2fe4eb23fa2496f9ca102ec583e9e022>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/7ad2d2ad-c003-472d-a9d3-cc0217e8244c> .
+
+<http://data.lblod.info/id/bestuurseenheden/b36da606fba6dd4dc99ae1ef5f4a52bba3268d33f4bc2cd1e65b87f01f35101a>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/4a062eeb-8a0c-4fee-9d65-95ee2201f2a6> .
+
+<http://data.lblod.info/id/bestuurseenheden/f923867abb64ec787e987ad25b3bae8bcf38dce127e3a664ad18b30e18d70986>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/01a80a07-f933-4eb3-ad55-abbce96232f1> .
+
+<http://data.lblod.info/id/bestuurseenheden/d03795d069b5de6a386ad04bdb0970ef079eaac1be473414bcb63a6c9eaed4d0>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/b7bbabee-aaea-4380-a6ea-ef80450a5419> .
+
+<http://data.lblod.info/id/bestuurseenheden/d8247b68bb62c768c36308fbd7203c58038e249b8363da29d223aa6cd97cf242>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/50ae7530-3c5c-47c5-a4c3-e867f7b8d913> .
+
+<http://data.lblod.info/id/bestuurseenheden/b4ff2bb483e5a18fed7b115a2da7af8447e1a3bec4283fb5cf480810608a1e76>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/b91371e9-96fd-40e7-94ac-2dff4b25bf94> .
+
+<http://data.lblod.info/id/bestuurseenheden/929c049597e4961ea84051927af6be67062da4fc8ed9b755fc33b1597b8cdc7c>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/8a01e75c-a469-484c-b16a-925066ce84f6> .
+
+<http://data.lblod.info/id/bestuurseenheden/a863212dae496f3c67044c214843841e636f373fb1c97a46fef3ef82d77ac925>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/fa7e9864-e350-4183-adb1-c448689fdc10> .
+
+<http://data.lblod.info/id/bestuurseenheden/be8c097326db7ba0e0e7c81b832da8b4cdeabe22b515494753dd95d33d9ea295>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/77bf3b5f-3f68-429a-885e-d88dbfefb3d2> .
+
+<http://data.lblod.info/id/bestuurseenheden/3eb8c9fae32d02359dcd7b22e2a74e67a5b48388df31ad819c27c688fedd10b0>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/c53d5dba-3877-43fd-9d41-d73b92549174> .
+
+<http://data.lblod.info/id/bestuurseenheden/d90c540e25805c2ba9efc77ca016e4f24102c44496f9590a3a5c769bd6dffa74>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/58808ab5-24a8-413b-80fb-68972c666bdd> .
+
+<http://data.lblod.info/id/bestuurseenheden/1b17382556917a15828249872bc4f913a24f7656cd5722be270f0e31b9ff0c06>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/3a91c63a-e100-49f8-9385-89c08c87675a> .
+
+<http://data.lblod.info/id/bestuurseenheden/52cc723a-9717-496d-9897-c6774cf124e4>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/cabaeee7-baa5-453c-85c5-64b797f74734> .
+
+<http://data.lblod.info/id/bestuurseenheden/c2c19bec2f337e69a4c9838eacd88041734db523df4f7534cf407c9d380b64b8>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/2a51b7c0-2708-4c9b-9ce8-8eb2c1c16b11> .
+
+<http://data.lblod.info/id/bestuurseenheden/6a56d8c050b6c2a76912c5f6ec3859b939de6d990815f35403e5be41a7703a44>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/0b24ff63-9e02-4149-b0da-5795de03ae6f> .
+
+<http://data.lblod.info/id/bestuurseenheden/696a100b72d304a89de34ac2f10c9ebbfc82268297f201feca5d60b51c8b883a>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/5464eefb-2fb0-4737-9304-466669a5ddc3> .
+
+<http://data.lblod.info/id/bestuurseenheden/70628fa6e628db4151087aff35bab9b21d2b3701ce3f59f133128daf0c9d14ef>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/047418fa-8aa8-4524-a4a3-65fdde2bd492> .
+
+<http://data.lblod.info/id/bestuurseenheden/3b337ebeb02ede5e152c952e2f24aa1bff3ebbb6afb968a647cb05efe72c0237>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/b09b6515-5781-48cc-ba0b-2d22e765b432> .
+
+<http://data.lblod.info/id/bestuurseenheden/9db1b46874a57fe63c08fb5f16b117e6f61fdd98e7f64f745d0fceb9d3731169>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/fadbd6f2-0118-43a8-9eb7-e8d4a91bc8ed> .
+
+<http://data.lblod.info/id/bestuurseenheden/8d7de878-db13-4fe1-8d74-bb8c9a690d90>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/80f91b42-8387-40e3-a57d-682f35b5954d> .
+
+<http://data.lblod.info/id/bestuurseenheden/59eaecae469f80eccaf6d36a165927eb8ee8749b9866ab1730e6b1ba45dfaaa7>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/df27db01-f88c-4c60-988b-74fec112c8b4> .
+
+<http://data.lblod.info/id/bestuurseenheden/36f1c660b51e5809170f17ce6bf420a9ad7bf596f049d0d2f2c638f107e8c509>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/81da9158-07fa-44bb-b598-31ad4ac20dc6> .
+
+<http://data.lblod.info/id/bestuurseenheden/5a8f9c6bde6c6b01bee07d9dbed16a8b685851865d5083edbf617a4dbd2e51ce>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/bfabc47a-37f0-4ed5-b4ba-70052e83d135> .
+
+<http://data.lblod.info/id/bestuurseenheden/47857958-7d00-47e0-ae83-00d914eca93f>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/16243d63-2cfd-42a4-834a-3ccb9a01a2f6>,
+    <http://data.lblod.info/id/betrokkenLokaleBesturen/a259314c-5931-4122-bac1-e7f9813cc10c> .
+
+<http://data.lblod.info/id/bestuurseenheden/c5b139c66d86282381b3eb0ae4da68252d6eaf974e310fa5d200601b7cb69070>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/6a929c1b-82e4-4d93-a3fe-d91a75217f46> .
+
+<http://data.lblod.info/id/bestuurseenheden/bcf3f79bcb96133312dbdc63dd157caabd3329358ed4440a03ce6d6fc6af09d2>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/7ff5d6d2-d991-486a-ad03-2beba2a88f68> .
+
+<http://data.lblod.info/id/bestuurseenheden/1f1e0b8819cb311774b62e85f5d701fcd0a50410894da331687b66b4ce3e96c5>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/28b914fa-0e7d-47e2-99fa-9fa3a409be54> .
+
+<http://data.lblod.info/id/bestuurseenheden/2d6f7aa09c55d347a56da51c583f762843fca5da4acd824ee2dede879a197a7a>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/8b4a085c-99a1-4789-b566-b6ad837bcd44> .
+
+<http://data.lblod.info/id/bestuurseenheden/1490ca18f894573f76065dc4fdfa2f9c0bcb00964a6af2e21ff8a81e9f1d1198>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/ad535a13-cff6-422b-a083-c827cd77f232> .
+
+<http://data.lblod.info/id/bestuurseenheden/8745182191882c1185893960aecc2ed4f91825d7a5ea2e62e9f2d7acca082a5e>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/709b701c-573c-42b3-ae08-4db84215308b> .
+
+<http://data.lblod.info/id/bestuurseenheden/30ffe6401585d30b839b382a730c253255d88403dd5baf70b4a3e60f1bd03cc0>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/cb8b230f-f1e4-4992-981d-e4d0ecf889a3> .
+
+<http://data.lblod.info/id/bestuurseenheden/64670f8facf973e783fc7dcf5bdb8db91d3460f1a54a262f113c2230b3685af7>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/c345fbfc-ab9b-4211-a032-e41753da5288> .
+
+<http://data.lblod.info/id/bestuurseenheden/b45815b052363cc4b1c89eeb8dd6ae4dbf8433883d314b4c1d88c96a8d912212>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/9a7efbb9-d5ff-418d-b02e-f9c09d8489f5> .
+
+<http://data.lblod.info/id/bestuurseenheden/56423901b281897688074e6ce6811a6a33eec4070da7e22c4fae65050d7b712f>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/d7565813-18f0-4dad-b6b8-41b91947f105> .
+
+<http://data.lblod.info/id/bestuurseenheden/7d7122bd82f165e091a36c830d041b59aa48e4be9ea0aa06dc4c67ef381b7505>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/f7054ad2-b4e6-4117-9f8a-d40e03da4ce5> .
+
+<http://data.lblod.info/id/bestuurseenheden/4e6d15d5c7fd95c996087bb13cdee985f0b550256be745024d5facd1485df284>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/5ec8ca42-4386-4888-a875-f2175106a813> .
+
+<http://data.lblod.info/id/bestuurseenheden/d7187635377e73d8cdd7e2743257bf93742a82f700e6839eb12a3e3705ac36c5>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/4baf611b-0850-4c92-9dd2-8872c5c4f629> .
+
+<http://data.lblod.info/id/bestuurseenheden/dcacdef6115b1c15bbaf8559ad4fbc3b694a12af37c178ac54227a630d2ead34>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/93db383d-b5f2-4bde-bf0e-2d36c5d2efa0> .
+
+<http://data.lblod.info/id/bestuurseenheden/6025a5d1ca2262a784f002edd8ce9ca9073ae3d5ebc6b6b5531f05a29e9250af>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/d2398702-63bf-498d-870d-6060cb716bc4> .
+
+<http://data.lblod.info/id/bestuurseenheden/2ac1bb2a7d7bbd98e2e7a24be2c67e42171788a71c2436a33060626593bb2f78>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/1047d898-f0a3-4f45-ae81-ea8e44e1599d> .
+
+<http://data.lblod.info/id/bestuurseenheden/87548df6451c56b75e1064613f01fa92bb0c1d9b1e0d9019336fabd39e54ace0>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/88a03a37-2ff7-47e5-a79b-9dc6e5b99a50> .
+
+<http://data.lblod.info/id/bestuurseenheden/75b2e9d02e7790b6c0a23a3885df7e3069723b219091025dddd67ef84ff24c87>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/0206d727-0cf5-4cb7-bc80-9af44cb205e2> .
+
+<http://data.lblod.info/id/bestuurseenheden/a0b451f349f1609834f2236ed8149e4f254e9aae1a897c531a99b9b0bbac0899>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/9985cafe-8eeb-4ca0-bdea-6f644f1466a1> .
+
+<http://data.lblod.info/id/bestuurseenheden/18eb574437cc9fa5af24990f495aaed7af868d33341faf60cffa2ee0e57dc914>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/54958763-5035-4429-a978-2f390c5e2b6f> .
+
+<http://data.lblod.info/id/bestuurseenheden/05099fa1f6524b8b994d86f61549455d2c00b2a956d5308683ac2d1f810fc729>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/d09c807b-a88a-452e-8522-ab1192e4c14f> .
+
+<http://data.lblod.info/id/bestuurseenheden/a3bd0845853278f478f90b14436d3efa99e73249a84d462f0ddc2e5b6e37a156>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/2feff2ed-ea4d-451e-b128-de14e7c2327e> .
+
+<http://data.lblod.info/id/bestuurseenheden/53eb88088ce2822bcef97df5f71154045e113b750c6b97b29793a29c4f0ac7b4>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/2ed9ac9d-5131-40aa-9881-c23860283973> .
+
+<http://data.lblod.info/id/bestuurseenheden/d59bf99ac29e71796ad7bdfe68cf74709c63721691d9680e0ea7636070f7513c>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/dfa69fc9-3739-4e65-9d18-1c8fd7721e34> .
+
+<http://data.lblod.info/id/bestuurseenheden/764278b3ceac360476b418c108d1b022b6e0cc8fb676f3f6b6b9faf78a2375ba>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/fe97d33f-d6f9-45c4-9526-caac68f2e880> .
+
+<http://data.lblod.info/id/bestuurseenheden/bc50bb1ff28814ab2441a22fe111d895742098d8a61d7f648efbd9ffd48446ed>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/7d22ca2f-1203-4333-bc93-f8e7826dfbf9> .
+
+<http://data.lblod.info/id/bestuurseenheden/1d2b18c49b345b619afdaaae22a13bf31156ef06417399fd59bbc321f15d228b>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/935cc3be-c4e1-4b3f-9aaf-c12c2b294b3d> .
+
+<http://data.lblod.info/id/bestuurseenheden/d93451bf-e89a-4528-80f3-f0a1c19361a8>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/34837fc6-c5f9-424e-8d9e-b9fef8751a8a>,
+    <http://data.lblod.info/id/betrokkenLokaleBesturen/b37752e5-6010-4bde-9528-d75267568b46> .
+
+<http://data.lblod.info/id/bestuurseenheden/e971816acb021c37576835e6a96922442628956fd029d885fd849c9f07414469>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/fd55d258-10c1-41fc-8158-ebe18ef9a3cf> .
+
+<http://data.lblod.info/id/bestuurseenheden/788f5e9af7c2e5e158bb9b72d7cababff6d4a871c5b63f346c8fcedefed33905>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/b02539bd-7de9-4b53-914d-b77a0b70b346> .
+
+<http://data.lblod.info/id/bestuurseenheden/8152e68420f560b8493d6c555a5bd4186903dc341028bb9855af6c44a9464fea>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/c4ea099a-26b3-4a6c-8d81-6b7985579499> .
+
+<http://data.lblod.info/id/bestuurseenheden/d3000e1841d968dd70d4534bf216699d830d146ccc1f88b902b0793caad9daf2>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/3440173c-27e5-4f0d-8f02-be3b91f605be> .
+
+<http://data.lblod.info/id/bestuurseenheden/f39eb137cb5c9195f92928522bbbf0d104fb54be6eb0c9c62a24d16b88b44272>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/c4c82ddf-4cd4-4e82-8976-45987e24c0fe> .
+
+<http://data.lblod.info/id/bestuurseenheden/a9e63c13a602de3cc5463cc81eee0b8d80d14a1846d1deb82b3a2d4e7efc96af>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/7f467c15-7ac5-4fc5-92af-83aa20bc920b> .
+
+<http://data.lblod.info/id/bestuurseenheden/80c5a6a8789862c171c8d33ae28cb0649b4a0186114eb49ed36dc28ea515604b>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/ba677230-e9bd-4902-b763-7672e5a3a979> .
+
+<http://data.lblod.info/id/bestuurseenheden/d2d0cd89d307fb651e2d0d064a89134dbc2f26b0ffacd92d2d71e9683468a206>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/d8dfe222-6a06-4b8c-a925-84bbc1d1cace> .
+
+<http://data.lblod.info/id/bestuurseenheden/bc1d9bf8b47dad5cc29db38c5510f1c91399302b27e928719ac1286637406f25>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/ade9acde-d2e6-4ae3-b733-733d8465e83b>,
+    <http://data.lblod.info/id/betrokkenLokaleBesturen/efea1be4-8f83-41d3-a3b1-44aa09d1e258> .
+
+<http://data.lblod.info/id/bestuurseenheden/e9e0287a3a974fba665e2649242a3607b8db35ca22085baf9ec26972b6e6a86c>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/509a0e42-bc30-442f-a872-d39fe8388f33> .
+
+<http://data.lblod.info/id/bestuurseenheden/6af55cecaea3621f53bb32417a36ed6e3d41b2aa5b9f6d62ab3d80cc8ec11539>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/74abb738-8f89-413b-81b6-bc7f461b278a> .
+
+<http://data.lblod.info/id/bestuurseenheden/974816591f269bb7d74aa1720922651529f3d3b2a787f5c60b73e5a0384950a4>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/bf6ecbe4-7ce3-4711-918f-04f498367d47> .
+
+<http://data.lblod.info/id/bestuurseenheden/5db8cd4f01b90c3dfc31f5d2b5e931cfdd9116a779790ee55cb71cd314c5a4bb>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/78aa54ff-a9ef-47d9-81d0-9266cb8ef940> .
+
+<http://data.lblod.info/id/bestuurseenheden/f0cc06aca0893bc875d3254bf753f2357f67f2895871347a0dd05628b0ce77c2>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/e2620be3-8f6c-4dee-a0ef-ed02009aa7dc> .
+
+<http://data.lblod.info/id/bestuurseenheden/955a75560dd7c57fb9b882b0e92826ab06d77f1a4fc2722b4421389d47a247f3>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/5ed9eb05-627f-4b28-8ed5-813e4b3dbf38> .
+
+<http://data.lblod.info/id/bestuurseenheden/4ff28976ce6eb2a8d6bd19346f5b4de202c53bc5b33904205c8cc580877e4769>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/cb597309-1b3e-41e2-8798-1670b0b3c2ad> .
+
+<http://data.lblod.info/id/bestuurseenheden/931a2bf4f5c461d8c3636b446fa642693d4535d865d3af068e87d25ddc93374e>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/a215fa25-a829-48b2-b40c-6edea1494795> .
+
+<http://data.lblod.info/id/bestuurseenheden/af8969752f6b28c66b6bc402d7987fa38774901ac72b95c5cb7976570487c3c9>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/a6309fc7-47e5-48a8-882b-2995f54463ad> .
+
+<http://data.lblod.info/id/bestuurseenheden/7c44225c68f7535a603d3a0a0c57a6424e8baa9fd066b6b9baa636d0facddb72>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/961861e5-a0a8-4591-b50a-815de0c98136> .
+
+<http://data.lblod.info/id/bestuurseenheden/8da71bf3f06102d4c2e45daa597622ffd1c13ca150ddd12f6258e02855cdaeb5>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/bf59dce8-dc6d-4cd6-a47a-aebc02e50e5b> .
+
+<http://data.lblod.info/id/bestuurseenheden/99a87e5fe755c1fbb0b7f5763c08e95561a02a358dd7dd0851d35496bec98203>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/0ccd39a1-6007-49d8-b4a3-57b5ec6cfc3b> .
+
+<http://data.lblod.info/id/bestuurseenheden/dac6ed961e62f29e2706c8213c6c5ee28d07bb719e564bcd47157499561e613b>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/65771337-68d9-4e12-821f-21e8bb2f3cdf> .
+
+<http://data.lblod.info/id/bestuurseenheden/94433cd9ac2dd4ef0ccda4e07f35217fb6531adbb80d8382915f89f585d00890>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/5890a48a-bff5-4dce-869a-64f386827dc1> .
+
+<http://data.lblod.info/id/bestuurseenheden/f08dca136aca8cfd86913c6e452ca3b763d618b52aec02f8864443942c50277a>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/4c2744fb-08d7-4be9-8392-d1fdf4664095> .
+
+<http://data.lblod.info/id/bestuurseenheden/af76592773d5172af4a57454ea5c3d94578379048cd7c37a4da016a07a91bb54>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/5572181b-d91c-4258-828f-372ae64f10e9> .
+
+<http://data.lblod.info/id/bestuurseenheden/995409aaafd41e4ad476aafc658669c794b3bd993ace46f08fd799c4d1151ff3>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/1a01900a-a9ce-4d10-87aa-df79e0d529ad> .
+
+<http://data.lblod.info/id/bestuurseenheden/b40be11d4f04a2e0fff76e8feae92471963c063e2d65a68210dab2707ac62726>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/cb39f5f3-ca4e-4d17-b9f2-9cd0b9a5cfdc> .
+
+<http://data.lblod.info/id/bestuurseenheden/6e7e9f3e54866ceeafcbee973e2799e4d1cc8c3970f92af29fd2d66d475c2b3b>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/e356d500-f70b-4f96-b2aa-030331b3368c> .
+
+<http://data.lblod.info/id/bestuurseenheden/530983bec9d00f1ab745b2eec290d35200c1011c592bd5694782680bf055092b>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/f62426cf-e089-49f3-8222-7e5af777ad0a> .
+
+<http://data.lblod.info/id/bestuurseenheden/4f0eb4436c88cf831c35f84e7c34ce32f9ee4e99c5139aff62990e5e531aa1e7>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/af47b89b-a457-43c8-aad3-d0c2f03b097b> .
+
+<http://data.lblod.info/id/bestuurseenheden/421187a1c73dac9514080c9eee61d018a1fb93977cf7aa96bff64f35dfd08961>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/e19033b0-8f1e-4f67-b2b4-a293a59f4aab> .
+
+<http://data.lblod.info/id/bestuurseenheden/95e51e4c874a9db9ab6fef81453b1d64531c4c5daaff47b24d266e3ac032d759>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/af5ff968-30f0-48c6-80bd-17c56501ed60> .
+
+<http://data.lblod.info/id/bestuurseenheden/319016d52cb54b416721b0c5fc74f211fdd4dd576d13a34aa9210759401dc7f2>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/84b30cfb-94c9-419a-8bf7-041a1ab94ac4> .
+
+<http://data.lblod.info/id/bestuurseenheden/8662dc060c121e9d69101062f67daeef8370d38bfe86533752b9e54190dd0e2f>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/b96042b6-bfbb-4187-803d-6661675958c3> .
+
+<http://data.lblod.info/id/bestuurseenheden/8fb90f367f105c14f37a7062d6732696dc2efc292f87fd5045548a0da407dbe4>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/0ac22758-7380-46be-b881-cb962acbcc4f> .
+
+<http://data.lblod.info/id/bestuurseenheden/169b6bfa2d8ee340f266af26d1a6055182214082dca720b8817d3893692f3068>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/d119dc08-213d-4030-ab98-fdbe796d4667> .
+
+<http://data.lblod.info/id/bestuurseenheden/7650801ef7de6598dbb2d45bb2caa877408defcc1337fa698520a25b85a300da>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/9fffe76f-9cfb-4e91-8408-d70c4feb75bc> .
+
+<http://data.lblod.info/id/bestuurseenheden/d9267014daa2764a9edd3b176678b56f57474ffe162363795690e5c684c6eab1>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/64c9f77a-5078-449e-966d-10de580ae689> .
+
+<http://data.lblod.info/id/bestuurseenheden/b4277a54dbd53cd3928c139c916eb58b03c7196c97c8d30f21b52200cb5156b9>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/be57a498-43d8-4c3a-8a5e-a1dc5f9d1fc3> .
+
+<http://data.lblod.info/id/bestuurseenheden/4a617484e231a6bde8dc15060a02642cf1730faa9c0e1dce0b7e6e29985deb04>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/06d5bcbe-7917-48f8-9e55-3a24a632b627> .
+
+<http://data.lblod.info/id/bestuurseenheden/57b1646f-bf4c-4dc4-8bc9-6ec8a6486018>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/a242d7d2-ab33-4cb6-8490-22584778764c> .
+
+<http://data.lblod.info/id/bestuurseenheden/0d2e643f4635d2b4d2fc75241a1624013b274c7ffbe8f8a5f36f2bf250336863>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/714a2f24-e9ba-4219-89ab-49129fba7986> .
+
+<http://data.lblod.info/id/bestuurseenheden/a277d61f41cf0025df3e51df800c9551a27c80e2515c32aabbbbbc2c818852eb>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/8daf621b-766d-45d0-b071-9ca71bcb4ff5> .
+
+<http://data.lblod.info/id/bestuurseenheden/23d04e951dabc6c108803eac7e8faf08c639ba6984d1cda170f09fbd8a511855>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/a8f2b132-4257-422e-9bd0-0f8081311fef> .
+
+<http://data.lblod.info/id/bestuurseenheden/02c739446ed9f2585fd96cb4c25743106462a589aa6d6f3e5feb088f025e6851>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/65163706-f40e-4944-9f18-ac0bdc51a368> .
+
+<http://data.lblod.info/id/bestuurseenheden/26e9007dd8e6316c45488b1c4d5ceff1707d25e67b892f82c166ee889c0c2e41>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/273f3fe0-fd88-4c20-9674-de1ac7a598f8> .
+
+<http://data.lblod.info/id/bestuurseenheden/8ef1e4a43efd913e6b09b0ddea344b7b5d723a344ad559389a55ae1ff0bebc8f>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/f1819db5-b9b5-45a2-9897-3fd3e551e0c3> .
+
+<http://data.lblod.info/id/bestuurseenheden/475062d945c58733894b4c506471bf7ce43c6fffde9a83bd5e390ad040203781>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/281edce4-7008-4464-8ad5-18e74b878124> .
+
+<http://data.lblod.info/id/bestuurseenheden/55155a78bd145df7bfa3caaa17ba491fb4dd238f4f4d2c5485bff1be96ca3036>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/b663f2e9-22c5-4308-82da-668b33efbb2d> .
+
+<http://data.lblod.info/id/bestuurseenheden/9a187d228c5c22e402cb2186f731a5b7cce9549d3fac1e667ce59a3cb80b76c0>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/fba041d9-1d8b-4c86-8454-6ba72da0db82> .
+
+<http://data.lblod.info/id/bestuurseenheden/393a7495daffabe3dabd5d341673287cedc58485c3c8bc273cbd058e735dfee2>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/c8dc25bf-8622-4f53-a61e-f2a852b8f441> .
+
+<http://data.lblod.info/id/bestuurseenheden/7c51e88f8a89d42e054368a7c5da3c16ecce3b86ea63918a0d7e1d46fbdde2b9>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/7ec382e1-fb93-4fb8-8a33-35491e963ad1> .
+
+<http://data.lblod.info/id/bestuurseenheden/a6fae65d377aa9e3f2575d4bc0f7cf53df2b5e80ca1823433885557ff0b18834>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/14c3966b-ab20-4c0d-b61d-04c386072052> .
+
+<http://data.lblod.info/id/bestuurseenheden/c26acb21f9fef0843d93523827562f96a6ccd939dfa43ad1dd70dcb8064c40a4>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/3a2fff57-3aca-4278-a7cc-c44ce6504d99> .
+
+<http://data.lblod.info/id/bestuurseenheden/fb4ab93def093fcefdcbafe1055941c02bb109290fffb9cd9012d549aed480b8>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/ae1fb5b6-b210-4b1a-81e7-429cfa4c6321> .
+
+<http://data.lblod.info/id/bestuurseenheden/3b1e0143755729396654f651bfed689681274839c427f9598e930d816fb7a1c8>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/a3b5ba49-7826-4221-afbe-58ea09f7e9ae> .
+
+<http://data.lblod.info/id/bestuurseenheden/c7ff21a1a6c315ca5aec2b136ffcf0d9d285dd37a1d5b10d8d134bb714e8d774>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/a96b574f-354e-45b5-b5c7-323c3686b20f> .
+
+<http://data.lblod.info/id/bestuurseenheden/71d2d00fdfc37c325895247f203ff4e4ed04cdb756413f5837d64854cc91f7c6>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/d7cd7da2-d97c-4496-9ed3-c423a0db4292> .
+
+<http://data.lblod.info/id/bestuurseenheden/1ed8e751e664569fe2792f523f234e66bdc42d9c01736d850ae59e1b2177d70b>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/6462d6a9-604d-4860-a480-06de8ab88488> .
+
+<http://data.lblod.info/id/bestuurseenheden/c0b6b5cf198cd939251dff8ed052177cfff245074c6b8d43394c8c97f7b6e945>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/5d2b4250-0927-4c24-aab7-08ba65a4f56a> .
+
+<http://data.lblod.info/id/bestuurseenheden/48fc71248bff17e9a5ca8f2c5c95d38ea551084b82e944cf7121749555ea00c9>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/cd84600f-5d7a-43c8-b971-8285b67ae173> .
+
+<http://data.lblod.info/id/bestuurseenheden/484b4d65dee04db442889741026527199e484ad1249a9a96401b45718d6d497b>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/d7672d1f-893b-496d-ae39-55fa40ab99b6> .
+
+<http://data.lblod.info/id/bestuurseenheden/6093f33e8eacb798481b1f826416eaf310552e9568e74804f59c69dada2187e4>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/7a1bc677-2030-48fb-85c3-7633a5c6a0a6> .
+
+<http://data.lblod.info/id/bestuurseenheden/4fd07fa6c794ef12a12c17976570c2bae5fe62dcc373a09032276397ae153f04>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/8d13312e-69c3-4284-b371-737b58be2361> .
+
+<http://data.lblod.info/id/bestuurseenheden/b47cda1a1458dc4935e118b6fffbdfbc55eba2659fc9321c61be0de63b5a27e3>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/3a1038f8-6e42-49b2-9f25-3bab894414f1> .
+
+<http://data.lblod.info/id/bestuurseenheden/c5dbb08e35e2d090a05d119fef4cc161b5ee1f322698cb8ea3c8c6643a521cf2>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/4c392c17-bff7-4f24-b288-99e3df00b589> .
+
+<http://data.lblod.info/id/bestuurseenheden/290c4b53b407dcb12457bd32c9c33e521f9a43e8743a64b02294c72d114ec6b7>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/213df356-1b68-45c0-a1db-8feab78aec81> .
+
+<http://data.lblod.info/id/bestuurseenheden/7004c5cca97f47f3ea5fd5d011983bed0257432c4dd317c4ebdf1f1d7035890a>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/692921a6-2465-47eb-8e04-2c29b49f50de> .
+
+<http://data.lblod.info/id/bestuurseenheden/5d814bf5ab1e7ef33db393cb938315910c262743afed3a464e93c1aa25f12e20>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/dcb29e8e-263d-490a-97ef-b312252822d8> .
+
+<http://data.lblod.info/id/bestuurseenheden/4fb8eb24aa9d5561f3cd7b502715fc758f41b71aafa13b872ee8aeb1d027dbe9>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/4dc96030-88e8-4748-adbf-1aebdc2ea2b3> .
+
+<http://data.lblod.info/id/bestuurseenheden/933e3d37deb3e75dba5869d264132550be0f8e2cd08ee71556b9dc6860279257>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/ad539bb3-f41a-44a9-947f-0dc6ecb29fea> .
+
+<http://data.lblod.info/id/bestuurseenheden/66374f1f46137c3240ba0690b24056a014f9ad5f36ae81e10bc14ad5a6305089>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/03ddc34f-7990-4bb2-888b-37bce5ce044e> .
+
+<http://data.lblod.info/id/bestuurseenheden/f8ad83ae8d0d96983b5bddb3c2cb768323b4f5103d95c111f6143c9109034aab>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/9773c47e-4206-44cd-81ac-a437e080b9d0> .
+
+<http://data.lblod.info/id/bestuurseenheden/4411539b345d3b7ffa3f9ac54fce0fc381e579b999c46cb11c7d9af03aa04a79>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/637812c3-34c4-4339-8618-bcc2675d83d4> .
+
+<http://data.lblod.info/id/bestuurseenheden/61c1066c653e5450f2b0a25baeaf60a14a8df400fc421caca07014b0efb55c96>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/94f23563-6df6-4808-8324-5924c86b4f25> .
+
+<http://data.lblod.info/id/bestuurseenheden/43d5a7c66986ee2e88090b3988ea0179ad4abf5bbfb8864fc44012aa181d0e4d>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/dd898f3b-87e5-432e-9e00-5d0d3fa54b05> .
+
+<http://data.lblod.info/id/bestuurseenheden/c648ea5d12626ee3364a02debb223908a71e68f53d69a7a7136585b58a083e77>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/849f49cf-bd09-4f88-96ea-e1bd702a94ca> .
+
+<http://data.lblod.info/id/bestuurseenheden/cb2a6e0a490ee881ddd0d9ded7f2b3d1dc2df7e57a19d014caac054bfa355f5a>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/5e40cc59-194b-4b42-b64a-6a53a8cb1152> .
+
+<http://data.lblod.info/id/bestuurseenheden/5a7f00816df0382694760a86baf23bb6c72a7ab5de0eb7f6db8c38a24b9c9aba>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/37b2f71b-c14f-4fa5-ba7d-8a765c87859e> .
+
+<http://data.lblod.info/id/bestuurseenheden/19a90656ebde5754d524ca8a17d06b857a6392b0b3db57dd24f899a1b71eda7d>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/4ba2e1d8-fa5d-4002-9d1b-c168a2a84045> .
+
+<http://data.lblod.info/id/bestuurseenheden/1313d4a58f9ecf52cc7e274e3549a759b35e731973cc9f5e07562e5650f594dd>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/aeeed194-f748-4ec1-a2c8-c54e8fd60545> .
+
+<http://data.lblod.info/id/bestuurseenheden/c362abc58ac4579ff417824ce620962ac57bc344b34fe8f51d21b35ef54da36d>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/b8d72a74-90c1-4241-8b3f-9df3abb6299b> .
+
+<http://data.lblod.info/id/bestuurseenheden/3e3d8146912fb57b6f7c4c665051351b6dd1a92730f363a17bddabe58bcdeb51>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/e395419c-b06e-484e-8302-cd2d1011601f> .
+
+<http://data.lblod.info/id/bestuurseenheden/a4509bc9057f893f626626a7eadd0c713eea564c9c948efdafdfae9a1c153771>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/2924cc14-f51c-4692-ae4b-84f886d4daf9> .
+
+<http://data.lblod.info/id/bestuurseenheden/665f6a3b8e4ad7766a1be93578b5d8b6312afa8600c1301388225880fe4eca53>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/c6e14db2-95da-4189-9d60-051164b5e0b5> .
+
+<http://data.lblod.info/id/bestuurseenheden/93bf61e0c1a48a58c1f6af804e087221de46fc492b30e3a7194b0b098356ab82>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/9ae6d05c-a9db-429b-8c7c-65367ff00fcb> .
+
+<http://data.lblod.info/id/bestuurseenheden/17e71437ad9e1abbfd416b7bcb1485c0e6e21ac4f65f2a1584eb0985e246b1c9>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/49d534b3-50ca-41ed-9fea-80cd49f67454> .
+
+<http://data.lblod.info/id/bestuurseenheden/c73ee91f068da28ed1f16fb057f38808e7c0d29f4c5b8b9d7b2eec235ed4d5a4>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/ef6637fa-f831-4c6a-92c7-2f8a1c29e383> .
+
+<http://data.lblod.info/id/bestuurseenheden/da17a1c564c4f0aecbe800efaedcee7428e80c127b4a1bc829519b375ad20707>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/7d08085a-3e2a-46ba-9347-8681b8173137> .
+
+<http://data.lblod.info/id/bestuurseenheden/0584f1096c6eb744a680d13e4974ff85744ec9aa163e31833acaa694c8c9c6c8>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/44d35426-24a8-4516-b9bb-6c8b56417e85> .
+
+<http://data.lblod.info/id/bestuurseenheden/72af5d601b193f4fcf18154d643d89481082ecd3eff61720f1cf118057666ac5>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/2e60a1c4-358c-409f-94ab-cbf817d55569> .
+
+<http://data.lblod.info/id/bestuurseenheden/ba4d960fe3e01984e15fd0b141028bab8f2b9b240bf1e5ab639ba0d7fe4dc522>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/626974f2-ad28-4a67-a59c-a60cd0c0ab77> .
+
+<http://data.lblod.info/id/bestuurseenheden/e39bc997aa6dd9f240277735efd745b6a0422614d2b36cf01825c86b1b91a9ee>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/40e1c80d-17ab-47ce-ba7c-bfcb39e7cd57>,
+    <http://data.lblod.info/id/betrokkenLokaleBesturen/a03b1945-3232-4561-b719-78b3e77b366e> .
+
+<http://data.lblod.info/id/bestuurseenheden/a605a770e69d0af2d501614a41b446c76328d2f32165be238458468fbd5f8b88>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/f09f7a20-5c11-4277-902c-851c1f98e031> .
+
+<http://data.lblod.info/id/bestuurseenheden/c42e0bde83126aaa67ed2c4b3ff5f5b42ae5023075e707c85369345195c79a43>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/f28864b3-d734-4c52-bf0c-e6335be2f714> .
+
+<http://data.lblod.info/id/bestuurseenheden/71f6925a4b895c2a91dce039c87d227809edcda82963714814141b1e41631b08>
+  <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/12451bc0-ed31-4c6b-9d1e-0c68ec2d23b5> .


### PR DESCRIPTION
I noticed that on the Loket side of the apps, some links have been added to be able to dispatch properly data to graphs (see [here for example](https://github.com/lblod/app-worship-decisions-database/blob/master/config/migrations/2022/20221110165132-add-missing-betrokken-besturen.ttl) ). This PR is adding the same data to keep the apps in sync. It'll also be useful for app-worship-organizations.

See DL-4442 for the context