### PR TITLE
Limit positions consumed to types we already onboarded

### DIFF
--- a/config/loket-consumer/leidinggevenden-dispatching/delta-context-config.js
+++ b/config/loket-consumer/leidinggevenden-dispatching/delta-context-config.js
@@ -19,7 +19,8 @@ const contextConfig = {
       queryTemplate: (subject) => `
         ${PREFIXES}
         CONSTRUCT {
-          ?functionaris org:holds ?bestuursfunctie .
+          ?functionaris org:holds ?bestuursfunctie ;
+            ?p ?o .
           ?orgaanInTime lblodlg:heeftBestuursfunctie ?bestuursfunctie ;
             mandaat:isTijdspecialisatieVan ?orgaan .
           ?orgaan besluit:bestuurt ?eenheid .
@@ -27,7 +28,8 @@ const contextConfig = {
         } WHERE {
           GRAPH <http://mu.semte.ch/graphs/landing-zone/leidinggevenden> {
             VALUES ?functionaris { ${subject} }
-            ?functionaris org:holds ?bestuursfunctie .
+            ?functionaris org:holds ?bestuursfunctie ;
+              ?p ?o .
             ?orgaanInTime lblodlg:heeftBestuursfunctie ?bestuursfunctie ;
               mandaat:isTijdspecialisatieVan ?orgaan .
             ?orgaan besluit:bestuurt ?eenheid .
@@ -42,7 +44,8 @@ const contextConfig = {
       queryTemplate: (subject) => `
         ${PREFIXES}
         CONSTRUCT {
-          ?functionaris org:holds ?bestuursfunctie .
+          ?functionaris org:holds ?bestuursfunctie ;
+            ?p ?o .
           ?orgaanInTime lblodlg:heeftBestuursfunctie ?bestuursfunctie ;
             mandaat:isTijdspecialisatieVan ?orgaan .
           ?orgaan besluit:bestuurt ?eenheid .
@@ -50,7 +53,8 @@ const contextConfig = {
         } WHERE {
           GRAPH <http://mu.semte.ch/graphs/landing-zone/leidinggevenden> {
             VALUES ?functionaris { ${subject} }
-            ?functionaris org:holds ?bestuursfunctie .
+            ?functionaris org:holds ?bestuursfunctie ;
+              ?p ?o .
             ?orgaanInTime lblodlg:heeftBestuursfunctie ?bestuursfunctie ;
               mandaat:isTijdspecialisatieVan ?orgaan .
             ?orgaan besluit:bestuurt ?eenheid .

--- a/config/loket-consumer/leidinggevenden-dispatching/delta-context-config.js
+++ b/config/loket-consumer/leidinggevenden-dispatching/delta-context-config.js
@@ -1,11 +1,67 @@
+const PREFIXES = `
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX lblodlg: <http://data.lblod.info/vocabularies/leidinggevenden/>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>`
+
 const contextConfig = {
   addTypes: {
     scope: 'all', // 'inserts, 'deletes', 'all' or none. To add rdf:type to subjects of inserts, deletes or both
     exhausitive: false, // true or false: find all types for a subject, even if one is already present in delta
   },
-  contextQueries: []
+  contextQueries: [
+    // Case Leidnggevenden
+    // They can be triggered when being inserted or when their link to a bestuursfunctie is added
+    {
+      trigger: { // subjectType or predicateValue
+        subjectType: "lblodlg:Functionaris"
+      },
+      queryTemplate: (subject) => `
+        ${PREFIXES}
+        CONSTRUCT {
+          ?functionaris org:holds ?bestuursfunctie .
+          ?orgaanInTime lblodlg:heeftBestuursfunctie ?bestuursfunctie ;
+            mandaat:isTijdspecialisatieVan ?orgaan .
+          ?orgaan besluit:bestuurt ?eenheid .
+          ?eenheid besluit:classificatie ?classification .
+        } WHERE {
+          GRAPH <http://mu.semte.ch/graphs/landing-zone/leidinggevenden> {
+            VALUES ?functionaris { ${subject} }
+            ?functionaris org:holds ?bestuursfunctie .
+            ?orgaanInTime lblodlg:heeftBestuursfunctie ?bestuursfunctie ;
+              mandaat:isTijdspecialisatieVan ?orgaan .
+            ?orgaan besluit:bestuurt ?eenheid .
+            ?eenheid besluit:classificatie ?classification .
+          }
+        }`
+    },
+    {
+      trigger: {
+        predicateValue: "org:holds"
+      },
+      queryTemplate: (subject) => `
+        ${PREFIXES}
+        CONSTRUCT {
+          ?functionaris org:holds ?bestuursfunctie .
+          ?orgaanInTime lblodlg:heeftBestuursfunctie ?bestuursfunctie ;
+            mandaat:isTijdspecialisatieVan ?orgaan .
+          ?orgaan besluit:bestuurt ?eenheid .
+          ?eenheid besluit:classificatie ?classification .
+        } WHERE {
+          GRAPH <http://mu.semte.ch/graphs/landing-zone/leidinggevenden> {
+            VALUES ?functionaris { ${subject} }
+            ?functionaris org:holds ?bestuursfunctie .
+            ?orgaanInTime lblodlg:heeftBestuursfunctie ?bestuursfunctie ;
+              mandaat:isTijdspecialisatieVan ?orgaan .
+            ?orgaan besluit:bestuurt ?eenheid .
+            ?eenheid besluit:classificatie ?classification .
+          }
+        }`
+    }
+  ]
 }
 
 module.exports = {
-  contextConfig
+  contextConfig,
+  PREFIXES
 };

--- a/config/loket-consumer/mandatarissen-dispatching/delta-context-config.js
+++ b/config/loket-consumer/mandatarissen-dispatching/delta-context-config.js
@@ -1,11 +1,115 @@
+const PREFIXES = `
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX lblodlg: <https://data.lblod.info/vocabularies/leidinggevenden/>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>`
+
 const contextConfig = {
   addTypes: {
     scope: 'all', // 'inserts, 'deletes', 'all' or none. To add rdf:type to subjects of inserts, deletes or both
     exhausitive: false, // true or false: find all types for a subject, even if one is already present in delta
   },
-  contextQueries: []
+  contextQueries: [
+    // FIRST CASE : Leidnggevenden
+    // They can be triggered when being inserted or when their link to a bestuursfunctie is added
+    {
+      trigger: { // subjectType or predicateValue
+        subjectType: "lblodlg:Functionaris"
+      },
+      queryTemplate: (subject) => `
+        ${PREFIXES}
+        CONSTRUCT {
+          ?functionaris org:holds ?bestuursfunctie .
+          ?orgaanInTime lblodlg:heeftBestuursfunctie ?bestuursfunctie ;
+            mandaat:isTijdspecialisatieVan ?orgaan .
+          ?orgaan besluit:bestuurt ?eenheid .
+          ?eenheid besluit:classificatie ?classification .
+        } WHERE {
+          GRAPH <http://mu.semte.ch/graphs/landing-zone/leidinggevenden> {
+            VALUES ?functionaris { ${subject} }
+            ?functionaris org:holds ?bestuursfunctie .
+            ?orgaanInTime lblodlg:heeftBestuursfunctie ?bestuursfunctie ;
+              mandaat:isTijdspecialisatieVan ?orgaan .
+            ?orgaan besluit:bestuurt ?eenheid .
+            ?eenheid besluit:classificatie ?classification .
+          }
+        }`
+    },
+    {
+      trigger: {
+        predicateValue: "org:holds"
+      },
+      queryTemplate: (subject) => `
+        ${PREFIXES}
+        CONSTRUCT {
+          ?functionaris org:holds ?bestuursfunctie .
+          ?orgaanInTime lblodlg:heeftBestuursfunctie ?bestuursfunctie ;
+            mandaat:isTijdspecialisatieVan ?orgaan .
+          ?orgaan besluit:bestuurt ?eenheid .
+          ?eenheid besluit:classificatie ?classification .
+        } WHERE {
+          GRAPH <http://mu.semte.ch/graphs/landing-zone/leidinggevenden> {
+            VALUES ?functionaris { ${subject} }
+            ?functionaris org:holds ?bestuursfunctie .
+            ?orgaanInTime lblodlg:heeftBestuursfunctie ?bestuursfunctie ;
+              mandaat:isTijdspecialisatieVan ?orgaan .
+            ?orgaan besluit:bestuurt ?eenheid .
+            ?eenheid besluit:classificatie ?classification .
+          }
+        }`
+    },
+    // SECOND CASE : Mandatarissen
+    // They can be triggered when being inserted or when their link to a mandate is added
+    {
+      trigger: { // subjectType or predicateValue
+        subjectType: "mandaat:Mandataris"
+      },
+      queryTemplate: (subject) => `
+        ${PREFIXES}
+        CONSTRUCT {
+          ?mandataris org:holds ?mandate .
+          ?orgaanInTime org:hasPost ?mandate ;
+            mandaat:isTijdspecialisatieVan ?orgaan .
+          ?orgaan besluit:bestuurt ?eenheid .
+          ?eenheid besluit:classificatie ?classification .
+        } WHERE {
+          GRAPH <http://mu.semte.ch/graphs/landing-zone/mandatarissen> {
+            VALUES ?mandataris { ${subject} }
+            ?mandataris org:holds ?mandate .
+            ?orgaanInTime org:hasPost ?mandate ;
+              mandaat:isTijdspecialisatieVan ?orgaan .
+            ?orgaan besluit:bestuurt ?eenheid .
+            ?eenheid besluit:classificatie ?classification .
+          }
+        }`
+    },
+    {
+      trigger: {
+        predicateValue: "org:holds"
+      },
+      queryTemplate: (subject) => `
+        ${PREFIXES}
+        CONSTRUCT {
+          ?mandataris org:holds ?mandate .
+          ?orgaanInTime org:hasPost ?mandate ;
+            mandaat:isTijdspecialisatieVan ?orgaan .
+          ?orgaan besluit:bestuurt ?eenheid .
+          ?eenheid besluit:classificatie ?classification .
+        } WHERE {
+          GRAPH <http://mu.semte.ch/graphs/landing-zone/mandatarissen> {
+            VALUES ?mandataris { ${subject} }
+            ?mandataris org:holds ?mandate .
+            ?orgaanInTime org:hasPost ?mandate ;
+              mandaat:isTijdspecialisatieVan ?orgaan .
+            ?orgaan besluit:bestuurt ?eenheid .
+            ?eenheid besluit:classificatie ?classification .
+          }
+        }`
+    },
+  ]
 }
 
 module.exports = {
-  contextConfig
+  contextConfig,
+  PREFIXES
 };

--- a/config/loket-consumer/mandatarissen-dispatching/delta-context-config.js
+++ b/config/loket-consumer/mandatarissen-dispatching/delta-context-config.js
@@ -19,7 +19,8 @@ const contextConfig = {
       queryTemplate: (subject) => `
         ${PREFIXES}
         CONSTRUCT {
-          ?mandataris org:holds ?mandate .
+          ?mandataris org:holds ?mandate ;
+            ?p ?o .
           ?orgaanInTime org:hasPost ?mandate ;
             mandaat:isTijdspecialisatieVan ?orgaan .
           ?orgaan besluit:bestuurt ?eenheid .
@@ -27,7 +28,8 @@ const contextConfig = {
         } WHERE {
           GRAPH <http://mu.semte.ch/graphs/landing-zone/mandatarissen> {
             VALUES ?mandataris { ${subject} }
-            ?mandataris org:holds ?mandate .
+            ?mandataris org:holds ?mandate ;
+              ?p ?o .
             ?orgaanInTime org:hasPost ?mandate ;
               mandaat:isTijdspecialisatieVan ?orgaan .
             ?orgaan besluit:bestuurt ?eenheid .
@@ -42,7 +44,8 @@ const contextConfig = {
       queryTemplate: (subject) => `
         ${PREFIXES}
         CONSTRUCT {
-          ?mandataris org:holds ?mandate .
+          ?mandataris org:holds ?mandate ;
+            ?p ?o .
           ?orgaanInTime org:hasPost ?mandate ;
             mandaat:isTijdspecialisatieVan ?orgaan .
           ?orgaan besluit:bestuurt ?eenheid .
@@ -50,7 +53,8 @@ const contextConfig = {
         } WHERE {
           GRAPH <http://mu.semte.ch/graphs/landing-zone/mandatarissen> {
             VALUES ?mandataris { ${subject} }
-            ?mandataris org:holds ?mandate .
+            ?mandataris org:holds ?mandate ;
+              ?p ?o .
             ?orgaanInTime org:hasPost ?mandate ;
               mandaat:isTijdspecialisatieVan ?orgaan .
             ?orgaan besluit:bestuurt ?eenheid .

--- a/config/loket-consumer/mandatarissen-dispatching/delta-context-config.js
+++ b/config/loket-consumer/mandatarissen-dispatching/delta-context-config.js
@@ -1,7 +1,7 @@
 const PREFIXES = `
 PREFIX org: <http://www.w3.org/ns/org#>
 PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
-PREFIX lblodlg: <https://data.lblod.info/vocabularies/leidinggevenden/>
+PREFIX lblodlg: <http://data.lblod.info/vocabularies/leidinggevenden/>
 PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>`
 
 const contextConfig = {
@@ -10,55 +10,7 @@ const contextConfig = {
     exhausitive: false, // true or false: find all types for a subject, even if one is already present in delta
   },
   contextQueries: [
-    // FIRST CASE : Leidnggevenden
-    // They can be triggered when being inserted or when their link to a bestuursfunctie is added
-    {
-      trigger: { // subjectType or predicateValue
-        subjectType: "lblodlg:Functionaris"
-      },
-      queryTemplate: (subject) => `
-        ${PREFIXES}
-        CONSTRUCT {
-          ?functionaris org:holds ?bestuursfunctie .
-          ?orgaanInTime lblodlg:heeftBestuursfunctie ?bestuursfunctie ;
-            mandaat:isTijdspecialisatieVan ?orgaan .
-          ?orgaan besluit:bestuurt ?eenheid .
-          ?eenheid besluit:classificatie ?classification .
-        } WHERE {
-          GRAPH <http://mu.semte.ch/graphs/landing-zone/leidinggevenden> {
-            VALUES ?functionaris { ${subject} }
-            ?functionaris org:holds ?bestuursfunctie .
-            ?orgaanInTime lblodlg:heeftBestuursfunctie ?bestuursfunctie ;
-              mandaat:isTijdspecialisatieVan ?orgaan .
-            ?orgaan besluit:bestuurt ?eenheid .
-            ?eenheid besluit:classificatie ?classification .
-          }
-        }`
-    },
-    {
-      trigger: {
-        predicateValue: "org:holds"
-      },
-      queryTemplate: (subject) => `
-        ${PREFIXES}
-        CONSTRUCT {
-          ?functionaris org:holds ?bestuursfunctie .
-          ?orgaanInTime lblodlg:heeftBestuursfunctie ?bestuursfunctie ;
-            mandaat:isTijdspecialisatieVan ?orgaan .
-          ?orgaan besluit:bestuurt ?eenheid .
-          ?eenheid besluit:classificatie ?classification .
-        } WHERE {
-          GRAPH <http://mu.semte.ch/graphs/landing-zone/leidinggevenden> {
-            VALUES ?functionaris { ${subject} }
-            ?functionaris org:holds ?bestuursfunctie .
-            ?orgaanInTime lblodlg:heeftBestuursfunctie ?bestuursfunctie ;
-              mandaat:isTijdspecialisatieVan ?orgaan .
-            ?orgaan besluit:bestuurt ?eenheid .
-            ?eenheid besluit:classificatie ?classification .
-          }
-        }`
-    },
-    // SECOND CASE : Mandatarissen
+    // Case Mandatarissen
     // They can be triggered when being inserted or when their link to a mandate is added
     {
       trigger: { // subjectType or predicateValue
@@ -105,7 +57,7 @@ const contextConfig = {
             ?eenheid besluit:classificatie ?classification .
           }
         }`
-    },
+    }
   ]
 }
 

--- a/config/migrations/2023/20230515111900-remove-not-yet-onboarded-functionarissen.sparql
+++ b/config/migrations/2023/20230515111900-remove-not-yet-onboarded-functionarissen.sparql
@@ -1,0 +1,21 @@
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?functionaris ?pfunctionaris ?ofunctionaris .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?functionaris a <http://data.lblod.info/vocabularies/leidinggevenden/Functionaris> ;
+    <http://www.w3.org/ns/org#holds> ?bestuursfunctie ;
+    ?pfunctionaris ?ofunctionaris .
+  }
+
+  ?orgaan <http://data.lblod.info/vocabularies/leidinggevenden/heeftBestuursfunctie> ?bestuursfunctie ;
+    <http://data.vlaanderen.be/ns/mandaat#isTijdspecialisatieVan>/<http://data.vlaanderen.be/ns/besluit#bestuurt>/<http://data.vlaanderen.be/ns/besluit#classificatie> ?classification .
+
+  FILTER(?classification NOT IN (
+    <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000000>,
+    <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001>,
+    <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000002>,
+    <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000003>
+  ))
+}

--- a/config/reasoner/dl2op/main/query.n3q
+++ b/config/reasoner/dl2op/main/query.n3q
@@ -34,9 +34,9 @@
     ?p ?o .
 
   ?orgaanInTime <http://data.lblod.info/vocabularies/leidinggevenden/heeftBestuursfunctie> ?bestuursfunctie ;
-    <http://data.vlaanderen.be/ns/mandaat#isTijdspecialisatieVan> ?orgaan .
+    <https://data.vlaanderen.be/ns/generiek#isTijdspecialisatieVan> ?orgaan .
   ?orgaan <http://data.vlaanderen.be/ns/besluit#bestuurt> ?bestuur .
-  ?bestuur <http://data.vlaanderen.be/ns/besluit#classificatie> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000000> .
+  ?bestuur <http://www.w3.org/ns/org#classification> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000000> .
  } => {
   ?s a <http://data.lblod.info/vocabularies/leidinggevenden/Functionaris> ;
     ?p ?o .
@@ -48,9 +48,9 @@
     ?p ?o .
 
   ?orgaanInTime <http://data.lblod.info/vocabularies/leidinggevenden/heeftBestuursfunctie> ?bestuursfunctie ;
-    <http://data.vlaanderen.be/ns/mandaat#isTijdspecialisatieVan> ?orgaan .
+    <https://data.vlaanderen.be/ns/generiek#isTijdspecialisatieVan> ?orgaan .
   ?orgaan <http://data.vlaanderen.be/ns/besluit#bestuurt> ?bestuur .
-  ?bestuur <http://data.vlaanderen.be/ns/besluit#classificatie> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001> .
+  ?bestuur <http://www.w3.org/ns/org#classification> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001> .
  } => {
   ?s a <http://data.lblod.info/vocabularies/leidinggevenden/Functionaris> ;
     ?p ?o .
@@ -62,9 +62,9 @@
     ?p ?o .
 
   ?orgaanInTime <http://data.lblod.info/vocabularies/leidinggevenden/heeftBestuursfunctie> ?bestuursfunctie ;
-    <http://data.vlaanderen.be/ns/mandaat#isTijdspecialisatieVan> ?orgaan .
+    <https://data.vlaanderen.be/ns/generiek#isTijdspecialisatieVan> ?orgaan .
   ?orgaan <http://data.vlaanderen.be/ns/besluit#bestuurt> ?bestuur .
-  ?bestuur <http://data.vlaanderen.be/ns/besluit#classificatie> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000002> .
+  ?bestuur <http://www.w3.org/ns/org#classification> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000002> .
  } => {
   ?s a <http://data.lblod.info/vocabularies/leidinggevenden/Functionaris> ;
     ?p ?o .
@@ -76,9 +76,9 @@
     ?p ?o .
 
   ?orgaanInTime <http://data.lblod.info/vocabularies/leidinggevenden/heeftBestuursfunctie> ?bestuursfunctie ;
-    <http://data.vlaanderen.be/ns/mandaat#isTijdspecialisatieVan> ?orgaan .
+    <https://data.vlaanderen.be/ns/generiek#isTijdspecialisatieVan> ?orgaan .
   ?orgaan <http://data.vlaanderen.be/ns/besluit#bestuurt> ?bestuur .
-  ?bestuur <http://data.vlaanderen.be/ns/besluit#classificatie> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000003> .
+  ?bestuur <http://www.w3.org/ns/org#classification> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000003> .
  } => {
   ?s a <http://data.lblod.info/vocabularies/leidinggevenden/Functionaris> ;
     ?p ?o .
@@ -92,9 +92,9 @@
     ?p ?o .
 
   ?orgaan <http://www.w3.org/ns/org#hasPost> ?mandate ;
-    <http://data.vlaanderen.be/ns/mandaat#isTijdspecialisatieVan> ?orgaan .
+    <https://data.vlaanderen.be/ns/generiek#isTijdspecialisatieVan> ?orgaan .
   ?orgaan <http://data.vlaanderen.be/ns/besluit#bestuurt> ?bestuur .
-  ?bestuur <http://data.vlaanderen.be/ns/besluit#classificatie> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000000> .
+  ?bestuur <http://www.w3.org/ns/org#classification> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000000> .
  } => {
   ?s a <http://data.vlaanderen.be/ns/mandaat#Mandataris> ;
     ?p ?o .
@@ -106,9 +106,9 @@
     ?p ?o .
 
   ?orgaan <http://www.w3.org/ns/org#hasPost> ?mandate ;
-    <http://data.vlaanderen.be/ns/mandaat#isTijdspecialisatieVan> ?orgaan .
+    <https://data.vlaanderen.be/ns/generiek#isTijdspecialisatieVan> ?orgaan .
   ?orgaan <http://data.vlaanderen.be/ns/besluit#bestuurt> ?bestuur .
-  ?bestuur <http://data.vlaanderen.be/ns/besluit#classificatie> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001> .
+  ?bestuur <http://www.w3.org/ns/org#classification> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001> .
  } => {
   ?s a <http://data.vlaanderen.be/ns/mandaat#Mandataris> ;
     ?p ?o .
@@ -120,9 +120,9 @@
     ?p ?o .
 
   ?orgaan <http://www.w3.org/ns/org#hasPost> ?mandate ;
-    <http://data.vlaanderen.be/ns/mandaat#isTijdspecialisatieVan> ?orgaan .
+    <https://data.vlaanderen.be/ns/generiek#isTijdspecialisatieVan> ?orgaan .
   ?orgaan <http://data.vlaanderen.be/ns/besluit#bestuurt> ?bestuur .
-  ?bestuur <http://data.vlaanderen.be/ns/besluit#classificatie> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000002> .
+  ?bestuur <http://www.w3.org/ns/org#classification> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000002> .
  } => {
   ?s a <http://data.vlaanderen.be/ns/mandaat#Mandataris> ;
     ?p ?o .
@@ -134,9 +134,9 @@
     ?p ?o .
 
   ?orgaan <http://www.w3.org/ns/org#hasPost> ?mandate ;
-    <http://data.vlaanderen.be/ns/mandaat#isTijdspecialisatieVan> ?orgaan .
+    <https://data.vlaanderen.be/ns/generiek#isTijdspecialisatieVan> ?orgaan .
   ?orgaan <http://data.vlaanderen.be/ns/besluit#bestuurt> ?bestuur .
-  ?bestuur <http://data.vlaanderen.be/ns/besluit#classificatie> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000003> .
+  ?bestuur <http://www.w3.org/ns/org#classification> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000003> .
  } => {
   ?s a <http://data.vlaanderen.be/ns/mandaat#Mandataris> ;
     ?p ?o .

--- a/config/reasoner/dl2op/main/query.n3q
+++ b/config/reasoner/dl2op/main/query.n3q
@@ -1,5 +1,7 @@
 # Filtering classes to ingest
 
+@prefix log: <http://www.w3.org/2000/10/swap/log#> .
+
 {
   ?s a <http://www.w3.org/ns/person#Person> ;
     ?p ?o .
@@ -24,17 +26,117 @@
     ?p ?o .
 }.
 
+# Functionarissen should be linked to a gemeente, district, provincie or ocmw only (FOR NOW)
+
 {
   ?s a <http://data.lblod.info/vocabularies/leidinggevenden/Functionaris> ;
+    <http://www.w3.org/ns/org#holds> ?bestuursfunctie ;
     ?p ?o .
+
+  ?orgaanInTime <http://data.lblod.info/vocabularies/leidinggevenden/heeftBestuursfunctie> ?bestuursfunctie ;
+    <http://data.vlaanderen.be/ns/mandaat#isTijdspecialisatieVan> ?orgaan .
+  ?orgaan <http://data.vlaanderen.be/ns/besluit#bestuurt> ?bestuur .
+  ?bestuur <http://data.vlaanderen.be/ns/besluit#classificatie> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000000> .
  } => {
   ?s a <http://data.lblod.info/vocabularies/leidinggevenden/Functionaris> ;
+    ?p ?o .
+}.
+
+{
+  ?s a <http://data.lblod.info/vocabularies/leidinggevenden/Functionaris> ;
+    <http://www.w3.org/ns/org#holds> ?bestuursfunctie ;
+    ?p ?o .
+
+  ?orgaanInTime <http://data.lblod.info/vocabularies/leidinggevenden/heeftBestuursfunctie> ?bestuursfunctie ;
+    <http://data.vlaanderen.be/ns/mandaat#isTijdspecialisatieVan> ?orgaan .
+  ?orgaan <http://data.vlaanderen.be/ns/besluit#bestuurt> ?bestuur .
+  ?bestuur <http://data.vlaanderen.be/ns/besluit#classificatie> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001> .
+ } => {
+  ?s a <http://data.lblod.info/vocabularies/leidinggevenden/Functionaris> ;
+    ?p ?o .
+}.
+
+{
+  ?s a <http://data.lblod.info/vocabularies/leidinggevenden/Functionaris> ;
+    <http://www.w3.org/ns/org#holds> ?bestuursfunctie ;
+    ?p ?o .
+
+  ?orgaanInTime <http://data.lblod.info/vocabularies/leidinggevenden/heeftBestuursfunctie> ?bestuursfunctie ;
+    <http://data.vlaanderen.be/ns/mandaat#isTijdspecialisatieVan> ?orgaan .
+  ?orgaan <http://data.vlaanderen.be/ns/besluit#bestuurt> ?bestuur .
+  ?bestuur <http://data.vlaanderen.be/ns/besluit#classificatie> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000002> .
+ } => {
+  ?s a <http://data.lblod.info/vocabularies/leidinggevenden/Functionaris> ;
+    ?p ?o .
+}.
+
+{
+  ?s a <http://data.lblod.info/vocabularies/leidinggevenden/Functionaris> ;
+    <http://www.w3.org/ns/org#holds> ?bestuursfunctie ;
+    ?p ?o .
+
+  ?orgaanInTime <http://data.lblod.info/vocabularies/leidinggevenden/heeftBestuursfunctie> ?bestuursfunctie ;
+    <http://data.vlaanderen.be/ns/mandaat#isTijdspecialisatieVan> ?orgaan .
+  ?orgaan <http://data.vlaanderen.be/ns/besluit#bestuurt> ?bestuur .
+  ?bestuur <http://data.vlaanderen.be/ns/besluit#classificatie> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000003> .
+ } => {
+  ?s a <http://data.lblod.info/vocabularies/leidinggevenden/Functionaris> ;
+    ?p ?o .
+}.
+
+# Mandatarissen should be linked to a gemeente, district, provincie or ocmw only (FOR NOW)
+
+{
+  ?s a <http://data.vlaanderen.be/ns/mandaat#Mandataris> ;
+    <http://www.w3.org/ns/org#holds> ?mandate ;
+    ?p ?o .
+
+  ?orgaan <http://www.w3.org/ns/org#hasPost> ?mandate ;
+    <http://data.vlaanderen.be/ns/mandaat#isTijdspecialisatieVan> ?orgaan .
+  ?orgaan <http://data.vlaanderen.be/ns/besluit#bestuurt> ?bestuur .
+  ?bestuur <http://data.vlaanderen.be/ns/besluit#classificatie> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000000> .
+ } => {
+  ?s a <http://data.vlaanderen.be/ns/mandaat#Mandataris> ;
     ?p ?o .
 }.
 
 {
   ?s a <http://data.vlaanderen.be/ns/mandaat#Mandataris> ;
+    <http://www.w3.org/ns/org#holds> ?mandate ;
     ?p ?o .
+
+  ?orgaan <http://www.w3.org/ns/org#hasPost> ?mandate ;
+    <http://data.vlaanderen.be/ns/mandaat#isTijdspecialisatieVan> ?orgaan .
+  ?orgaan <http://data.vlaanderen.be/ns/besluit#bestuurt> ?bestuur .
+  ?bestuur <http://data.vlaanderen.be/ns/besluit#classificatie> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001> .
+ } => {
+  ?s a <http://data.vlaanderen.be/ns/mandaat#Mandataris> ;
+    ?p ?o .
+}.
+
+{
+  ?s a <http://data.vlaanderen.be/ns/mandaat#Mandataris> ;
+    <http://www.w3.org/ns/org#holds> ?mandate ;
+    ?p ?o .
+
+  ?orgaan <http://www.w3.org/ns/org#hasPost> ?mandate ;
+    <http://data.vlaanderen.be/ns/mandaat#isTijdspecialisatieVan> ?orgaan .
+  ?orgaan <http://data.vlaanderen.be/ns/besluit#bestuurt> ?bestuur .
+  ?bestuur <http://data.vlaanderen.be/ns/besluit#classificatie> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000002> .
+ } => {
+  ?s a <http://data.vlaanderen.be/ns/mandaat#Mandataris> ;
+    ?p ?o .
+}.
+
+{
+  ?s a <http://data.vlaanderen.be/ns/mandaat#Mandataris> ;
+    <http://www.w3.org/ns/org#holds> ?mandate ;
+    ?p ?o .
+
+  ?orgaan <http://www.w3.org/ns/org#hasPost> ?mandate ;
+    <http://data.vlaanderen.be/ns/mandaat#isTijdspecialisatieVan> ?orgaan .
+  ?orgaan <http://data.vlaanderen.be/ns/besluit#bestuurt> ?bestuur .
+  ?bestuur <http://data.vlaanderen.be/ns/besluit#classificatie> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000003> .
  } => {
   ?s a <http://data.vlaanderen.be/ns/mandaat#Mandataris> ;
     ?p ?o .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -228,7 +228,7 @@ services:
     restart: always
     logging: *default-logging
   reasoner:
-    image: eyereasoner/reasoning-service:1.0.2
+    image: eyereasoner/reasoning-service:increased-stack-limit
     volumes:
       - ./config/reasoner:/config
   ################################################################################
@@ -497,7 +497,7 @@ services:
   ldes-delta-pusher:
     image: redpencil/ldes-delta-pusher:latest
     environment:
-      LDES_ENDPOINT: 'http://ldes-backend/organizations'
+      LDES_ENDPOINT: "http://ldes-backend/organizations"
     volumes:
       - ./config/ldes-delta-pusher/:/config/
     links:
@@ -508,14 +508,14 @@ services:
     environment:
       FOLDER_DEPTH: 1
       PAGE_RESOURCES_COUNT: 50
-      LDES_STREAM_PREFIX: 'http://data.lblod.info/streams/op/'
-      TIME_TREE_RELATION_PATH: 'http://www.w3.org/ns/prov#generatedAtTime'
+      LDES_STREAM_PREFIX: "http://data.lblod.info/streams/op/"
+      TIME_TREE_RELATION_PATH: "http://www.w3.org/ns/prov#generatedAtTime"
       CACHE_SIZE: 10
-      DATA_FOLDER: '/data'
-      ENABLE_AUTH: 'false'
+      DATA_FOLDER: "/data"
+      ENABLE_AUTH: "false"
     restart: always
     volumes:
-      - './data/ldes-feed/:/data/'
+      - "./data/ldes-feed/:/data/"
 
   ################################################################################
   # MU SEARCH


### PR DESCRIPTION
This PR removes data that has been wrongly consumed and adds a limit to the types of admin units from which we consume positions.

This applies for leidinggevenden as well as for mandatarissen.