### PR TITLE
Include local-identifier and label for each identifier of organizations sent to ldes feed

### DIFF
--- a/config/ldes-delta-pusher/dispatch.ts
+++ b/config/ldes-delta-pusher/dispatch.ts
@@ -11,12 +11,16 @@ export default async function dispatch(changesets: Changeset[]) {
         PREFIX code: <http://telegraphis.net/ontology/measurement/code#>
         PREFIX org: <http://www.w3.org/ns/org#>
         PREFIX adms: <http://www.w3.org/ns/adms#>
+        PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
   
         CONSTRUCT {
           ?organization a org:Organization;
                         skos:prefLabel ?prefLabel;
                         adms:identifier ?identifier;
                         org:hasPrimarySite ?site.
+          ?identifier skos:notation ?identifierLabel;
+                      generiek:gestructureerdeIdentificator ?gestructureerdeIdentificator.
+          ?gestructureerdeIdentificator generiek:lokaleIdentificator ?lokaleIdentificator.
           ?site org:siteAddress ?siteAddress.
           ?siteAddress ?p ?o.
         } WHERE {
@@ -26,6 +30,9 @@ export default async function dispatch(changesets: Changeset[]) {
                           skos:prefLabel ?prefLabel;
                           adms:identifier ?identifier;
                           org:hasPrimarySite ?site.
+            ?identifier skos:notation ?identifierLabel;
+                        generiek:gestructureerdeIdentificator ?gestructureerdeIdentificator.
+            ?gestructureerdeIdentificator generiek:lokaleIdentificator ?lokaleIdentificator.
             ?site org:siteAddress ?siteAddress.
             ?siteAddress ?p ?o.
           } UNION {
@@ -34,6 +41,9 @@ export default async function dispatch(changesets: Changeset[]) {
                           skos:prefLabel ?prefLabel;
                           adms:identifier ?identifier;
                           org:hasPrimarySite ?site.
+            ?identifier skos:notation ?identifierLabel;
+                        generiek:gestructureerdeIdentificator ?gestructureerdeIdentificator.
+            ?gestructureerdeIdentificator generiek:lokaleIdentificator ?lokaleIdentificator.
             ?site org:siteAddress ?siteAddress.
             ?siteAddress ?p ?o.
           } UNION {
@@ -42,12 +52,16 @@ export default async function dispatch(changesets: Changeset[]) {
                           skos:prefLabel ?prefLabel;
                           adms:identifier ?identifier;
                           org:hasPrimarySite ?site.
+            ?identifier skos:notation ?identifierLabel;
+                        generiek:gestructureerdeIdentificator ?gestructureerdeIdentificator.
+            ?gestructureerdeIdentificator generiek:lokaleIdentificator ?lokaleIdentificator.
             ?site org:siteAddress ?siteAddress.
             ?siteAddress ?p ?o.
           } 
         }
 			`);
       if(bindings.length){
+        console.log('SUCCESS')
         await moveTriples([
           {
             inserts: bindings.map(({ s, p, o}) => { return { subject: s, predicate: p, object: o} }),


### PR DESCRIPTION
### Overview
This PR includes a change to the `dispatch` function of the ldes-delta-pusher. For each organization sent to the LDES feed, the local identifiers and labels for each of their identifiers is also included.

### How to test
- Set-up the stack
- Create/edit and organization and include some identifiers
- Check if the ldes-feed has been updated with the new information on `/ldes/organizations/1`, the new information will be included on the last page of the feed.

### Notes
The structure sent to the LDES-feed is a bit complicated, maybe we can use other predicates to link the KBO/OVO numbers to the organizations directly instead of through the `local-identifier`/`structured-identifier` predicates?