### PR TITLE
Remove cache from dcat resources

### DIFF
--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -330,11 +330,11 @@ defmodule Dispatcher do
   #################################################################
 
   get "/datasets/*path", %{ layer: :api_services, accept: %{ json: true } } do
-    Proxy.forward conn, path, "http://cache/datasets/"
+    Proxy.forward conn, path, "http://resource/datasets/"
   end
 
   get "/distributions/*path", %{ layer: :api_services, accept: %{ json: true } } do
-    Proxy.forward conn, path, "http://cache/distributions/"
+    Proxy.forward conn, path, "http://resource/distributions/"
   end
 
 


### PR DESCRIPTION
My previous attempt here https://github.com/lblod/app-organization-portal/pull/240 was not enough because before getting the file we try go get the dataset & distributions and we get outdated info. Restarting the cache fixes the issue. So I think that now with this change we'll be fine :crossed_fingers: 