### PR TITLE
Add dev profile to ldes feed

### DIFF
--- a/config/delta/rules.js
+++ b/config/delta/rules.js
@@ -162,6 +162,8 @@ export default [
       optOutMuScopeIds: ["http://redpencil.data.gift/id/concept/muScope/deltas/initialSync"]
     }
   },
+/*
+  Commenting ldes rules until ready to go to qa/prod. In the meantime, we override the configuration on dev.
   {
     match: {
       graph: {
@@ -210,4 +212,5 @@ export default [
       gracePeriod: 1000,
     }
   }
+*/
 ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -496,6 +496,7 @@ services:
 
   ldes-delta-pusher:
     image: redpencil/ldes-delta-pusher:latest
+    profiles: ["dev"] # Disable ldes feed by default until ready for qa/prod
     environment:
       LDES_ENDPOINT: 'http://ldes-backend/organizations'
     volumes:
@@ -505,6 +506,7 @@ services:
 
   ldes-backend:
     image: redpencil/fragmentation-producer:0.3.2
+    profiles: ["dev"] # Disable ldes feed by default until ready for qa/prod
     environment:
       FOLDER_DEPTH: 1
       PAGE_RESOURCES_COUNT: 50


### PR DESCRIPTION
OP-2400

As the LDES feed it's not ready yet to be used on QA or PROD, to simplify the release process, we add a profile to the related services to disable it by default.
To enable it on dev, we just have to run the following command: `docker-compose --profile dev up` and mount a delta config including the ldes rules.