### PR TITLE
use same graph for dcat and files to avoid bug

### DIFF
--- a/config/delta-producer/dump-file-publisher/config.json
+++ b/config/delta-producer/dump-file-publisher/config.json
@@ -20,7 +20,7 @@
     "targetGraph": "http://redpencil.data.gift/id/deltas/producer/organizations",
     "fileBaseName": "dump-organizations",
     "targetDcatGraph": "http://redpencil.data.gift/id/deltas/producer/organizations-deltas",
-    "targetFilesGraph": "http://redpencil.data.gift/id/deltas/producer/organization-sdeltas",
+    "targetFilesGraph": "http://redpencil.data.gift/id/deltas/producer/organizations-deltas",
     "cleanupOldDumps": true
   },
   "http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/initialPublicationGraphSyncing/organizations": {

--- a/config/delta-producer/dump-file-publisher/config.json
+++ b/config/delta-producer/dump-file-publisher/config.json
@@ -20,7 +20,7 @@
     "targetGraph": "http://redpencil.data.gift/id/deltas/producer/organizations",
     "fileBaseName": "dump-organizations",
     "targetDcatGraph": "http://redpencil.data.gift/id/deltas/producer/organizations-deltas",
-    "targetFilesGraph": "http://redpencil.data.gift/id/deltas/producer/organizationsdeltas",
+    "targetFilesGraph": "http://redpencil.data.gift/id/deltas/producer/organization-sdeltas",
     "cleanupOldDumps": true
   },
   "http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/initialPublicationGraphSyncing/organizations": {
@@ -28,7 +28,7 @@
     "targetGraph": "http://redpencil.data.gift/id/deltas/producer/organizations",
     "fileBaseName": "dump-organizations",
     "targetDcatGraph": "http://redpencil.data.gift/id/deltas/producer/organizations-deltas",
-    "targetFilesGraph": "http://redpencil.data.gift/id/deltas/producer/organizationsdeltas",
+    "targetFilesGraph": "http://redpencil.data.gift/id/deltas/producer/organizations-deltas",
     "cleanupOldDumps": true
   },
   "http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/deltaDumpFileCreation/public": {

--- a/config/migrations/2023/20230119164500-cleanup-files.sparql
+++ b/config/migrations/2023/20230119164500-cleanup-files.sparql
@@ -1,0 +1,4 @@
+# MOVE SILENT <http://redpencil.data.gift/id/deltas/producer/organizationsdeltas> <http://redpencil.data.gift/id/deltas/producer/organizations-deltas>
+DELETE { GRAPH <http://redpencil.data.gift/id/deltas/producer/organizationsdeltas> { ?s ?p ?o } }
+INSERT { GRAPH <http://redpencil.data.gift/id/deltas/producer/organizations-deltas> { ?s ?p ?o } }
+WHERE { GRAPH <http://redpencil.data.gift/id/deltas/producer/organizationsdeltas> { ?s ?p ?o } }


### PR DESCRIPTION
cf OP-2069

Work around bug in dump-file publisher when deleting old dumps https://github.com/lblod/delta-producer-dump-file-publisher/pull/6 