### PR TITLE
Update ldes-backend image to 0.4.0

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -81,6 +81,9 @@ services:
     restart: "no"
   worship-services-sensitive-consumer:
     restart: "no"
+  ldes-backend:
+    environment:
+      BASE_URL: "http://localhost/ldes/"
   # use this to test acmidm
   # tlsproxy:
   #   image: caddy:2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -505,7 +505,7 @@ services:
       - db:database
 
   ldes-backend:
-    image: redpencil/fragmentation-producer:0.3.3
+    image: redpencil/fragmentation-producer:0.4.0
     profiles: ["dev"] # Disable ldes feed by default until ready for qa/prod
     environment:
       FOLDER_DEPTH: 1


### PR DESCRIPTION
### Overview

This PR updates the ldes-backend image to 0.4.0. 
This update includes some breaking changes, as it is now required to pass a `BASE_URL` environment variable to the service.
The service uses `BASE_URL` to resolve its relative URLs.

### Notes
I included the `BASE_URL` env var in `docker-compose.dev.yml`, set as `http://localhost/ldes/`.