### PR TITLE
Fix migration removing too much data

### DIFF
--- a/config/migrations/2023/20230330164600-sync-loket-to-op/20230330164606-remove-ministers-that-will-get-synced.sparql
+++ b/config/migrations/2023/20230330164600-sync-loket-to-op/20230330164606-remove-ministers-that-will-get-synced.sparql
@@ -1,13 +1,14 @@
+PREFIX org: <http://www.w3.org/ns/org#>
 PREFIX ere: <http://data.lblod.info/vocabularies/erediensten/>
 
 DELETE {
   GRAPH <http://mu.semte.ch/graphs/worship-service> {
-    ?ministerPosition ?p ?o .
-    ?worshipService <http://data.lblod.info/vocabularies/erediensten/wordtBediendDoor> ?ministerPosition .
+    ?minister ?p ?o .
   }
 } WHERE {
   GRAPH <http://mu.semte.ch/graphs/worship-service> { 
-    ?ministerPosition a ere:PositieBedienaar ;
+    ?minister a ere:RolBedienaar ;
+      org:holds ?ministerPosition ;
       ?p ?o .
 
     VALUES ?status {


### PR DESCRIPTION
OP-2326

This story of ministers, positions, ministers positions ... It's getting everybody confused, me included apparently :sweat_smile: 
In the previous migration, I removed the theoretical positions (`PositieBedienaar`) instead of the real position (aka the person in the position at a certain time, `RolBedienaar`).
It only got deployed on dev, so I restored the missing data on dev directly (using Loket as a source, as it was in sync). This migration should now only delete what's necessary, no more.

Deploy note: when deploying this fix to dev, it will also remove already-synced ministers as the initial sync has already run. We'll have to re-trigger an initial sync (should be fine as positions can't be edited in OP anymore). For QA and Prod,  no problem as the wrong migration didn't run and the sync isn't set up yet.