### PR TITLE
Ensure organen dates are datetimes

### DIFF
--- a/config/migrations/2023/20230503143253-organen-start-and-end-should-be-datetimes-part-one.sparql
+++ b/config/migrations/2023/20230503143253-organen-start-and-end-should-be-datetimes-part-one.sparql
@@ -1,0 +1,58 @@
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX ere: <http://data.lblod.info/vocabularies/erediensten/>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+
+DELETE {
+  GRAPH ?g {
+    ?orgaanInTime mandaat:bindingEinde ?end .
+  }
+} INSERT {
+  GRAPH ?g {
+    ?orgaanInTime mandaat:bindingEinde ?endDateTime .
+  }
+} WHERE {
+  VALUES ?g {
+    <http://mu.semte.ch/graphs/worship-service>
+    <http://mu.semte.ch/graphs/administrative-unit>
+  }
+  GRAPH ?g {
+    ?bestuurseenheid a ?type .
+
+    ?bestuursorgaan besluit:bestuurt ?bestuurseenheid .
+
+    ?orgaanInTime generiek:isTijdspecialisatieVan ?bestuursorgaan .
+
+    ?orgaanInTime mandaat:bindingEinde ?end .
+    FILTER (datatype(?end) = xsd:date)
+    BIND(strdt(concat(str(?end), 'T01:00:00'), xsd:dateTime) as ?endDateTime)
+  }
+}
+
+;
+
+DELETE {
+  GRAPH ?g {
+    ?orgaanInTime mandaat:bindingStart ?start .
+  }
+} INSERT {
+  GRAPH ?g {
+    ?orgaanInTime mandaat:bindingStart ?startDateTime .
+  }
+} WHERE {
+  VALUES ?g {
+    <http://mu.semte.ch/graphs/worship-service>
+    <http://mu.semte.ch/graphs/administrative-unit>
+  }
+  GRAPH ?g {
+    ?bestuurseenheid a ?type .
+
+    ?bestuursorgaan besluit:bestuurt ?bestuurseenheid .
+
+    ?orgaanInTime generiek:isTijdspecialisatieVan ?bestuursorgaan .
+
+    ?orgaanInTime mandaat:bindingStart ?start .
+    FILTER (datatype(?start) = xsd:date)
+    BIND(strdt(concat(str(?start), 'T01:00:00'), xsd:dateTime) as ?startDateTime)
+  }
+}

--- a/config/migrations/2023/20230503143421-organen-start-and-end-should-be-datetimes-part-two.sparql
+++ b/config/migrations/2023/20230503143421-organen-start-and-end-should-be-datetimes-part-two.sparql
@@ -1,0 +1,60 @@
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX ere: <http://data.lblod.info/vocabularies/erediensten/>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+
+DELETE {
+  GRAPH ?g {
+    ?orgaanInTime mandaat:bindingEinde ?end .
+  }
+} INSERT {
+  GRAPH ?g {
+    ?orgaanInTime mandaat:bindingEinde ?endDateTime .
+  }
+} WHERE {
+  VALUES ?g {
+    <http://mu.semte.ch/graphs/worship-service>
+    <http://mu.semte.ch/graphs/administrative-unit>
+  }
+  GRAPH ?g {
+    ?bestuurseenheid a ?type .
+
+    ?bestuursorgaan besluit:bestuurt ?bestuurseenheid .
+
+    ?orgaanInTime generiek:isTijdspecialisatieVan ?bestuursorgaan .
+
+    ?orgaanInTime mandaat:bindingEinde ?end .
+
+    FILTER (HOURS(?end) = 1)
+    BIND(strdt(concat(xsd:date(?end), 'T00:00:00'), xsd:dateTime) as ?endDateTime)
+  }
+}
+
+;
+
+DELETE {
+  GRAPH ?g {
+    ?orgaanInTime mandaat:bindingStart ?start .
+  }
+} INSERT {
+  GRAPH ?g {
+    ?orgaanInTime mandaat:bindingStart ?startDateTime .
+  }
+} WHERE {
+  VALUES ?g {
+    <http://mu.semte.ch/graphs/worship-service>
+    <http://mu.semte.ch/graphs/administrative-unit>
+  }
+  GRAPH ?g {
+    ?bestuurseenheid a ?type .
+
+    ?bestuursorgaan besluit:bestuurt ?bestuurseenheid .
+
+    ?orgaanInTime generiek:isTijdspecialisatieVan ?bestuursorgaan .
+
+    ?orgaanInTime mandaat:bindingStart ?start .
+
+    FILTER (HOURS(?start) = 1)
+    BIND(strdt(concat(xsd:date(?start), 'T00:00:00'), xsd:dateTime) as ?startDateTime)
+  }
+}

--- a/config/resources/domain.json
+++ b/config/resources/domain.json
@@ -578,11 +578,11 @@
       "class": "besluit:Bestuursorgaan",
       "attributes": {
         "start-date": {
-          "type": "date",
+          "type": "datetime",
           "predicate": "mandaat:bindingStart"
         },
         "end-date": {
-          "type": "date",
+          "type": "datetime",
           "predicate": "mandaat:bindingEinde"
         }
       },


### PR DESCRIPTION
OP-2308

The migration goes in two parts because, for some reason, changing the type doesn't work when the date = the datetime exactly, so I use a subterfuge where I put a datetime slightly different from the date (1h different :sweat_smile: ) and put it back in a second migration.