### PR TITLE
Update ldes-backend image to 0.3.3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -505,7 +505,7 @@ services:
       - db:database
 
   ldes-backend:
-    image: redpencil/fragmentation-producer:0.3.2
+    image: redpencil/fragmentation-producer:0.3.3
     profiles: ["dev"] # Disable ldes feed by default until ready for qa/prod
     environment:
       FOLDER_DEPTH: 1


### PR DESCRIPTION
This PR updates the `redpencil/fragmentation-producer` to version 0.3.3 which includes a fix for situations where feed members were incomplete