### PR TITLE
Update migration to avoid data loss

### DIFF
--- a/config/migrations/2023/20230106110000-delete-duplicate-worship-services.sparql
+++ b/config/migrations/2023/20230106110000-delete-duplicate-worship-services.sparql
@@ -28,7 +28,6 @@ DELETE {
     OPTIONAL { ?representatieveOrgaan <http://www.w3.org/ns/org#linkedTo> ?bestuur }
 
     ?bestuur ?pbestuur ?obestuur .
-
   }
 }
 
@@ -52,16 +51,16 @@ DELETE {
     OPTIONAL {
       ?bestuur <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite.
       ?primarySite ?pprimarySite ?oprimarySite .
-    } 
 
-    OPTIONAL {
-    	?primarySite <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?address.
-    	?address ?paddress ?oaddress .
-    }
-    
-    OPTIONAL {
-    	?primarySite <http://www.w3.org/ns/org#siteAddress> ?contactPoint .
-    	?contactPoint ?pcontactPoint ?ocontactPoint .
+      OPTIONAL {
+        ?primarySite <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?address.
+        ?address ?paddress ?oaddress .
+      }
+
+      OPTIONAL {
+        ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contactPoint .
+        ?contactPoint ?pcontactPoint ?ocontactPoint .
+      }
     }
   }
 }
@@ -85,11 +84,11 @@ DELETE {
     OPTIONAL { 
       ?bestuur <http://www.w3.org/ns/adms#identifier> ?identifier . 
       ?identifier ?pidentifier ?oidentifier .
-    }
-        
-    OPTIONAL {
-      ?identifier <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator> ?structuredIdentifier.
-      ?structuredIdentifier ?pstructuredIdentifier ?ostructuredIdentifier .
+
+      OPTIONAL {
+        ?identifier <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator> ?structuredIdentifier.
+        ?structuredIdentifier ?pstructuredIdentifier ?ostructuredIdentifier .
+      }
     }
   }
 }


### PR DESCRIPTION
The migration was removing all the contact points, all the addresses and all the identifiers of the database.

It's important to order the optionals correctly, each optional is a distinct block and what happens in an optional block stays in the optional block. So a variable defined in an optional block can't be reused outside of this block.