### PR TITLE
delete empty literals

### DIFF
--- a/config/migrations/2023/20230118153000-delete-empty-literals.sparql
+++ b/config/migrations/2023/20230118153000-delete-empty-literals.sparql
@@ -1,0 +1,10 @@
+DELETE {
+  GRAPH ?g {
+    ?s ?p "".
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?s ?p "".
+  }
+}


### PR DESCRIPTION
OP-1329

No new empty literals should be created
- frontend has been adapted (OP-1331)
- loket consumers retract empty literals

No re-index triggers needed