### PR TITLE
Produce as much public data as prod

### DIFF
--- a/config/delta-producer/public/export.json
+++ b/config/delta-producer/public/export.json
@@ -281,6 +281,7 @@
       "type": "http://data.vlaanderen.be/ns/besluit#Bestuursorgaan",
       "graphsFilter": [
         "http://mu.semte.ch/graphs/shared",
+        "http://mu.semte.ch/graphs/administrative-unit",
         "http://mu.semte.ch/graphs/worship-service"
       ],
       "properties": [
@@ -292,7 +293,7 @@
         "https://data.vlaanderen.be/ns/generiek#isTijdspecialisatieVan",
         "http://www.w3.org/ns/org#hasPost"
       ],
-      "additionalFilter": "?subject (<https://data.vlaanderen.be/ns/generiek#isTijdspecialisatieVan>/<http://data.vlaanderen.be/ns/besluit#bestuurt>/<http://www.w3.org/ns/org#classification>)|(<http://data.vlaanderen.be/ns/besluit#bestuurt>/<http://www.w3.org/ns/org#classification>) ?bestuurClassification . FILTER (?bestuurClassification IN (<http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>, <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86>))"
+      "additionalFilter": "?subject (<https://data.vlaanderen.be/ns/generiek#isTijdspecialisatieVan>/<http://www.w3.org/ns/org#classification>/<http://www.w3.org/2004/02/skos/core#inScheme>)|(<http://www.w3.org/ns/org#classification>/<http://www.w3.org/2004/02/skos/core#inScheme>) <http://lblod.data.gift/concept-schemes/10caf4a4-1ff5-4c05-917e-56489910d68b> ."
     },
     {
       "type": "http://lblod.data.gift/vocabularies/organisatie/TypeEredienst",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -325,7 +325,7 @@ services:
     restart: always
     logging: *default-logging
   delta-producer-pub-graph-maintainer-public:
-    image: lblod/delta-producer-publication-graph-maintainer:0.15.1
+    image: lblod/delta-producer-publication-graph-maintainer:0.15.4
     environment:
       MAX_BODY_SIZE: "50mb"
       JOBS_GRAPH: "http://mu.semte.ch/graphs/jobs"


### PR DESCRIPTION
In https://github.com/lblod/app-organization-portal/pull/268, Nordine fixed an issue where too many triples were deleted from the producer graph during updates. After this change, we noticed that the data currently produced on prod is more that is should be (the concept scheme of the public producer is linked to more classifications than we thought).

We are thinking about how best to handle it (do nothing, as this data will be synced in the future anyways ? produce less data, if so we need to ensure the deletes will not break Loket ?). Meanwhile, this PR makes sure that the data produced on DEV is the same as the data produced on PROD, that way we don't block any deploy. The fix from https://github.com/lblod/app-organization-portal/pull/268 is still active in this PR.