### PR TITLE
Remove deprecated delta-producer-json-diff-file-publisher service

### DIFF
--- a/config/delta/rules.js
+++ b/config/delta/rules.js
@@ -107,24 +107,6 @@ export default [
   },
   {
     match: {
-      graph: {
-        type: 'uri',
-        value: 'http://redpencil.data.gift/id/deltas/producer/organizations'
-      }
-    },
-    callback: {
-      url: 'http://delta-producer-json-diff-publisher-organizations/delta',
-      method: 'POST'
-    },
-    options: {
-      resourceFormat: 'v0.0.1',
-      gracePeriod: 1000,
-      ignoreFromSelf: true,
-      optOutMuScopeIds: ["http://redpencil.data.gift/id/concept/muScope/deltas/initialSync"]
-    }
-  },
-  {
-    match: {
     },
     callback: {
       url: 'http://delta-producer-pub-graph-maintainer-public/delta',
@@ -138,24 +120,6 @@ export default [
         "http://redpencil.data.gift/id/concept/muScope/deltas/initialSync",
         "http://redpencil.data.gift/id/concept/muScope/deltas/publicationGraphMaintenance"
       ]
-    }
-  },
-  {
-    match: {
-      graph: {
-        type: 'uri',
-        value: 'http://redpencil.data.gift/id/deltas/producer/public'
-      }
-    },
-    callback: {
-      url: 'http://delta-producer-json-diff-publisher-public/delta',
-      method: 'POST'
-    },
-    options: {
-      resourceFormat: 'v0.0.1',
-      gracePeriod: 1000,
-      ignoreFromSelf: true,
-      optOutMuScopeIds: ["http://redpencil.data.gift/id/concept/muScope/deltas/initialSync"]
     }
   },
   {

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -337,21 +337,12 @@ defmodule Dispatcher do
     Proxy.forward conn, path, "http://resource/distributions/"
   end
 
-
-  #################################################################
-  #  DELTA: administrative-units
-  #################################################################
-
-  get "/sync/administrative-units/files/*path" do
-    Proxy.forward conn, path, "http://delta-producer-json-diff-file-publisher-administrative-units/files/"
-  end
-
   #################################################################
   #  DELTA: organizations
   #################################################################
 
   get "/sync/organizations/files/*path" do
-    Proxy.forward conn, path, "http://delta-producer-json-diff-file-publisher-organizations/files/"
+    Proxy.forward conn, path, "http://delta-producer-pub-graph-maintainer-organizations/files/"
   end
 
   #################################################################
@@ -359,7 +350,7 @@ defmodule Dispatcher do
   #################################################################
 
   get "/sync/public/files/*path" do
-    Proxy.forward conn, path, "http://delta-producer-json-diff-publisher-public/files/"
+    Proxy.forward conn, path, "http://delta-producer-pub-graph-maintainer-public/files/"
   end
 
   #################################################################

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -55,8 +55,6 @@ services:
     restart: "no"
   delta-producer-pub-graph-maintainer-organizations:
     restart: "no"
-  delta-producer-json-diff-publisher-organizations:
-    restart: "no"
   search:
     restart: "no"
     volumes:
@@ -72,6 +70,10 @@ services:
   delta-producer-bg-jobs-initiator-worship-posts:
     restart: "no"
   delta-producer-pub-graph-maintainer-worship-posts:
+    restart: "no"
+  delta-producer-bg-jobs-initiator-public:
+    restart: "no"
+  delta-producer-pub-graph-maintainer-public:
     restart: "no"
   # use this to test acmidm
   # tlsproxy:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -263,7 +263,7 @@ services:
     restart: always
     logging: *default-logging
   delta-producer-pub-graph-maintainer-organizations:
-    image: lblod/delta-producer-publication-graph-maintainer:0.7.0
+    image: lblod/delta-producer-publication-graph-maintainer:0.15.4
     environment:
       MAX_BODY_SIZE: "50mb"
       JOBS_GRAPH: "http://mu.semte.ch/graphs/jobs"
@@ -275,30 +275,17 @@ services:
       USE_VIRTUOSO_FOR_EXPENSIVE_SELECTS: "true" # some queries are just too expensive
       SKIP_MU_AUTH_INITIAL_SYNC: "true"
       HEALING_PATCH_GRAPH_BATCH_SIZE: 500
+      SERVE_DELTA_FILES: "true"
+      PUBLISHER_URI: "http://data.lblod.info/services/delta-production-json-diff-file-manager/organizations"
+      DELTA_INTERVAL_MS: 10000
+      PRETTY_PRINT_DIFF_JSON: "true"
+      ERROR_GRAPH: "http://mu.semte.ch/graphs/jobs"
     volumes:
       - ./config/delta-producer/organizations:/config
       - ./data/files/:/share
     links:
       - db:database
       - triplestore:virtuoso
-    restart: always
-    logging: *default-logging
-  delta-producer-json-diff-publisher-organizations:
-    image: lblod/delta-producer-json-diff-file-publisher:0.2.3
-    environment:
-      MAX_BODY_SIZE: "50mb"
-      ERROR_GRAPH: "http://mu.semte.ch/graphs/jobs"
-      RELATIVE_FILE_PATH: "deltas/organizations"
-      PUBLISHER_URI: "http://data.lblod.info/services/delta-production-json-diff-file-manager/organizations"
-      PUBLICATION_GRAPH: "http://redpencil.data.gift/id/deltas/producer/organizations"
-      DELTA_INTERVAL_MS: 10000
-      PRETTY_PRINT_DIFF_JSON: "true"
-    volumes:
-      - ./data/files:/share
-    labels:
-      - "logging=true"
-    links:
-      - db:database
     restart: always
     logging: *default-logging
   ################################################################################
@@ -337,30 +324,17 @@ services:
       USE_VIRTUOSO_FOR_EXPENSIVE_SELECTS: "true" # some queries are just too expensive
       SKIP_MU_AUTH_INITIAL_SYNC: "true"
       HEALING_PATCH_GRAPH_BATCH_SIZE: 500
+      SERVE_DELTA_FILES: "true"
+      PUBLISHER_URI: "http://data.lblod.info/services/delta-production-json-diff-file-manager/public"
+      DELTA_INTERVAL_MS: 10000
+      PRETTY_PRINT_DIFF_JSON: "true"
+      ERROR_GRAPH: "http://mu.semte.ch/graphs/jobs"
     volumes:
       - ./config/delta-producer/public:/config
       - ./data/files/:/share
     links:
       - db:database
       - triplestore:virtuoso
-    restart: always
-    logging: *default-logging
-  delta-producer-json-diff-publisher-public:
-    image: lblod/delta-producer-json-diff-file-publisher:0.2.3
-    environment:
-      MAX_BODY_SIZE: "50mb"
-      ERROR_GRAPH: "http://mu.semte.ch/graphs/jobs"
-      RELATIVE_FILE_PATH: "deltas/public"
-      PUBLISHER_URI: "http://data.lblod.info/services/delta-production-json-diff-file-manager/public"
-      PUBLICATION_GRAPH: "http://redpencil.data.gift/id/deltas/producer/public"
-      DELTA_INTERVAL_MS: 10000
-      PRETTY_PRINT_DIFF_JSON: "true"
-    volumes:
-      - ./data/files:/share
-    labels:
-      - "logging=true"
-    links:
-      - db:database
     restart: always
     logging: *default-logging
   ################################################################################


### PR DESCRIPTION
OP-2364

The [delta-producer-json-diff-file-publisher](https://github.com/lblod/delta-producer-json-diff-file-publisher) service has been archived and can fully be replaced by using only [delta-producer-publication-graph-maintainer](https://github.com/lblod/delta-producer-publication-graph-maintainer).