### PR TITLE
Enable new period for organen and create missing data

### DIFF
--- a/config/migrations/2023/20230327162700-prepare-change-legislation-period/20230327162800-merge-organen.sparql
+++ b/config/migrations/2023/20230327162700-prepare-change-legislation-period/20230327162800-merge-organen.sparql
@@ -1,0 +1,42 @@
+# We have two bestuursorganen of the same classification for 2 bestuurseenheden.
+# Then need to be merged, as we should only have one orgaan (not in time) per classification.
+
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX ere: <http://data.lblod.info/vocabularies/erediensten/>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?otherBestuursorgaan ?potherBestuursorgaan ?ootherBestuursorgaan .
+    ?s ?p ?otherBestuursorgaan .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?s ?p ?bestuursorgaan .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    VALUES ?type {
+      ere:BestuurVanDeEredienst
+      ere:CentraalBestuurVanDeEredienst
+    }
+
+    ?bestuurseenheid a ?type .
+
+    FILTER NOT EXISTS {
+      ?bestuurseenheid <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311> .
+    }
+
+    ?bestuursorgaan besluit:bestuurt ?bestuurseenheid ;
+      <http://www.w3.org/ns/org#classification> ?classif .
+
+    ?otherBestuursorgaan besluit:bestuurt ?bestuurseenheid ;
+      <http://www.w3.org/ns/org#classification> ?classif ;
+      ?potherBestuursorgaan ?ootherBestuursorgaan .
+
+    ?s ?p ?otherBestuursorgaan .
+
+    FILTER (str(?bestuursorgaan) > str(?otherBestuursorgaan))
+  }
+}

--- a/config/migrations/2023/20230327162700-prepare-change-legislation-period/20230327162900-create-missing-organen-in-time-2023-2026.sparql
+++ b/config/migrations/2023/20230327162700-prepare-change-legislation-period/20230327162900-create-missing-organen-in-time-2023-2026.sparql
@@ -1,0 +1,46 @@
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX ere: <http://data.lblod.info/vocabularies/erediensten/>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?orgaanInTime a besluit:Bestuursorgaan ;
+      mu:uuid ?uuidOrgaanInTime ;
+      mandaat:bindingStart "2023-04-01T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+      mandaat:bindingEinde "2026-03-31T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+      generiek:isTijdspecialisatieVan ?bestuursorgaan .
+  }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    VALUES ?type {
+      ere:BestuurVanDeEredienst
+      ere:CentraalBestuurVanDeEredienst
+    }
+
+    ?bestuurseenheid a ?type .
+
+    FILTER NOT EXISTS {
+      ?bestuurseenheid <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311> .
+    }
+
+    ?bestuursorgaan besluit:bestuurt ?bestuurseenheid .
+
+    FILTER NOT EXISTS {
+      ?missingOrgaanInTime generiek:isTijdspecialisatieVan ?bestuursorgaan .
+      ?missingOrgaanInTime mandaat:bindingStart ?start .
+      FILTER CONTAINS(STR(?start), "2023")
+    }
+
+    FILTER NOT EXISTS {
+      ?missingOrgaanInTime generiek:isTijdspecialisatieVan ?bestuursorgaan .
+      ?missingOrgaanInTime mandaat:bindingEinde ?end .
+      FILTER CONTAINS(STR(?end), "2026")
+    }
+  }
+
+  BIND(MD5(CONCAT(?bestuurseenheid, ?bestuursorgaan, "2023-2026")) as ?uuidOrgaanInTime)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/bestuursorganen/", ?uuidOrgaanInTime)) AS ?orgaanInTime)
+}

--- a/config/migrations/2023/20230327162700-prepare-change-legislation-period/20230327163000-create-missing-positions-central-worship-services-2023-2026.sparql
+++ b/config/migrations/2023/20230327162700-prepare-change-legislation-period/20230327163000-create-missing-positions-central-worship-services-2023-2026.sparql
@@ -1,0 +1,152 @@
+# Add missing mandates to central worship services
+
+## 2023 - 2026
+
+PREFIX ere: <http://data.lblod.info/vocabularies/erediensten/>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?orgaanInTime org:hasPost ?expert .
+
+    ?expert a mandaat:Mandaat ;
+      mu:uuid ?uuidExpert ;
+      org:role <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/8c91c321ad477c4fc372ee36358d3ed4> .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?worshipService a ere:CentraalBestuurVanDeEredienst .
+    ?orgaan besluit:bestuurt ?worshipService .
+    ?orgaanInTime generiek:isTijdspecialisatieVan ?orgaan ;
+      mandaat:bindingStart "2023-04-01T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+      mandaat:bindingEinde "2026-03-31T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+
+    FILTER NOT EXISTS {
+      ?orgaanInTime org:hasPost ?expert .
+      ?expert org:role <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/8c91c321ad477c4fc372ee36358d3ed4> .
+    }
+  }
+
+  BIND(MD5(CONCAT(?worshipService, ?orgaan, "Expert 2023-2026")) as ?uuidExpert)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/mandaten/", ?uuidExpert)) AS ?expert)
+}
+
+;
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?orgaanInTime org:hasPost ?vertegenwoordiger .
+
+    ?vertegenwoordiger a mandaat:Mandaat ;
+      mu:uuid ?uuidVertegenwoordiger ;
+      org:role <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/6e26e94ea4b127eeb850fb6debe07271> .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?worshipService a ere:CentraalBestuurVanDeEredienst .
+    ?orgaan besluit:bestuurt ?worshipService .
+    ?orgaanInTime generiek:isTijdspecialisatieVan ?orgaan ;
+      mandaat:bindingStart "2023-04-01T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+      mandaat:bindingEinde "2026-03-31T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+
+    FILTER NOT EXISTS {
+      ?orgaanInTime org:hasPost ?vertegenwoordiger .
+      ?vertegenwoordiger org:role <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/6e26e94ea4b127eeb850fb6debe07271> .
+    }
+  }
+
+  BIND(MD5(CONCAT(?worshipService, ?orgaan, "Vertegenwoordiger 2023-2026")) as ?uuidVertegenwoordiger)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/mandaten/", ?uuidVertegenwoordiger)) AS ?vertegenwoordiger)
+}
+
+;
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?orgaanInTime org:hasPost ?secretaris .
+
+    ?secretaris a mandaat:Mandaat ;
+      mu:uuid ?uuidSecretaris ;
+      org:role <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/e2af0ea1a6af96cfb698ac39ad985eea> .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?worshipService a ere:CentraalBestuurVanDeEredienst .
+    ?orgaan besluit:bestuurt ?worshipService .
+    ?orgaanInTime generiek:isTijdspecialisatieVan ?orgaan ;
+      mandaat:bindingStart "2023-04-01T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+      mandaat:bindingEinde "2026-03-31T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+
+    FILTER NOT EXISTS {
+      ?orgaanInTime org:hasPost ?secretaris .
+      ?secretaris org:role <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/e2af0ea1a6af96cfb698ac39ad985eea> .
+    }
+  }
+
+  BIND(MD5(CONCAT(?worshipService, ?orgaan, "Secretaris 2023-2026")) as ?uuidSecretaris)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/mandaten/", ?uuidSecretaris)) AS ?secretaris)
+}
+
+;
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?orgaanInTime org:hasPost ?voorzitter .
+
+    ?voorzitter a mandaat:Mandaat ;
+      mu:uuid ?uuidVoorzitter ;
+      org:role <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5960262f753661cf84329f3afa9f7df7> .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?worshipService a ere:CentraalBestuurVanDeEredienst .
+    ?orgaan besluit:bestuurt ?worshipService .
+    ?orgaanInTime generiek:isTijdspecialisatieVan ?orgaan ;
+      mandaat:bindingStart "2023-04-01T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+      mandaat:bindingEinde "2026-03-31T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+
+    FILTER NOT EXISTS {
+      ?orgaanInTime org:hasPost ?voorzitter .
+      ?voorzitter org:role <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5960262f753661cf84329f3afa9f7df7> .
+    }
+  }
+
+  BIND(MD5(CONCAT(?worshipService, ?orgaan, "Voorzitter 2023-2026")) as ?uuidVoorzitter)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/mandaten/", ?uuidVoorzitter)) AS ?voorzitter)
+}
+
+;
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?orgaanInTime org:hasPost ?bestuurslid .
+
+    ?bestuurslid a mandaat:Mandaat ;
+      mu:uuid ?uuidBestuurslid ;
+      org:role <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/f848fa3cc2c5fb7c581a116866293925> .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?worshipService a ere:CentraalBestuurVanDeEredienst .
+    ?orgaan besluit:bestuurt ?worshipService .
+    ?orgaanInTime generiek:isTijdspecialisatieVan ?orgaan ;
+      mandaat:bindingStart "2023-04-01T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+      mandaat:bindingEinde "2026-03-31T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+
+    FILTER NOT EXISTS {
+      ?worshipService <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311> .
+    }
+
+    FILTER NOT EXISTS {
+      ?orgaanInTime org:hasPost ?bestuurslid .
+      ?bestuurslid org:role <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/f848fa3cc2c5fb7c581a116866293925> .
+    }
+  }
+
+  BIND(MD5(CONCAT(?worshipService, ?orgaan, "Bestuurslid 2023-2026")) as ?uuidBestuurslid)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/mandaten/", ?uuidBestuurslid)) AS ?bestuurslid)
+}

--- a/config/migrations/2023/20230327162700-prepare-change-legislation-period/20230327163000-create-missing-positions-worship-services-2023-2026.sparql
+++ b/config/migrations/2023/20230327162700-prepare-change-legislation-period/20230327163000-create-missing-positions-worship-services-2023-2026.sparql
@@ -1,0 +1,186 @@
+# Add missing mandates to worship services for period 2023-2026
+
+PREFIX ere: <http://data.lblod.info/vocabularies/erediensten/>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+
+## Case LidVanRechtswege : shared mandate for all the organen in time
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?orgaanInTime org:hasPost ?lidVanRechtswege .
+
+    ?lidVanRechtswege a mandaat:Mandaat ;
+      mu:uuid ?uuidLidVanRechtswege ;
+      org:role <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5972fccd87f864c4ec06bfbd20b5008b> .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    VALUES (?start ?end) {
+      ("2023-04-01T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> "2026-03-31T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime>)
+    }
+
+    ?worshipService a ere:BestuurVanDeEredienst .
+    ?orgaan besluit:bestuurt ?worshipService .
+    ?orgaanInTime generiek:isTijdspecialisatieVan ?orgaan ;
+      mandaat:bindingStart ?start ;
+      mandaat:bindingEinde ?end .
+
+    FILTER NOT EXISTS {
+      ?orgaanInTime org:hasPost ?lidVanRechtswege .
+      ?lidVanRechtswege org:role <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5972fccd87f864c4ec06bfbd20b5008b> .
+    }
+  }
+
+  BIND(MD5(CONCAT(?worshipService, ?orgaan, "Rechtswege")) as ?uuidLidVanRechtswege)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/mandaten/", ?uuidLidVanRechtswege)) AS ?lidVanRechtswege)
+}
+
+## Case Bestuursleden, small or big half : 2023 is the beggining of a KH
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?orgaanInTime org:hasPost ?bestuurslidGH .
+
+    ?bestuurslidGH a mandaat:Mandaat ;
+      mu:uuid ?uuidBestuurslidGH ;
+      org:role <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/a8b5509b-f86b-48f8-94d6-fe463a9b77e3> .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?worshipService a ere:BestuurVanDeEredienst .
+    ?orgaan besluit:bestuurt ?worshipService .
+    ?orgaanInTime generiek:isTijdspecialisatieVan ?orgaan ;
+      mandaat:bindingStart "2023-04-01T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+      mandaat:bindingEinde "2026-03-31T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+
+    FILTER NOT EXISTS {
+      ?orgaanInTime org:hasPost ?bestuurslidGH .
+      ?bestuurslidGH org:role <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/a8b5509b-f86b-48f8-94d6-fe463a9b77e3> .
+    }
+  }
+
+  BIND(MD5(CONCAT(?worshipService, ?orgaan, "BestuurslidGH 2020-2026")) as ?uuidBestuurslidGH)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/mandaten/", ?uuidBestuurslidGH)) AS ?bestuurslidGH)
+}
+
+;
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?orgaanInTime org:hasPost ?bestuurslidKH .
+
+    ?bestuurslidKH a mandaat:Mandaat ;
+      mu:uuid ?uuidBestuurslidKH ;
+      org:role <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/2962f0bd-2836-4758-9866-8ce8ea2c536f> .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    VALUES (?start ?end) {
+      ("2023-04-01T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> "2026-03-31T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime>)
+    }
+
+    ?worshipService a ere:BestuurVanDeEredienst .
+    ?orgaan besluit:bestuurt ?worshipService .
+    ?orgaanInTime generiek:isTijdspecialisatieVan ?orgaan ;
+      mandaat:bindingStart ?start ;
+      mandaat:bindingEinde ?end .
+
+    FILTER NOT EXISTS {
+      ?orgaanInTime org:hasPost ?bestuurslidKH .
+      ?bestuurslidKH org:role <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/2962f0bd-2836-4758-9866-8ce8ea2c536f> .
+    }
+  }
+
+  BIND(MD5(CONCAT(?worshipService, ?orgaan, "BestuurslidKH 2023-2029")) as ?uuidBestuurslidKH)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/mandaten/", ?uuidBestuurslidKH)) AS ?bestuurslidKH)
+}
+
+;
+
+## Other cases are simpler, one mandate is linked to only one orgaan in time. Creating them when missing.
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?orgaanInTime org:hasPost ?voorzitter .
+
+    ?voorzitter a mandaat:Mandaat ;
+      mu:uuid ?uuidVoorzitter ;
+      org:role <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/67e6e585166cd97575b3e17ffc430a43> .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?worshipService a ere:BestuurVanDeEredienst .
+    ?orgaan besluit:bestuurt ?worshipService .
+    ?orgaanInTime generiek:isTijdspecialisatieVan ?orgaan ;
+      mandaat:bindingStart "2023-04-01T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+      mandaat:bindingEinde "2026-03-31T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+
+    FILTER NOT EXISTS {
+      ?orgaanInTime org:hasPost ?voorzitter .
+      ?voorzitter org:role <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/67e6e585166cd97575b3e17ffc430a43> .
+    }
+  }
+
+  BIND(MD5(CONCAT(?worshipService, ?orgaan, "Voorzitter 2023-2026")) as ?uuidVoorzitter)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/mandaten/", ?uuidVoorzitter)) AS ?voorzitter)
+}
+
+;
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?orgaanInTime org:hasPost ?secretaris .
+
+    ?secretaris a mandaat:Mandaat ;
+      mu:uuid ?uuidSecretaris ;
+      org:role <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ac134b9800b81da3c450d6b9605cef2> .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?worshipService a ere:BestuurVanDeEredienst .
+    ?orgaan besluit:bestuurt ?worshipService .
+    ?orgaanInTime generiek:isTijdspecialisatieVan ?orgaan ;
+      mandaat:bindingStart "2023-04-01T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+      mandaat:bindingEinde "2026-03-31T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+
+    FILTER NOT EXISTS {
+      ?orgaanInTime org:hasPost ?secretaris .
+      ?secretaris org:role <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ac134b9800b81da3c450d6b9605cef2> .
+    }
+  }
+
+  BIND(MD5(CONCAT(?worshipService, ?orgaan, "Secretaris 2023-2026")) as ?uuidSecretaris)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/mandaten/", ?uuidSecretaris)) AS ?secretaris)
+}
+
+;
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?orgaanInTime org:hasPost ?penningmeester .
+
+    ?penningmeester a mandaat:Mandaat ;
+      mu:uuid ?uuidPenningmeester ;
+      org:role <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/180d13930d6f1a3938e0aa7fa9990002> .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?worshipService a ere:BestuurVanDeEredienst .
+    ?orgaan besluit:bestuurt ?worshipService .
+    ?orgaanInTime generiek:isTijdspecialisatieVan ?orgaan ;
+      mandaat:bindingStart "2023-04-01T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+      mandaat:bindingEinde "2026-03-31T00:00:00"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+
+    FILTER NOT EXISTS {
+      ?orgaanInTime org:hasPost ?penningmeester .
+      ?penningmeester org:role <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/180d13930d6f1a3938e0aa7fa9990002> .
+    }
+  }
+
+  BIND(MD5(CONCAT(?worshipService, ?orgaan, "Penningmeester 2023-2026")) as ?uuidPenningmeester)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/mandaten/", ?uuidPenningmeester)) AS ?penningmeester)
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -218,6 +218,9 @@ services:
       - ./config/jobs-controller/:/config/
   construct-administrative-unit-relationships:
     image: lblod/construct-administrative-unit-relationships-service:0.1.1
+    environment:
+      START_DATE_WORSHIP_GOVERNING_BODY: "2023-04-01T00:00:00"
+      END_DATE_WORSHIP_GOVERNING_BODY: "2026-03-31T00:00:00"
     links:
       - db:database
     restart: always


### PR DESCRIPTION
OP-2241

In this PR we:
- Update config variables to create worship organen in the new legislation period on worship service creation
- Fix oddities in the bestuursorganen (organen that needed to be merged, missing organen, missing mandates)