### PR TITLE
Migrations triggering reindex

### DIFF
--- a/config/migrations-triggering-indexing/2023/20230203150000-remove-dummy-worship.sparql
+++ b/config/migrations-triggering-indexing/2023/20230203150000-remove-dummy-worship.sparql
@@ -48,20 +48,3 @@ DELETE {
     }        
   }
 }
-
-# The associated call to trigger a reindex is :
-
-# curl --location --request POST '172.25.0.34/update' \
-# --header 'Content-Type: application/vnd.api+json' \
-# --data-raw ' [
-#   {
-#     "deletes": [
-#       {
-#         "subject": { "type": "uri", "value": "http://data.lblod.info/id/besturenVanDeEredienst/578bf96f86056e2260dc21cee91aa519" },
-#         "predicate": { "type": "uri", "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" },
-#         "object": { "type": "uri", "value": "http://data.vlaanderen.be/ns/besluit#Bestuurseenheid" }
-#       }
-#     ],
-#     "inserts": []
-#   }
-# ]'

--- a/config/migrations/2023/20230203150000-remove-dummy-worship.sparql
+++ b/config/migrations/2023/20230203150000-remove-dummy-worship.sparql
@@ -1,0 +1,67 @@
+PREFIX org:  <http://www.w3.org/ns/org#>
+PREFIX adms: <http://www.w3.org/ns/adms#>
+PREFIX generiek:    <https://data.vlaanderen.be/ns/generiek#>
+PREFIX organisatie: <https://data.vlaanderen.be/ns/organisatie#>
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/organisatieportaal> {
+    ?bestuur ?pbestuur ?obestuur .
+    ?primarySite ?pprimarySite ?oprimarySite .
+    ?address ?paddress ?oaddress .
+    ?contactPoint ?pcontactPoint ?ocontactPoint .
+    ?identifier ?pidentifier ?oidentifier .
+    ?structuredIdentifier ?pstructuredIdentifier ?ostructuredIdentifier .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/organisatieportaal> {    
+    BIND(<http://data.lblod.info/id/besturenVanDeEredienst/578bf96f86056e2260dc21cee91aa519> as ?bestuur)
+
+    ?bestuur ?pbestuur ?obestuur .
+
+    OPTIONAL {
+
+      ?bestuur org:hasPrimarySite ?primarySite . 
+
+        OPTIONAL {
+          ?primarySite organisatie:bestaatUit ?address .
+          ?address ?paddress ?oaddress .
+        }
+        OPTIONAL {
+          ?primarySite org:siteAddress ?contactPoint .            
+          ?contactPoint ?pcontactPoint ?ocontactPoint .
+        }
+
+      ?primarySite ?pprimarySite ?oprimarySite .
+
+    }
+    OPTIONAL {
+
+      ?bestuur adms:identifier ?identifier .
+
+        OPTIONAL {
+          ?identifier generiek:gestructureerdeIdentificator ?structuredIdentifier .
+          ?structuredIdentifier ?pstructuredIdentifier ?ostructuredIdentifier .            
+        }
+
+      ?identifier ?pidentifier ?oidentifier .
+      
+    }        
+  }
+}
+
+# The associated call to trigger a reindex is :
+
+# curl --location --request POST '172.25.0.34/update' \
+# --header 'Content-Type: application/vnd.api+json' \
+# --data-raw ' [
+#   {
+#     "deletes": [
+#       {
+#         "subject": { "type": "uri", "value": "http://data.lblod.info/id/besturenVanDeEredienst/578bf96f86056e2260dc21cee91aa519" },
+#         "predicate": { "type": "uri", "value": "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" },
+#         "object": { "type": "uri", "value": "http://data.vlaanderen.be/ns/besluit#Bestuurseenheid" }
+#       }
+#     ],
+#     "inserts": []
+#   }
+# ]'

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -17,6 +17,8 @@ services:
     volumes:
       - ./config/dev-migrations:/data/migrations/dev/
     restart: "no"
+  migrations-triggering-indexing:
+    restart: "no"
   resource:
     restart: "no"
   cache:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,16 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
+  migrations-triggering-indexing:
+    image: semtech/mu-migrations-service:0.8.0
+    links:
+      - db:database
+    volumes:
+      - ./config/migrations-triggering-indexing:/data/migrations
+    labels:
+      - "logging=true"
+    restart: always
+    logging: *default-logging
   resource:
     image: semtech/mu-cl-resources:1.21.1
     environment:


### PR DESCRIPTION
OP-2117

I used a [currently ongoing PR](https://github.com/lblod/app-organization-portal/pull/234) to test wiring mu-migrations to mu-auth to see how would the reindexing work in our stack. And as a first test, it looks conclusive !

I wired it as a separate service because our previous migrations are full of comments and maybe other things that mu-auth does not like. So if we would go to having just one migrations service, we'd have to also clean older migrations to ensure that the project would be able to run from an empty DB. And I think that it doesn't hurt to keep it as a second service for now, gives us more time to try it out and see how the auto-reindexing goes.

It also means that now, before starting `migrations-triggering-indexing`, some services should be up for the changes to be picked up (triplestore, db, deltanotifier, search, elasticsearch)