### PR TITLE
Add IGS positions to the sync

### DIFF
--- a/config/migrations/2023/20230712152618-igs-link-positions-to-unit-classifications.sparql
+++ b/config/migrations/2023/20230712152618-igs-link-positions-to-unit-classifications.sparql
@@ -1,0 +1,12 @@
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4>
+      ext:appliesWithin
+        <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/b156b67f-c5f4-4584-9b30-4c090be02fdc> ,
+        <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/d01bb1f6-2439-4e33-9c25-1fc295de2e71> ,
+        <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/cd93f147-3ece-4308-acab-5c5ada3ec63d> ,
+        <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/4b8450cf-a326-4c66-9e63-b4ec10acc7f6> .
+  }
+}

--- a/config/reasoner/dl2op/main/query.n3q
+++ b/config/reasoner/dl2op/main/query.n3q
@@ -26,7 +26,7 @@
     ?p ?o .
 }.
 
-# Functionarissen should be linked to a agb, apb, gemeente, district, provincie or ocmw only (FOR NOW)
+# Functionarissen should be linked to an igs, agb, apb, gemeente, district, provincie or ocmw only (FOR NOW)
 
 {
   ?s a <http://data.lblod.info/vocabularies/leidinggevenden/Functionaris> ;
@@ -111,6 +111,61 @@
     ?p ?o .
 }.
 
+{
+  ?s a <http://data.lblod.info/vocabularies/leidinggevenden/Functionaris> ;
+    <http://www.w3.org/ns/org#holds> ?bestuursfunctie ;
+    ?p ?o .
+
+  ?orgaanInTime <http://data.lblod.info/vocabularies/leidinggevenden/heeftBestuursfunctie> ?bestuursfunctie ;
+    <https://data.vlaanderen.be/ns/generiek#isTijdspecialisatieVan> ?orgaan .
+  ?orgaan <http://data.vlaanderen.be/ns/besluit#bestuurt> ?bestuur .
+  ?bestuur <http://www.w3.org/ns/org#classification> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/b156b67f-c5f4-4584-9b30-4c090be02fdc> .
+ } => {
+  ?s a <http://data.lblod.info/vocabularies/leidinggevenden/Functionaris> ;
+    ?p ?o .
+}.
+
+{
+  ?s a <http://data.lblod.info/vocabularies/leidinggevenden/Functionaris> ;
+    <http://www.w3.org/ns/org#holds> ?bestuursfunctie ;
+    ?p ?o .
+
+  ?orgaanInTime <http://data.lblod.info/vocabularies/leidinggevenden/heeftBestuursfunctie> ?bestuursfunctie ;
+    <https://data.vlaanderen.be/ns/generiek#isTijdspecialisatieVan> ?orgaan .
+  ?orgaan <http://data.vlaanderen.be/ns/besluit#bestuurt> ?bestuur .
+  ?bestuur <http://www.w3.org/ns/org#classification> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/d01bb1f6-2439-4e33-9c25-1fc295de2e71> .
+ } => {
+  ?s a <http://data.lblod.info/vocabularies/leidinggevenden/Functionaris> ;
+    ?p ?o .
+}.
+
+{
+  ?s a <http://data.lblod.info/vocabularies/leidinggevenden/Functionaris> ;
+    <http://www.w3.org/ns/org#holds> ?bestuursfunctie ;
+    ?p ?o .
+
+  ?orgaanInTime <http://data.lblod.info/vocabularies/leidinggevenden/heeftBestuursfunctie> ?bestuursfunctie ;
+    <https://data.vlaanderen.be/ns/generiek#isTijdspecialisatieVan> ?orgaan .
+  ?orgaan <http://data.vlaanderen.be/ns/besluit#bestuurt> ?bestuur .
+  ?bestuur <http://www.w3.org/ns/org#classification> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/cd93f147-3ece-4308-acab-5c5ada3ec63d> .
+ } => {
+  ?s a <http://data.lblod.info/vocabularies/leidinggevenden/Functionaris> ;
+    ?p ?o .
+}.
+
+{
+  ?s a <http://data.lblod.info/vocabularies/leidinggevenden/Functionaris> ;
+    <http://www.w3.org/ns/org#holds> ?bestuursfunctie ;
+    ?p ?o .
+
+  ?orgaanInTime <http://data.lblod.info/vocabularies/leidinggevenden/heeftBestuursfunctie> ?bestuursfunctie ;
+    <https://data.vlaanderen.be/ns/generiek#isTijdspecialisatieVan> ?orgaan .
+  ?orgaan <http://data.vlaanderen.be/ns/besluit#bestuurt> ?bestuur .
+  ?bestuur <http://www.w3.org/ns/org#classification> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/4b8450cf-a326-4c66-9e63-b4ec10acc7f6> .
+ } => {
+  ?s a <http://data.lblod.info/vocabularies/leidinggevenden/Functionaris> ;
+    ?p ?o .
+}.
 
 # Mandatarissen should be linked to a gemeente, district, provincie or ocmw only (FOR NOW)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -219,7 +219,7 @@ services:
     volumes:
       - ./config/jobs-controller/:/config/
   construct-administrative-unit-relationships:
-    image: lblod/construct-administrative-unit-relationships-service:0.1.3
+    image: lblod/construct-administrative-unit-relationships-service:0.1.4
     environment:
       START_DATE_WORSHIP_GOVERNING_BODY: "2023-04-01T00:00:00"
       END_DATE_WORSHIP_GOVERNING_BODY: "2026-03-31T00:00:00"


### PR DESCRIPTION
OP-2513

For testing, it's a little bit tricky as we miss some data. I took some notes that you can reuse !

```
Test with leidinggevenden of Stadsregio Turnhout

Can not be tested the right way because we are missing too much data (primary sites data + labels of ISG)
So by adding this extra data, we'll at least be able to test for the leidinggevenden of ONE bestuur to see if the code
works or not. We add a label and an existing primary site, to make our lifes easier :)

INSERT DATA {
  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
    <http://data.lblod.info/id/bestuurseenheden/7cab1a9c6f5dc798164f1c6812fc790e5279a8fe7800a2e8b7a159c581c866f1>
      skos:prefLabel "Stadsregio Turnhout" ;
      <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/e215e097cd2f054c9de6db80cf34d65d> .
  }
}

restart cache & resource

Then visit http://localhost:4200/bestuurseenheden/7cab1a9c6f5dc798164f1c6812fc790e5279a8fe7800a2e8b7a159c581c866f1/leidinggevenden !


To import leidinggevenden:
- dr inspect app-organization-portal-leidinggevenden-consumer-1
- curl --request POST <ip>/flush // Wait that the flushing finishes
- drc restart leidinggevenden-consumer // Wait for the initial sync to finish, +/-10min
- sh ./scripts/reset-elastic.sh // This takes +/- 1h, check search logs
```