### PR TITLE
Import PZ & HVZ basic data

### DIFF
--- a/config/migrations/2023/20231005111600-onboarding-pz-hvz/20231005111611-pz-hz-from-Loket.graph
+++ b/config/migrations/2023/20231005111600-onboarding-pz-hvz/20231005111611-pz-hz-from-Loket.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/administrative-unit

--- a/config/migrations/2023/20231005111600-onboarding-pz-hvz/20231005111611-pz-hz-from-Loket.ttl
+++ b/config/migrations/2023/20231005111600-onboarding-pz-hvz/20231005111611-pz-hz-from-Loket.ttl
@@ -1,0 +1,3883 @@
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix besluit: <http://data.vlaanderen.be/ns/besluit#> .
+@prefix generiek: <https://data.vlaanderen.be/ns/generiek#> .
+@prefix mandaat: <http://data.vlaanderen.be/ns/mandaat#> .
+@prefix mu: <http://mu.semte.ch/vocabularies/core/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://data.lblod.info/id/bestuursorganen/009d6677e7b37c6994d5fd4db533f368eb2a4b43d4e20adc1e5283d712a433e1> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "009d6677e7b37c6994d5fd4db533f368eb2a4b43d4e20adc1e5283d712a433e1" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/0b2f136de55ce294f4ddeb0e677056180f247d384e50864ed2ca1710a329d53c> .
+
+<http://data.lblod.info/id/bestuursorganen/03da0fb32df092ecc0fdc83cc0e36fb9bab525d61132935f6d5f0b3b85a62752> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "03da0fb32df092ecc0fdc83cc0e36fb9bab525d61132935f6d5f0b3b85a62752" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/c03a73f68f70d447ec6ca07a2319c57e6e961b8ae91c25f7277e79d341cb8c96> .
+
+<http://data.lblod.info/id/bestuursorganen/05950ad0289951ee1f45efca7dcf117b7e5032ff71cfefa8e0f67464ccc40246> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "05950ad0289951ee1f45efca7dcf117b7e5032ff71cfefa8e0f67464ccc40246" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/c1d75d5eb7e1613c82482b16a535581baeade6c855b8fc071c13cd35850bdc6f> .
+
+<http://data.lblod.info/id/bestuursorganen/063916b901beaa3940a9068ce0acef862629393eca53858df13f14d2fd626fcd> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "063916b901beaa3940a9068ce0acef862629393eca53858df13f14d2fd626fcd" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/7bf046650a0ef8a7b38818cf3610ee872206f905a20bc1574811af2947ea21e1> .
+
+<http://data.lblod.info/id/bestuursorganen/0716d33ba303c1c68461427be814fbd4ea117d7674eb7f279fe23ac61e7f0e95> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "0716d33ba303c1c68461427be814fbd4ea117d7674eb7f279fe23ac61e7f0e95" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/2c773267a6abad81d35999e1dac030fe573e701fca079c897f6eebccbc4481e1> .
+
+<http://data.lblod.info/id/bestuursorganen/0884b656-c9bf-46cb-af25-09321b90a9c3> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "0884b656-c9bf-46cb-af25-09321b90a9c3" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/17ccfb25-d79f-4f85-9380-c677c875e873> .
+
+<http://data.lblod.info/id/bestuursorganen/09b3ba7a81c078b155ccbacd3b031ae0a342bd39e61b57616692bba67c6eaf42> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "09b3ba7a81c078b155ccbacd3b031ae0a342bd39e61b57616692bba67c6eaf42" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/d3f90bedf300b3c9e7a5f5c8e8e58ea71cdde59d54abd03e4b95493b513769ce> .
+
+<http://data.lblod.info/id/bestuursorganen/09d4ee592dca6e4154bac5bee43154eba37d4d53139b24e9499e2828e8bd60b8> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "09d4ee592dca6e4154bac5bee43154eba37d4d53139b24e9499e2828e8bd60b8" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/78749cf2dd2a1bbb21c7bfaca988a5a7e28068e9dc60242ea7d6e7b3c2a4a255> .
+
+<http://data.lblod.info/id/bestuursorganen/09e4e6e2e877b968544828e08518b3251fa2fbaa0f7f02e0cf8c4514d715d7c4> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "09e4e6e2e877b968544828e08518b3251fa2fbaa0f7f02e0cf8c4514d715d7c4" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/e88b7ff83522145f4c933546db0ce10e93aea1a93c2553970a1ae263394b11a8> .
+
+<http://data.lblod.info/id/bestuursorganen/0ce64317e66e60110311d9d1ba8459f2ba0cfd31ebbc7d1c9830cb0556bc0379> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "0ce64317e66e60110311d9d1ba8459f2ba0cfd31ebbc7d1c9830cb0556bc0379" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/a20c5acfd21334c1b82d78888d913ef16609606a2d3d19257fc5182f9f6df6cb> .
+
+<http://data.lblod.info/id/bestuursorganen/10908991ea478d09631d38c7489f843deeda74f92d40d9c06c997d7fa71e6b0f> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "10908991ea478d09631d38c7489f843deeda74f92d40d9c06c997d7fa71e6b0f" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/e67a3e7f21dece7b29f9ee0ee5414f3f2d17cf931b0beaf7d50d3f381f50dc92> .
+
+<http://data.lblod.info/id/bestuursorganen/15e5c6128e8b54b5776290b90f055f7e1148a9e550dddbcd576650d008b5c587> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "15e5c6128e8b54b5776290b90f055f7e1148a9e550dddbcd576650d008b5c587" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/dd70da7c5ce9d89360ad524dca8351df7089d466577acac0bb4148a631d52c9d> .
+
+<http://data.lblod.info/id/bestuursorganen/16ddb0c854ddbdde4850f5209c43d774df4540fe6d7916d270752ec4cdd38c37> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "16ddb0c854ddbdde4850f5209c43d774df4540fe6d7916d270752ec4cdd38c37" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/9f532e59a3250a39ec638593724303f00766acb9a8451c67c74eb7ef8cc417c8> .
+
+<http://data.lblod.info/id/bestuursorganen/16fb048ae778dd8ffa1a7b05eecfd414853cc66a4d33af9acf7002eac1075994> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "16fb048ae778dd8ffa1a7b05eecfd414853cc66a4d33af9acf7002eac1075994" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/71b56a20685680191b2926df026b4f0d4e3783ad914a7ffeeff3c038ed61f1f5> .
+
+<http://data.lblod.info/id/bestuursorganen/199a9dfff6197b14c38ae7d4778d4ff975c6bab3bf6306db91b2add057d4f623> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "199a9dfff6197b14c38ae7d4778d4ff975c6bab3bf6306db91b2add057d4f623" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/ac99fb29603859cfbe1613ed9c0b8c2216a9ef86749225795a141e7cf09c71f8> .
+
+<http://data.lblod.info/id/bestuursorganen/1a4b1c43b9619ea7262e3938ce6105e18c6f5f5fbc193cebcaa8eb552c5a7eeb> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "1a4b1c43b9619ea7262e3938ce6105e18c6f5f5fbc193cebcaa8eb552c5a7eeb" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/3539915d9303229e6e9d178499431c08499afed4bd03b80af86bf92adac7425a> .
+
+<http://data.lblod.info/id/bestuursorganen/1d1291d6c6af383ecd0ff0339e5312da9c3d1d8c91c103199f7e232910265e19> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "1d1291d6c6af383ecd0ff0339e5312da9c3d1d8c91c103199f7e232910265e19" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/9c2e36ea480ca2a0ea41ab119b1c7921a31428aebf29bde2d59ee6b5c5a56d87> .
+
+<http://data.lblod.info/id/bestuursorganen/1ec1c99eba448f51fc0f3e11c3335ab6153934aa62baf5aa6e2ff837a4491f59> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "1ec1c99eba448f51fc0f3e11c3335ab6153934aa62baf5aa6e2ff837a4491f59" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/b0bc13326e46496e51232f0d0c3e9bb7f17fe9d1b15c1941961676328c884591> .
+
+<http://data.lblod.info/id/bestuursorganen/1ef2a30e0c114aa94c058e071a4c4bd4b65d3dbcbce26d01e39f1d97dce12b7b> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "1ef2a30e0c114aa94c058e071a4c4bd4b65d3dbcbce26d01e39f1d97dce12b7b" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/0264941d3fa9def69cf7bd61f98087911ada1dc46d7c55ae4427d98b04e7f56d> .
+
+<http://data.lblod.info/id/bestuursorganen/21bd05fd722f8eb3115b9b14f918355722bc7a3e37251b2c6beec9c02785e6f5> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "21bd05fd722f8eb3115b9b14f918355722bc7a3e37251b2c6beec9c02785e6f5" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/7ac3312ad5d3fca9f72841899f31613a547adf28a170483b0f139c1011af0147> .
+
+<http://data.lblod.info/id/bestuursorganen/2231dab7f916e0b02e1b542ab9efc35e47b656c0fffc3874cc555993325f539d> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "2231dab7f916e0b02e1b542ab9efc35e47b656c0fffc3874cc555993325f539d" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/1b2ca21f9ecbd86c0b40f620bfbf5369c09c74934f62f2bddfff1aaa902f5624> .
+
+<http://data.lblod.info/id/bestuursorganen/228500b66f7c3f74deba2b4769517aad17e4e2dbee486becc10fcbeb2957f10c> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "228500b66f7c3f74deba2b4769517aad17e4e2dbee486becc10fcbeb2957f10c" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/404211a388065f93cf963479ebd82c8b1c322322a1268586f82cd5139fd66b65> .
+
+<http://data.lblod.info/id/bestuursorganen/22eb1f33dfc936bfd624ca207c68d87c7a8becb61e07c9a2a244169286fa8f49> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "22eb1f33dfc936bfd624ca207c68d87c7a8becb61e07c9a2a244169286fa8f49" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/507a094c51995bc6963861872b45024125aa631cfd733b7266fabbcb3b2cd1fb> .
+
+<http://data.lblod.info/id/bestuursorganen/24c8bd1cf9c3b310c748a87511841b2067c4930e80472849824ce190a410a9b3> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "24c8bd1cf9c3b310c748a87511841b2067c4930e80472849824ce190a410a9b3" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/004b987f2b84e3aca78d5e03fba1c76656c4daa206486320ef786cd917ef40fb> .
+
+<http://data.lblod.info/id/bestuursorganen/26b29bd577f24a551f8d3ab51a4b4d3e49d9d1573b0f501db1ef5a843d96b401> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "26b29bd577f24a551f8d3ab51a4b4d3e49d9d1573b0f501db1ef5a843d96b401" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/51ca586d220ada4e87b51545d1521844006911705581b8da99658471fd357cb0> .
+
+<http://data.lblod.info/id/bestuursorganen/280f83dd5ae5e09983c05b8a83757b93d8206baadf6eb952dae516fde79ce370> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "280f83dd5ae5e09983c05b8a83757b93d8206baadf6eb952dae516fde79ce370" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/b0c3e6a188884d1a81e2b657efb2dc852218f23051d0a9b416ecabbcb3feec0a> .
+
+<http://data.lblod.info/id/bestuursorganen/281c620f04284875d196e877dcb2b431b6ba84c8469f2dd1f0d4a99d54bb3905> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "281c620f04284875d196e877dcb2b431b6ba84c8469f2dd1f0d4a99d54bb3905" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/e1737a57a865e2f0140136f68d9a44dab686277b79ca997ef27f6d23b9efc4c5> .
+
+<http://data.lblod.info/id/bestuursorganen/2ad894f92b585aa0e86e7e1378996e8270c94bb2caf8ddec3982f15e928717df> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "2ad894f92b585aa0e86e7e1378996e8270c94bb2caf8ddec3982f15e928717df" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/a64d98e6fbb024936acca5a9bf08adf89cd6ece4eb7c74e2de2a50218283d773> .
+
+<http://data.lblod.info/id/bestuursorganen/2ec55541d22ae866bc196bed74f21d0d7f7394128552786d3e1317b52309f29a> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "2ec55541d22ae866bc196bed74f21d0d7f7394128552786d3e1317b52309f29a" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/ad9954198d1e28df6a09568605dff85cd3a14339b765157839aa4b721497cd72> .
+
+<http://data.lblod.info/id/bestuursorganen/2f2473b42832f611c4039d3153105ec1a08389940e62ae0b8338d7929f6d3c63> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "2f2473b42832f611c4039d3153105ec1a08389940e62ae0b8338d7929f6d3c63" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/8fa0b4e410ca016fdb944c37978f9ee112fe6ad70eed1e1fde9a7aad31ea03f8> .
+
+<http://data.lblod.info/id/bestuursorganen/35cda722358ce2a96fb1117f895aeea7e9d36604a73402ed95a89167de03709f> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "35cda722358ce2a96fb1117f895aeea7e9d36604a73402ed95a89167de03709f" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/2b2bf786c8dc07a9ee59a1bf6170ecaaebf6c67baee55c8677149e6d54fac759> .
+
+<http://data.lblod.info/id/bestuursorganen/3ac6cbf0b47515b41cdc97b2d8f7b107d335a96b4e2b553f2d4e048ab313d6c3> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "3ac6cbf0b47515b41cdc97b2d8f7b107d335a96b4e2b553f2d4e048ab313d6c3" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/41fd4bf87df07ff3cb1f697a68f240b1464c735cf0d49e1b0f98f7d698753b5f> .
+
+<http://data.lblod.info/id/bestuursorganen/3b8127d1a3c6c0a88ff5a343996af7ef501338c5dcd70b00f23a83d550bebc09> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "3b8127d1a3c6c0a88ff5a343996af7ef501338c5dcd70b00f23a83d550bebc09" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/cfce8c6db32a54a3624966bb828a392ecc778931b47afdac5cbe498d47d63d62> .
+
+<http://data.lblod.info/id/bestuursorganen/3d0a685178f54a54d585de7dbc22c735158cd94c69da7af5dc11ad57751560da> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "3d0a685178f54a54d585de7dbc22c735158cd94c69da7af5dc11ad57751560da" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/7aee63f3ec64c6e55b3f5c4c23397926d7c1e61ec8e652ddd306709e777f7d26> .
+
+<http://data.lblod.info/id/bestuursorganen/3e27d8a3c8abad9560f943c369bbb08a53f25d6b2cfb98ab4144572b3272a46f> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "3e27d8a3c8abad9560f943c369bbb08a53f25d6b2cfb98ab4144572b3272a46f" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/9593e8a4472b19cbadbf8c97cc6c4b9dd93b3534fe2d74ea59fdd432ccfe90f6> .
+
+<http://data.lblod.info/id/bestuursorganen/3ee7157e5ec009f665479d973db36ab0337eb767a2c9f76da507da09d4680dff> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "3ee7157e5ec009f665479d973db36ab0337eb767a2c9f76da507da09d4680dff" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/f67ce180da03b62f5a7e77e801eeb2c01182f8968922e27500beee76b51c659d> .
+
+<http://data.lblod.info/id/bestuursorganen/3ef452398a9fa6e7e1bedd79e9815fccffb666c3eaed62abd637aeedccbd87da> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "3ef452398a9fa6e7e1bedd79e9815fccffb666c3eaed62abd637aeedccbd87da" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/2c264a56e7cdaac776517d8162c8fc0c02a0ef22cd1e9b5a51d8e13f56073aa0> .
+
+<http://data.lblod.info/id/bestuursorganen/3ef90354f5bd6abb6a52b20a383791e46fa81aada82390f21e5b0807e3e980bc> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "3ef90354f5bd6abb6a52b20a383791e46fa81aada82390f21e5b0807e3e980bc" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/3b4188f6e3ac8959cb305c1063d9371f67b3b231173c0dbea27620bba30878bd> .
+
+<http://data.lblod.info/id/bestuursorganen/3f45cf66a149651ce50a1eddb97064488d03cd41f2e94e354b7f08bd045b15a8> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "3f45cf66a149651ce50a1eddb97064488d03cd41f2e94e354b7f08bd045b15a8" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/7339599327f9e9f2e4343765481362b230c40cdf3fc557c94ad8ac0272754b91> .
+
+<http://data.lblod.info/id/bestuursorganen/40a0760639766a69b087e4198ac7b5b10eefa9f2c880979ceb4777b7f199d404> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "40a0760639766a69b087e4198ac7b5b10eefa9f2c880979ceb4777b7f199d404" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/4b51012e90f99de11e64330e37243fa137517d0f2dab74f4a3f1dbc71ebbdba8> .
+
+<http://data.lblod.info/id/bestuursorganen/4143d41e612cc448f83518827cc4d9dd44e22e68c4e0aabf4befa2f456bccf61> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "4143d41e612cc448f83518827cc4d9dd44e22e68c4e0aabf4befa2f456bccf61" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/a36c7aa67ce72f21c3f30cb6d70b0ab4000452ad5a266a7da3a018c906278c95> .
+
+<http://data.lblod.info/id/bestuursorganen/433ec84ce031a421645c5eb37924fb776dab4aeac3a1d54cdaaf65ff85fe55f4> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "433ec84ce031a421645c5eb37924fb776dab4aeac3a1d54cdaaf65ff85fe55f4" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/7adc5c6e3eb50c334f24db19778c27133ecb306c544b6751b1d1012bad479f76> .
+
+<http://data.lblod.info/id/bestuursorganen/46232c3816fa7d6cdbb52d773f864ec57905d18073ea469ba45f30cb62eb8df4> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "46232c3816fa7d6cdbb52d773f864ec57905d18073ea469ba45f30cb62eb8df4" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/1e2f978c307054084fcdedf5c4be33ab69bbdf9dd35acc68642e47ddac631557> .
+
+<http://data.lblod.info/id/bestuursorganen/47b7d7d23304b0d9f835151eb6445548d4cf2372031cc13edd741383b7c17a4f> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "47b7d7d23304b0d9f835151eb6445548d4cf2372031cc13edd741383b7c17a4f" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/d23fcee888e47314beee898cec76eca886c07d0413c792718b608d366c0480d1> .
+
+<http://data.lblod.info/id/bestuursorganen/4a0cf8d6cdf6c8a896242b3911800868b95a7595c1d5a50446fe776a5f32e770> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "4a0cf8d6cdf6c8a896242b3911800868b95a7595c1d5a50446fe776a5f32e770" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/d07bdcbb9b05dada8889e5ff93c429c09e537537936cd2ae59a4bee33c07a4d9> .
+
+<http://data.lblod.info/id/bestuursorganen/4a2cd05a-e196-40d7-bef0-649bbf1becd7> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "4a2cd05a-e196-40d7-bef0-649bbf1becd7" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/d0537227-526a-4207-bdf2-73c8b429bf87> .
+
+<http://data.lblod.info/id/bestuursorganen/4a565ab1d849f51474ba8bdfa5481a2c9e92c63e84053b133f5dc2c0e0ffaee8> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "4a565ab1d849f51474ba8bdfa5481a2c9e92c63e84053b133f5dc2c0e0ffaee8" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/a6e70030d8819bb7b66cceeef854db6f883db23e3abf27adb1c61884f6d9db92> .
+
+<http://data.lblod.info/id/bestuursorganen/4b6e9286a36035c0eb3cf9e5608d9b7595dc3bd69af6378db1ac1f63d64236a2> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "4b6e9286a36035c0eb3cf9e5608d9b7595dc3bd69af6378db1ac1f63d64236a2" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/0935eb02a30042b77a03353ba0b546fe64ef129d57eb4b23b511d3da36aef921> .
+
+<http://data.lblod.info/id/bestuursorganen/4d55fc00a723a3275b012841a17cd598f987f081edcfb5329bd2f58f2c0daaec> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "4d55fc00a723a3275b012841a17cd598f987f081edcfb5329bd2f58f2c0daaec" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/968a33b1e856d58ddaf843e6db9829450b21be0f05dde0f7a91caec338282a3c> .
+
+<http://data.lblod.info/id/bestuursorganen/4fb36164a0697d7a022c3beb679a10bd2bde62597afc995ab9ee2f3f72c21d93> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "4fb36164a0697d7a022c3beb679a10bd2bde62597afc995ab9ee2f3f72c21d93" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/3f4a8a4e95eb1811a283ff327fa17b24199e60a125cb543244dfd407a89502c0> .
+
+<http://data.lblod.info/id/bestuursorganen/501357b4f2cd350e7e0c7ac39458a6e3747f77b30b4c844321f74d635ec64c08> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "501357b4f2cd350e7e0c7ac39458a6e3747f77b30b4c844321f74d635ec64c08" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/9fbfc20d279f6eb9434c7edfc75814827a3fb2316b7dccd6d7b74a46b3081ac2> .
+
+<http://data.lblod.info/id/bestuursorganen/503573c5e689df055490fd9e7c77a8b917706775451137ef6cb9a29214ca19b8> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "503573c5e689df055490fd9e7c77a8b917706775451137ef6cb9a29214ca19b8" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/0945a9bf1486486617901058b957936d5f9a79d7dfce12404a8bc4437674eadd> .
+
+<http://data.lblod.info/id/bestuursorganen/50a59b7522db9183cb6293108ceb847e871dc8769ee0a270dd17acd76a94fd22> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "50a59b7522db9183cb6293108ceb847e871dc8769ee0a270dd17acd76a94fd22" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/e53cacd32b83cf8dc141da4198b0a01ca7b6cb224ab8b11b0ca437de6412df3e> .
+
+<http://data.lblod.info/id/bestuursorganen/512635ccc5b9093b08e080309df14e382ae084bafa6bd15867dace8a6e264eaf> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "512635ccc5b9093b08e080309df14e382ae084bafa6bd15867dace8a6e264eaf" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/89453c0cf3385de05258a703220298a0e9d75dd2252beb14edb0f025188ee960> .
+
+<http://data.lblod.info/id/bestuursorganen/52dcacab0e85af03c6fd49f65ed7c07d93c22c2fd12252673ff385aff315697a> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "52dcacab0e85af03c6fd49f65ed7c07d93c22c2fd12252673ff385aff315697a" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/ab33eab78f0ac966f60f266c4263de35ebbc26a94ca210bf48bbf25127453950> .
+
+<http://data.lblod.info/id/bestuursorganen/541b51f13f2c4e16243b5fc3d3a225d023a18916a3ed7cb9b1461ce870078af6> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "541b51f13f2c4e16243b5fc3d3a225d023a18916a3ed7cb9b1461ce870078af6" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/c6d47f5cad3ec5e6dcb2d1b80d7ea0fdf5a69ebe96960937d0cf132f0cfbfab2> .
+
+<http://data.lblod.info/id/bestuursorganen/5469778ff6c981eef7444672559e1f22908c92fe6607d2fcd1606276deaf536a> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "5469778ff6c981eef7444672559e1f22908c92fe6607d2fcd1606276deaf536a" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/ce89601ffc39063e9ad5c12ba4f48bcc08abac984770b835a559b2e1ab19de94> .
+
+<http://data.lblod.info/id/bestuursorganen/57cc71755a226e55a881e36d37b56d1a4642c8b94067e21be9f3971673862b17> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "57cc71755a226e55a881e36d37b56d1a4642c8b94067e21be9f3971673862b17" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/12d6dd992c699c1229532d2dbfe600502a2dc42577095ce835b4824037655301> .
+
+<http://data.lblod.info/id/bestuursorganen/58ece82eaf48a488e169ffbc6dbb20f2babba2873d4a73bdd3e0cf5685303689> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "58ece82eaf48a488e169ffbc6dbb20f2babba2873d4a73bdd3e0cf5685303689" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/4996e6041d12eafb2487012c627351f6d9056bbc3727aa21928fb6f400b21b55> .
+
+<http://data.lblod.info/id/bestuursorganen/5adf874a0f9eb09739b53306aeb79c58b8fca4e9e8f3cb384fb6e49c99e2ff4c> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "5adf874a0f9eb09739b53306aeb79c58b8fca4e9e8f3cb384fb6e49c99e2ff4c" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/40e0181b3b8f67b85087032373a067e2fdade2971c062fbd3b342548377fff74> .
+
+<http://data.lblod.info/id/bestuursorganen/5b7724c1baa75bb411d1fe5bf58051d13d756b709e85332f43b6e3300c36451e> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "5b7724c1baa75bb411d1fe5bf58051d13d756b709e85332f43b6e3300c36451e" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/4253826e1f8aa01e9d6700e0444b7bbcf6f4bdea53f2d48264327d0f1f59502f> .
+
+<http://data.lblod.info/id/bestuursorganen/5b827430bae051c6f83b4efec104c5bb6e73bd8e70bdd4f10a2dff46956297ad> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "5b827430bae051c6f83b4efec104c5bb6e73bd8e70bdd4f10a2dff46956297ad" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/a8572ab7614eb52a85fabd156f43eeed3b8bbad0e3f8dde37bde612c20aff8db> .
+
+<http://data.lblod.info/id/bestuursorganen/60961812795c94bfb4bead9bdc4d20bd4223772509db294e5b5252e15ab5be72> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "60961812795c94bfb4bead9bdc4d20bd4223772509db294e5b5252e15ab5be72" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/c4cfb722c3a4ba20cba22164bc7597340c1c9b1913514ef0ba98f5e61ce38c93> .
+
+<http://data.lblod.info/id/bestuursorganen/60a885b00850e1a54b3f07a7e86322358cec351a44333ede2654da0c0f1a0a5d> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "60a885b00850e1a54b3f07a7e86322358cec351a44333ede2654da0c0f1a0a5d" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/3cedfab88e82ad5a694f2628b81966a3d40b1dfba13c0c02f33d0ef877e14254> .
+
+<http://data.lblod.info/id/bestuursorganen/6152f1c958c62348de94f43da72bb0cae8f1ff71d876bb91e701646520a89060> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "6152f1c958c62348de94f43da72bb0cae8f1ff71d876bb91e701646520a89060" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/1754b3b92f34e1ec5edd8a92cb62185b087f9a19f4a30634152c92c3f66a10b6> .
+
+<http://data.lblod.info/id/bestuursorganen/65c586595e7e4927512f691972d504a1d2bdf8775f046fc9b70e5cc8dfc98cb2> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "65c586595e7e4927512f691972d504a1d2bdf8775f046fc9b70e5cc8dfc98cb2" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/65a8794da5b83d35831749f2cfa9801d3d586cbdf0dfb1252165d21f8daaabea> .
+
+<http://data.lblod.info/id/bestuursorganen/667ba9aa12c96d3c74d35ff0b2710c7a3258980830694f510036f12aa69e2ad0> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "667ba9aa12c96d3c74d35ff0b2710c7a3258980830694f510036f12aa69e2ad0" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/aa54f465bcad51fc5a644c4aeda21179021a786c6f148d497f56ca9d398986ec> .
+
+<http://data.lblod.info/id/bestuursorganen/66a035311fc80a0d321221dd19e412536b1e2b5e3f476cc58d40c54054592a50> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "66a035311fc80a0d321221dd19e412536b1e2b5e3f476cc58d40c54054592a50" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/7881c32d87abf297f1dc67539cec5c591ebf575d5ef9d07fc90ed4b80c6c1089> .
+
+<http://data.lblod.info/id/bestuursorganen/67f344046b93e7219c5a78b3b23442f39469b23b16eb55493028c6a206f75123> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "67f344046b93e7219c5a78b3b23442f39469b23b16eb55493028c6a206f75123" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/3a22c1079e1d82d832ba4209590adbb910f0a4dea29ecf4900eeeaf0eaf2023e> .
+
+<http://data.lblod.info/id/bestuursorganen/68ade0f1ff92bcb10a033c6ec34bc2d0679272de18a6cb33ea088cb228b8b541> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "68ade0f1ff92bcb10a033c6ec34bc2d0679272de18a6cb33ea088cb228b8b541" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/4fa94fc5d0edc7ed240afe744203039fba6f54d3419ab4b1ce3883f63e9a074e> .
+
+<http://data.lblod.info/id/bestuursorganen/6eab34c28c0119edd95d4f97483182958d19fe93cf5dc8d8afe8708f48da8e6c> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "6eab34c28c0119edd95d4f97483182958d19fe93cf5dc8d8afe8708f48da8e6c" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/d3a9b2bff1eb0652e49bf1592a054a6b1d6e20bb8289f49d2b3af53e48e01965> .
+
+<http://data.lblod.info/id/bestuursorganen/71af261f-3e21-474c-864b-9e65f9d2f918> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "71af261f-3e21-474c-864b-9e65f9d2f918" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/17d1ecc1-e882-4dd1-9c72-419cb9dbce4a> .
+
+<http://data.lblod.info/id/bestuursorganen/71ef8f2bce0f44c14f46158614d7a4f7fc022d0cd637d11cd4ef32d94a838457> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "71ef8f2bce0f44c14f46158614d7a4f7fc022d0cd637d11cd4ef32d94a838457" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/3f2c09c994b9153ae8af1cccbe4646558679f26f446b1aa848d1cd8c54f32b89> .
+
+<http://data.lblod.info/id/bestuursorganen/74d76770e35df5315321ddf22fd3088d057795c64b198b934e432951e43868db> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "74d76770e35df5315321ddf22fd3088d057795c64b198b934e432951e43868db" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/88e23bccae1f08fddcc8ca1982bff6946d0696fe9090dc1eacdbe68023d91c8d> .
+
+<http://data.lblod.info/id/bestuursorganen/766801e870ff9ab2820dfb947c6684959e6588b8b89ead2268ff2a98f87d93f4> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "766801e870ff9ab2820dfb947c6684959e6588b8b89ead2268ff2a98f87d93f4" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/bf33e5da250eea04c3dcbd657a3cbed1d91d99478cc8c30795bf9ed2e7f1b451> .
+
+<http://data.lblod.info/id/bestuursorganen/77fb785871808a477915b934d8ecd251f02169dda616e54304e441d2802b605a> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "77fb785871808a477915b934d8ecd251f02169dda616e54304e441d2802b605a" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/0cf860c877d526d6bd27bac991627e03e2178581f76f3ee7684bfcf8c00f8312> .
+
+<http://data.lblod.info/id/bestuursorganen/790000e1c2579a209e7f855fef8d8210418b7fd50daaaaf3044f67f3c143146a> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "790000e1c2579a209e7f855fef8d8210418b7fd50daaaaf3044f67f3c143146a" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/29a196a3af4194ae03dfacdfd783b5ec4931448185a12c858e5715ac766db579> .
+
+<http://data.lblod.info/id/bestuursorganen/795b27019a2a936e25fe66c26598f8a5220220571fbb4aa59c96d6821a5d1706> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "795b27019a2a936e25fe66c26598f8a5220220571fbb4aa59c96d6821a5d1706" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/34eef1f5170f387676229e79cc2486446f7607b1ed928d0cd62d81feaccf2924> .
+
+<http://data.lblod.info/id/bestuursorganen/796a07f6524aae6f2d9e89a9c16e23cf2d664f216e293b0ce37352c8deae9175> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "796a07f6524aae6f2d9e89a9c16e23cf2d664f216e293b0ce37352c8deae9175" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/55005ebf67b2f2c48ae5e3473eeb06d7fc61c3a4e62405ab8c9bb774bd9a6ac7> .
+
+<http://data.lblod.info/id/bestuursorganen/7e3cd4c8156bfd4bf889b07a5a6b26f8eddb268244d94b78774a9eb79c272c51> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "7e3cd4c8156bfd4bf889b07a5a6b26f8eddb268244d94b78774a9eb79c272c51" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/02e41f1ee0b643ee75ec9ee4f09b09b44ba720521dd0ccc2b68ce9e5c58f945a> .
+
+<http://data.lblod.info/id/bestuursorganen/7fc0da51854e937115aec258f5f13510701fe06cd073d91f852d89f5e45ebe20> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "7fc0da51854e937115aec258f5f13510701fe06cd073d91f852d89f5e45ebe20" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/422b28a3193cd2a0e656c96c3d003883909d52e828e5abb2235d31e957defe4f> .
+
+<http://data.lblod.info/id/bestuursorganen/82116c91d58b30e0607f02fac3f12758cb454ac51438a28336f5202c5e705198> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "82116c91d58b30e0607f02fac3f12758cb454ac51438a28336f5202c5e705198" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/dd5a962f3e6aff1e164db672a8131610846bd7aaffe152d5c08b02c15f097011> .
+
+<http://data.lblod.info/id/bestuursorganen/841cc8c784717dd7d9146700fd73337673cc5bef0e4423269e0440362a272881> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "841cc8c784717dd7d9146700fd73337673cc5bef0e4423269e0440362a272881" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/b56f7e3603c0883b4a154efb32f1db15fc73ea475fe4057bbfad4b5fefba66bc> .
+
+<http://data.lblod.info/id/bestuursorganen/841ee84caad500e27dcf2a3649ee215aab2dc369819247860279b21a96e186ec> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "841ee84caad500e27dcf2a3649ee215aab2dc369819247860279b21a96e186ec" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/758ff2bb253ba40d70a4a62da94322a00f67e55d0fb7f921ff83b782f3deba64> .
+
+<http://data.lblod.info/id/bestuursorganen/8568ac8a6d5a6a13de4505b4ede22c1c0824f7bd919f83b5d6be33aebfee5c46> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "8568ac8a6d5a6a13de4505b4ede22c1c0824f7bd919f83b5d6be33aebfee5c46" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/08c77182a1b66166f8ffcaa4ac4903cd66d8c10ad587c058b6e229070a7159a4> .
+
+<http://data.lblod.info/id/bestuursorganen/863606f3329717683f1caeaef02dce20816c6af48ec2f0d26078c9b91c05d463> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "863606f3329717683f1caeaef02dce20816c6af48ec2f0d26078c9b91c05d463" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/b2fb65f57be7f634463ecd414b87e8ccc512646c679b8d2b30260f0a881413fc> .
+
+<http://data.lblod.info/id/bestuursorganen/89f00011afac5cc84e866e6546c5a4aa125052f8e28f34a2dbe25739620ee313> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "89f00011afac5cc84e866e6546c5a4aa125052f8e28f34a2dbe25739620ee313" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/541b806a3c4045c5f81edcb4c25200d2fce9e7b692ef6083ee118604d1ddb011> .
+
+<http://data.lblod.info/id/bestuursorganen/8d158b6b839c730601220047cf6c913e039bf4df91d44d6af711b0d72fb0aaa5> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "8d158b6b839c730601220047cf6c913e039bf4df91d44d6af711b0d72fb0aaa5" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/26133b05ed497e1947dec9db08433fe4d23f69ff212e73bbe20934fe0c866ba4> .
+
+<http://data.lblod.info/id/bestuursorganen/8d26559602b7901f1d5a7a053723be23a600c7c0af72221c1bfaf93a7966983d> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "8d26559602b7901f1d5a7a053723be23a600c7c0af72221c1bfaf93a7966983d" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/38f52872be00c52972eda82ed35f738b9a4e30e407d31712cbe2188d77341d10> .
+
+<http://data.lblod.info/id/bestuursorganen/8dd9da4b298ef3e18f9d332ba28de96be7c585652c7f7256f8a48644e97285bd> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "8dd9da4b298ef3e18f9d332ba28de96be7c585652c7f7256f8a48644e97285bd" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/bb72a29ac24ac0a56df9164c8d6cf249edd45ab79b02c5b12a2492b1eae2f216> .
+
+<http://data.lblod.info/id/bestuursorganen/900d2edfb751115f0f0533c40d12295da8895c5f9c419e89ccec46d44ed11982> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "900d2edfb751115f0f0533c40d12295da8895c5f9c419e89ccec46d44ed11982" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/5381222906f03160eff7fd29b40bbfd32a02a79dc9e9fcdcf55a87346212509b> .
+
+<http://data.lblod.info/id/bestuursorganen/954f89cd5fd273a079a7341386355d06f0044b177daaa2c29482f1ce02aa53a2> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "954f89cd5fd273a079a7341386355d06f0044b177daaa2c29482f1ce02aa53a2" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/ab5e6e3b4a0e4c66047c8968d5326bf72ab4fba2ccbaf7ecd71a1d94892d651f> .
+
+<http://data.lblod.info/id/bestuursorganen/964600b2cd30e7593dcd6f5f9d12fd7867ab59d8babf0ba0f79c0e4fbc328f58> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "964600b2cd30e7593dcd6f5f9d12fd7867ab59d8babf0ba0f79c0e4fbc328f58" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/c029d98db12366b386c5699466a2e6c7ff6df25e3d9233a1d04c368b204eff9d> .
+
+<http://data.lblod.info/id/bestuursorganen/9c01c8ba9e036328f255fe0fc00680a2c9e4832edda0b350e6f8619a291ec5f5> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "9c01c8ba9e036328f255fe0fc00680a2c9e4832edda0b350e6f8619a291ec5f5" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/f33df35271289024049289d3fd0f84a907b9d6266ccbc84b9eec1ece5aa39f30> .
+
+<http://data.lblod.info/id/bestuursorganen/9e7f75b13c168402d8e03c07e73199fd60548fbddad6110bf66f1dca4c7fe593> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "9e7f75b13c168402d8e03c07e73199fd60548fbddad6110bf66f1dca4c7fe593" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/747267050b26f1ed68f3976a31f00bd3bcf623bab12041517f2fcf52663e131f> .
+
+<http://data.lblod.info/id/bestuursorganen/a1527187-bfa1-4437-8f20-1784973f2ab4> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "a1527187-bfa1-4437-8f20-1784973f2ab4" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/4f68440b-432f-41be-a29a-d1344ba3bab4> .
+
+<http://data.lblod.info/id/bestuursorganen/a39bb26ed9f8e2b98e52b221175b556ba993b29e8bc40d9d1b135254095a70d0> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "a39bb26ed9f8e2b98e52b221175b556ba993b29e8bc40d9d1b135254095a70d0" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/187722a4ab2900cf7670f6c836bef6e154be17718a8d3ce13fc367d5523ca11b> .
+
+<http://data.lblod.info/id/bestuursorganen/a4326c991ceb01ec365851a4cab7177abd7ff1f99498f2d6a20af34e411a076c> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "a4326c991ceb01ec365851a4cab7177abd7ff1f99498f2d6a20af34e411a076c" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/4674408ed3bea722e6b4553f5b53c9aa06805bc625dc949607b25be7967ec351> .
+
+<http://data.lblod.info/id/bestuursorganen/a4d418ef259948c0019cc7ca4d96c7f80216cc7dac55fe349cd3bbb91dd28eff> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "a4d418ef259948c0019cc7ca4d96c7f80216cc7dac55fe349cd3bbb91dd28eff" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/a76403fa66a665feae46be0fb2b1dd28702a63e70780e7034d265a0679a113c7> .
+
+<http://data.lblod.info/id/bestuursorganen/ab1e3bf45ed06ecef3c5f455b74a3f493936e96ffee0ffd313dfe7a94d6d937e> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "ab1e3bf45ed06ecef3c5f455b74a3f493936e96ffee0ffd313dfe7a94d6d937e" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/b7b67e8a09ac43ecf65485c89c219b5d501ebb4790dcc05ea5603dbd8ac15678> .
+
+<http://data.lblod.info/id/bestuursorganen/ab45101ab5fdb2cbdd148ddc71e5b63d41f592cab7b2cce5629683579435c21b> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "ab45101ab5fdb2cbdd148ddc71e5b63d41f592cab7b2cce5629683579435c21b" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/4c182202196da6c3c4c8ac48799ef1a4716eb6f7b314c50df6b5b43ac2d86adf> .
+
+<http://data.lblod.info/id/bestuursorganen/aecf1c45c72c5dc29ff0e57525b039da1072242078269b17cfe6de826e768de4> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "aecf1c45c72c5dc29ff0e57525b039da1072242078269b17cfe6de826e768de4" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/b7d3654a54cc34984824a41bcc328c283008962389d5247702170cf207443f4c> .
+
+<http://data.lblod.info/id/bestuursorganen/b18df1766c19867bfbf466512fbb3e0fdc6ece9896c3d41253ae090428b26b28> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "b18df1766c19867bfbf466512fbb3e0fdc6ece9896c3d41253ae090428b26b28" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/5630c479e87a659fb90e8de670e01be62e79af57aee3c5c15f08b971412a2116> .
+
+<http://data.lblod.info/id/bestuursorganen/b1d7fc58360db8e54b4cac7e7130657c7ab7b0343a09d8925a53102cf468044d> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "b1d7fc58360db8e54b4cac7e7130657c7ab7b0343a09d8925a53102cf468044d" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/da092eb82f28e5b9a8ad46e07a685d3933ea02aabb9a74ea16e82b6926e620bc> .
+
+<http://data.lblod.info/id/bestuursorganen/b39c133f7ac7eb88ace5f3629b279e0ad43d2f88c31b9074f4719d5ac0f00184> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "b39c133f7ac7eb88ace5f3629b279e0ad43d2f88c31b9074f4719d5ac0f00184" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/b96b772e0f64eb4c56501da6d968fdc8b6dfaa88b15160aa312f5dffb7dfd598> .
+
+<http://data.lblod.info/id/bestuursorganen/b3ba737dcd31105971c11ec6d230bb3a383f3610c3c1172d8dda06a98987e7fa> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "b3ba737dcd31105971c11ec6d230bb3a383f3610c3c1172d8dda06a98987e7fa" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/06b24bc1d86fdf607eb16266e47d3e9c6c0c1d900eaa07501626e61f12e9c7dc> .
+
+<http://data.lblod.info/id/bestuursorganen/b5d378ab47f57f75c5429305da3deb673e1d57360c6097c702f76efe0cbd0b9c> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "b5d378ab47f57f75c5429305da3deb673e1d57360c6097c702f76efe0cbd0b9c" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/ad44799fe1887c1bf17259bcb799085d7e5c0c48ac941bd07451c83e2c4d3514> .
+
+<http://data.lblod.info/id/bestuursorganen/bc160a57c7ecd8957902dd01b9b225afa03d7c287ec6e4ecb1cd0d45aa642304> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "bc160a57c7ecd8957902dd01b9b225afa03d7c287ec6e4ecb1cd0d45aa642304" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/32e6367265dddd8b602418bd0a3fcdade33245036b8042cd20aa9688c3abf3e4> .
+
+<http://data.lblod.info/id/bestuursorganen/bca2b5d9b2181a4277cf1585fec5844a3d6b7a578a506fccbb582a32a322033e> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "bca2b5d9b2181a4277cf1585fec5844a3d6b7a578a506fccbb582a32a322033e" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/e45525033ffa6011bc3564afe993eccc94e237daa1b3cd78dec8ecc5c9a30cc2> .
+
+<http://data.lblod.info/id/bestuursorganen/bdab4bc6256448bd3b6fa4f918cffa6c2e63b1bd19d8086acda257235ca1a0f6> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "bdab4bc6256448bd3b6fa4f918cffa6c2e63b1bd19d8086acda257235ca1a0f6" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/7e3cbc1cae3d258a31c15541262cbe1b90dc5bc7cf9029d92451abe503b27333> .
+
+<http://data.lblod.info/id/bestuursorganen/be2bcdd9fc6d3fe2be5a1ba3f9d9aaab5b33b25985b0784ac6f497251fe75de5> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "be2bcdd9fc6d3fe2be5a1ba3f9d9aaab5b33b25985b0784ac6f497251fe75de5" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/ad298537d9846fce67445cb41e21c367b1073432228e4af76c9f6a9a0f4000f3> .
+
+<http://data.lblod.info/id/bestuursorganen/be32f9a8b9c0adb569365d4d8b6fa46ecf2031cdd651a5d2b2211eed1025a80f> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "be32f9a8b9c0adb569365d4d8b6fa46ecf2031cdd651a5d2b2211eed1025a80f" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/e53aba91d448d36d34599d43f00c9b1b25df34ba0cfdfb4504a8633bcdd0aa7e> .
+
+<http://data.lblod.info/id/bestuursorganen/be81440eebbcb5d7875f5c925ba45cca81b9740f895365132d9b9b094ddfd55c> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "be81440eebbcb5d7875f5c925ba45cca81b9740f895365132d9b9b094ddfd55c" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/2e4a5825d4b64ae25ef6d7ad3905b05321d07df2ce6bd3758596d5b9d0ee8e59> .
+
+<http://data.lblod.info/id/bestuursorganen/bf11dce2bad398d8be131e1225e5f5eed5a416f7ad6768e684b60ed3b00fd684> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "bf11dce2bad398d8be131e1225e5f5eed5a416f7ad6768e684b60ed3b00fd684" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/940f5bdc2899c0006f5f31b7df009408f9b4c0035d2a089e834c17786935fa95> .
+
+<http://data.lblod.info/id/bestuursorganen/bf988241f8268425a6b73e89091a67ae2db0bf412398b8e5915ca28b1ff9b384> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "bf988241f8268425a6b73e89091a67ae2db0bf412398b8e5915ca28b1ff9b384" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/53963fc2687a8c7e92fda2324242c47af3dc04c30c00722bf7087b00f24b3841> .
+
+<http://data.lblod.info/id/bestuursorganen/c2cc885ed6eb540dae330c202af313cf256abac6dc20a104324a7768743477e7> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "c2cc885ed6eb540dae330c202af313cf256abac6dc20a104324a7768743477e7" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/abd1184a3846446e7647088a633b082195291322f77c862c76e17929ff430702> .
+
+<http://data.lblod.info/id/bestuursorganen/c2f7ba3cf8ee67ac5bc40cafe18e0733f2a0f9e135be52b4aecb532efb8620d2> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "c2f7ba3cf8ee67ac5bc40cafe18e0733f2a0f9e135be52b4aecb532efb8620d2" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/a93dd23b9b7f46a43bad1e90ea436275d2f3105ad722671fc803d37891251207> .
+
+<http://data.lblod.info/id/bestuursorganen/c3c1a12b3818d7dd71e6d39197afcd581a47f66e745b674751efb2354580f8ad> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "c3c1a12b3818d7dd71e6d39197afcd581a47f66e745b674751efb2354580f8ad" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/2c83a12918acc239a4d2958a09abfb091cff07b35b651f5e5b55389f43aef448> .
+
+<http://data.lblod.info/id/bestuursorganen/c70fecf2c91dcec48b01e8bddddd25b36e25de4fe30ea9b6e866f6e50cb27433> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "c70fecf2c91dcec48b01e8bddddd25b36e25de4fe30ea9b6e866f6e50cb27433" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/211936f624c114f75167200429b21b03f90fd73bc2fd2547f710af01f8e07a61> .
+
+<http://data.lblod.info/id/bestuursorganen/ca3c455dd898b1e3253b4096e0241428a542e6c50f9cef48f84a531fc8b437ce> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "ca3c455dd898b1e3253b4096e0241428a542e6c50f9cef48f84a531fc8b437ce" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/ce368a23e7112f17589787d268262c601e571757c01d5093f595a466b6a2f33b> .
+
+<http://data.lblod.info/id/bestuursorganen/cc73363c8dbd74578a1269c91598c3eac876ee750615b5840df74367fef1fbc1> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "cc73363c8dbd74578a1269c91598c3eac876ee750615b5840df74367fef1fbc1" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/26b6df4738ce1915b1668117c9d28247819f79ecda5d178185f0259d1b37e0ee> .
+
+<http://data.lblod.info/id/bestuursorganen/cc9f79b2474762414349f0ddcce86d1c1ea054fd5bd38cb2cec71503ba37fedf> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "cc9f79b2474762414349f0ddcce86d1c1ea054fd5bd38cb2cec71503ba37fedf" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/89be9e5bcacbdd2ae16ca49530384556eec0c029e6b51a684e3373503d36b864> .
+
+<http://data.lblod.info/id/bestuursorganen/cde14265b0851b5456e49756853ad2915801559150cc748bbab68836c8ca71af> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "cde14265b0851b5456e49756853ad2915801559150cc748bbab68836c8ca71af" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/afb609343e0e481dfa0a87badd69c5b5cf3f90dc7db78b557e45e9220aa78f4c> .
+
+<http://data.lblod.info/id/bestuursorganen/d1681799cd3919e501d4456ddc48b4719d5d2036a48be9747fb92f36768db8b6> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "d1681799cd3919e501d4456ddc48b4719d5d2036a48be9747fb92f36768db8b6" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/fba2239d017ed85faba473682254fac7fa3308e4971b4dfd86c623a627b13567> .
+
+<http://data.lblod.info/id/bestuursorganen/d39d41c4fc776917120eef5509a456b9903124c5004741750158458491e17712> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "d39d41c4fc776917120eef5509a456b9903124c5004741750158458491e17712" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/e62c8ff0aef0cd553aab50e784eddd37b1cbee46e4d71e14ec4f25ed63ae5166> .
+
+<http://data.lblod.info/id/bestuursorganen/d4c25be87a76044ee6aff9229dfbd509afdb55a2ae1ee21064c49ed1f6b47d47> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "d4c25be87a76044ee6aff9229dfbd509afdb55a2ae1ee21064c49ed1f6b47d47" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/ccbe5e3d265dfd3ce8d9285c2503e32e7765c8e828e1c265cdf3a62e1cf34574> .
+
+<http://data.lblod.info/id/bestuursorganen/d638ce6f-d5f8-4cf0-b6b0-867c94fe18d0> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "d638ce6f-d5f8-4cf0-b6b0-867c94fe18d0" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/e25f74be-d10f-418d-ac4a-60ce47cc64f2> .
+
+<http://data.lblod.info/id/bestuursorganen/d7b4fcf1b7de64127f7ad17e12cf3bb476b1e22aede473b29bf8391dde1d3575> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "d7b4fcf1b7de64127f7ad17e12cf3bb476b1e22aede473b29bf8391dde1d3575" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/ab9f97152062755b31241908502735be2b0ac4e263ba2e1897fd64d3e9fb12b3> .
+
+<http://data.lblod.info/id/bestuursorganen/d91521fcd08369164266c140a3dbba2b67870ee428e50d7c710a1aa3ae59f10e> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "d91521fcd08369164266c140a3dbba2b67870ee428e50d7c710a1aa3ae59f10e" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/7108a2070c5e6ca2f3cb2fd09ffc4bd8a86a16321671385210863381f7d4441b> .
+
+<http://data.lblod.info/id/bestuursorganen/d9c5b640587ff660442bad17e37ad20c5a036176a789c98e0094af594cb3e469> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "d9c5b640587ff660442bad17e37ad20c5a036176a789c98e0094af594cb3e469" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/df83801b70823aac84d779d91bc91d75ae51f246b2e9d90ae1d231b09a15f0c4> .
+
+<http://data.lblod.info/id/bestuursorganen/d9d7a66d0b67007922d0a4d0164e0fb0419b0736e89ad53df139443ffd967712> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "d9d7a66d0b67007922d0a4d0164e0fb0419b0736e89ad53df139443ffd967712" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/b360183023767a27503c1caa77ea9e1dbb03c7eb7b4a6f74e3b8f6e3b3964120> .
+
+<http://data.lblod.info/id/bestuursorganen/db367cee8a8edca18c6c3a8834140622c98a062b463a9b795ec23f9e15416df1> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "db367cee8a8edca18c6c3a8834140622c98a062b463a9b795ec23f9e15416df1" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/7b5215124b24a9a33df4707169b06b5730ed6fb126b6c37e11ca3f94e037e8d8> .
+
+<http://data.lblod.info/id/bestuursorganen/def2bea159fab128c8bc5e216cdb26e350a38419c6d7d764dc4ac746e30291a3> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "def2bea159fab128c8bc5e216cdb26e350a38419c6d7d764dc4ac746e30291a3" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/d98423cff5784cadd05c42746992d58ebaa69889f78c418a0e42ced64b616faa> .
+
+<http://data.lblod.info/id/bestuursorganen/e011923781d2d6eac74bfce64e9093a100989f22eee691aedf7d469c503c14bf> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "e011923781d2d6eac74bfce64e9093a100989f22eee691aedf7d469c503c14bf" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/2ff3993d5a331fbbb17a790b8d52eb2c70e9f79955dac42116121f76ff1cadc7> .
+
+<http://data.lblod.info/id/bestuursorganen/e06c7238cbd97ba6b9b7cbb69ead729074fa7eecdc7d690dd301b15d64510362> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "e06c7238cbd97ba6b9b7cbb69ead729074fa7eecdc7d690dd301b15d64510362" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/ac180012457e7741dbee64f40b0cc9d5526517fc9e400f339b6270cd5e000930> .
+
+<http://data.lblod.info/id/bestuursorganen/e18afa449e15adde801fb471d851aa9a06ba8d47d3e9caec515bf876e48bbee4> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "e18afa449e15adde801fb471d851aa9a06ba8d47d3e9caec515bf876e48bbee4" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/ed76c22d67b3ebacc3798c1851a9a354b5db0ba80293b574d5162026b5ee0ab0> .
+
+<http://data.lblod.info/id/bestuursorganen/e64a22d8aafa1f0958e5eac312684f6e2c13893c0f9b11b0f11821aa4ec87bb6> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "e64a22d8aafa1f0958e5eac312684f6e2c13893c0f9b11b0f11821aa4ec87bb6" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/b16a63f8daa7b7e88f0a24f89ddee8bffd33370533641872cfeb4057eb40bc97> .
+
+<http://data.lblod.info/id/bestuursorganen/eb462e4b1171a67fdbaa2c78a69b5b74ed81919aa518f1eb9650a1fcc4dd91cf> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "eb462e4b1171a67fdbaa2c78a69b5b74ed81919aa518f1eb9650a1fcc4dd91cf" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/cfeec004a6df1722afc124323465073ad24e06a05bc9c75a49ca2ea304daba9c> .
+
+<http://data.lblod.info/id/bestuursorganen/ebda91fa148fdf733f7dc976153d8be740a0f5bff9a9209bd67f7812d21aedc8> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "ebda91fa148fdf733f7dc976153d8be740a0f5bff9a9209bd67f7812d21aedc8" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/ad95c28d33d2a13a5a06f81e57cfd1d6b512e9d91c5a61dd0316f675f795ff93> .
+
+<http://data.lblod.info/id/bestuursorganen/ec6dd6d55878d86424539a52ed9f2ad12ef8fa7d3e1d30b14dd06e25003a70e3> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "ec6dd6d55878d86424539a52ed9f2ad12ef8fa7d3e1d30b14dd06e25003a70e3" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/be543b6840f2f8bbea7c8a73e4ba0516d7b1bc68e20cb67fef64dd9a9f4b8cda> .
+
+<http://data.lblod.info/id/bestuursorganen/ef2bd63caafde1a168948d2eac3107ab773b115109c800491373fd8611eb1807> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "ef2bd63caafde1a168948d2eac3107ab773b115109c800491373fd8611eb1807" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/6d354234eb83462afaefcd82fd294669d50e75c4a4487c8388c4ed7a0c381603> .
+
+<http://data.lblod.info/id/bestuursorganen/f07e0fcaa759b02bd5708c82ae67931913710ce6ea7790794dc5bbbacf149969> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "f07e0fcaa759b02bd5708c82ae67931913710ce6ea7790794dc5bbbacf149969" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/9b88397e55811b1692f49da30f220bc30b88fe076c2e44ca3bf04dbf90a2cc71> .
+
+<http://data.lblod.info/id/bestuursorganen/f08263341ad1236cef861c77968a393b84533c6c8dda5bffda5217147baa7104> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "f08263341ad1236cef861c77968a393b84533c6c8dda5bffda5217147baa7104" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/9fb9c51277ac35fb14673f4cc240047aa65ce7185ab39ed593675eb4b5ccc37e> .
+
+<http://data.lblod.info/id/bestuursorganen/f1ae71d69db3601ac8ff38ef2b679f8f5a1adcf04e226f46c8b132629d814cab> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "f1ae71d69db3601ac8ff38ef2b679f8f5a1adcf04e226f46c8b132629d814cab" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/8d63ee68e96eb864947685aac31dfbae3780af1810ed9ff6fd11d513c1508cca> .
+
+<http://data.lblod.info/id/bestuursorganen/f4798f9c-b9b6-443e-9ad5-7fa7c795e6d0> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "f4798f9c-b9b6-443e-9ad5-7fa7c795e6d0" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/53e96e3b-3ace-463a-bf31-4a8ce363e355> .
+
+<http://data.lblod.info/id/bestuursorganen/f4acfccaf86b70c6979977ba8c0cf4a9c0b2ad902cde59838303eb6eb552cd11> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "f4acfccaf86b70c6979977ba8c0cf4a9c0b2ad902cde59838303eb6eb552cd11" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/c1fcc12b652bef30c8bc0f94ef48ce3d407354a786bcf6c2267d30f3f5f80309> .
+
+<http://data.lblod.info/id/bestuursorganen/f70cb2d76c2884384d5985c43574ac82003ccaf522d51f6068d67b37c4f288f0> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "f70cb2d76c2884384d5985c43574ac82003ccaf522d51f6068d67b37c4f288f0" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/9b1a2ab43fcf8b21768c71f23fd6b3dc5722d611326d1d629b8a771e0be5a975> .
+
+<http://data.lblod.info/id/bestuursorganen/fda765fecc3ed87fb23252d42797f13d61c4cffa6f69a25ad718478bb930e2d4> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "fda765fecc3ed87fb23252d42797f13d61c4cffa6f69a25ad718478bb930e2d4" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/9dc5edb53c4e1b72143f5c257f40595d6214f7b8c6681f7cc84d5fc9d81053f3> .
+
+<http://data.lblod.info/id/bestuursorganen/fde97fa50c8538b5b1482a365f1b4fa86c74366d883b816bbdc9a6a9fc1bb948> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "fde97fa50c8538b5b1482a365f1b4fa86c74366d883b816bbdc9a6a9fc1bb948" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/b2baff6c62b437755e369944c40fd5d28a3be107e78d851945086b80450b8bf7> .
+
+<http://data.lblod.info/id/bestuurseenheden/04e7a09c988feed3cf8df1c51aafe0f0a50811e325f5f5ab8e1b9750f48630fd> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/ab773e757bd152b8ab6ab450a4ec78fc5a86126bba1a99e545523241030aa822> ;
+    mu:uuid "04e7a09c988feed3cf8df1c51aafe0f0a50811e325f5f5ab8e1b9750f48630fd" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/fbf4493931eed8c035056b0cf9ddbbf8> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/05354d6fcc016d06f988a0e044fb160be7573550c11fe414b3c011961150a686> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/5a6fead60c5caf1b9c8a995038586670f953cdfb1aa0ce8ebbd64de0bd3d3352> ;
+    mu:uuid "05354d6fcc016d06f988a0e044fb160be7573550c11fe414b3c011961150a686" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/b521662ee00b84161caf451435c1395c> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/0594a740b99274c7347f3492ae4d05f9b05d057a1cbad30683634296e189cc38> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/748bbeb17d070410cb7c84ca684fe2149fa2957041f1be6194cc12ad1a6038bc> ;
+    mu:uuid "0594a740b99274c7347f3492ae4d05f9b05d057a1cbad30683634296e189cc38" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/728dbeb4587d377486a1332e9b8fbc4d> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/0610b306e95fae751dc07050565e987f31ba06420863bc44616b2e05452d8822> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/358d8d89278c1eb16a86ed20d248f717a1ec8a5e2491e3a93273403d492e3f25> ;
+    mu:uuid "0610b306e95fae751dc07050565e987f31ba06420863bc44616b2e05452d8822" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/b7e2a357e05d4cdae817179bf3d05a0e> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/08293a0d743c13f37e99deddf000e75ba13f70ca6a5ac65cde49ad23d600ab3c> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/05200c01bb94f80297204fa643dcdb5534283b9662ef46877662b4e6c0557e3f> ;
+    mu:uuid "08293a0d743c13f37e99deddf000e75ba13f70ca6a5ac65cde49ad23d600ab3c" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/86cc19bb579e960317920536c0af08aa> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/08b125860dd7716256dd35ba2e38a009206555f29adc44642c655450a471ebef> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/2e6e7d5c4f66e569cfbfa4171463ce704f5c1e622e1f4fb3c5c3c0beb88203ac> ;
+    mu:uuid "08b125860dd7716256dd35ba2e38a009206555f29adc44642c655450a471ebef" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/b8eb0c081b2d719746c0c30f20fa6037> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/08b6bdc2c34dacae28168cf967ef2e13384f032a147ddaea7f1145eff4f0d161> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/fd5b69ad963314358d44cd16b182614b8514a8bf8e3885913136d968e329486a> ;
+    mu:uuid "08b6bdc2c34dacae28168cf967ef2e13384f032a147ddaea7f1145eff4f0d161" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/1152fcfd9dde3278de59dfa17d468d75> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/097191c539cc02e6044671221f3ea0a8428c7fbc8dbdd5f38ee8f02ca51c6082> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/3a9b09cbccb798c8f9d5bad3fce1476bce1ee014165ba243488b0af690d0f464> ;
+    mu:uuid "097191c539cc02e6044671221f3ea0a8428c7fbc8dbdd5f38ee8f02ca51c6082" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/63d11d63c5f29336fe4d1186dd54a643> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/0b1af0370213e4b8ea5c3d5a2ccadcfce1149d092da47a3e447fe383050f9506> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/07550a135c689629e5ea5214ca1c4630c1180110ca9b2f81debbe4d4bffa1058> ;
+    mu:uuid "0b1af0370213e4b8ea5c3d5a2ccadcfce1149d092da47a3e447fe383050f9506" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/7b6dd8db087c6eaa6c800d8f3363c007> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/0cfc443c59ad06e1292b9805d967f181b989913a1ccc3e3f50a4dd8ca16bc772> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/91b4a50d5345c1faec9814719ce19cd44e3eea5b1fcca86824cc240234551365> ;
+    mu:uuid "0cfc443c59ad06e1292b9805d967f181b989913a1ccc3e3f50a4dd8ca16bc772" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/47dc67156a24f0c9e51c1c18db9610c0> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/0e951dd15341d38413bf809f16ef5f1bd163092001ac04ce78a4de5b5e9cdd37> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/cf7e3a12d707eadf9af6358de7477c0f57916268279e1fe908239f2850490eb8> ;
+    mu:uuid "0e951dd15341d38413bf809f16ef5f1bd163092001ac04ce78a4de5b5e9cdd37" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/5c800a8ffa1bdbfec09aa47caa4af039> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/ea446861-2c51-45fa-afd3-4e4a37b71562> .
+
+<http://data.lblod.info/id/bestuurseenheden/11feae29e6178a2b58ac73bb639360d58248e3e438f2201f219b95b58c6b4ef4> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/e2a49b7f1e6938765937e2fe15a7bd064afafb50563dbd8aaf05a7967271134d> ;
+    mu:uuid "11feae29e6178a2b58ac73bb639360d58248e3e438f2201f219b95b58c6b4ef4" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/ae04b3ad890a8fedd85fdb7670f1c348> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/1298cc0fec62af4dcaa86b44d43fe7e3ee3632247e66e8fccd87c0e5c7b7742f> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/1a17e9ad24bea1ef16512d66921948898716427bcb4c53496f962be627bc36b6> ;
+    mu:uuid "1298cc0fec62af4dcaa86b44d43fe7e3ee3632247e66e8fccd87c0e5c7b7742f" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/a52fc1a9c6da49e113dffc60ddb01646> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/150440a8bb763d6f53d24ca1c6f1460cb5817c8a261fd90e74aadac3292c3efe> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/71edef5720534cd8511b8e521c75d300e79643f2f8ffef3906613a2b72fa43a4> ;
+    mu:uuid "150440a8bb763d6f53d24ca1c6f1460cb5817c8a261fd90e74aadac3292c3efe" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/b7e6e9c6ff101a62874a8dd2f3730d33> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/165a9a64a6b84a278806b11c3f760f48198990168f591cf7a7462beb0f2cb16b> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/0ef1d6ed24687d2cf89a42922e8da600d7293e4bfb6f05c4907c1635cc531a94> ;
+    mu:uuid "165a9a64a6b84a278806b11c3f760f48198990168f591cf7a7462beb0f2cb16b" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/9795027f003b708f81b89420af4cb836> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/1915208b0a66992ee2014df894f7a9c538fe727a975fd9538d9e2c949e1a8471> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/141d487fe849fa900cb12f1e5904cc4c54e4c5af27c42fe1a216efec295e8254> ;
+    mu:uuid "1915208b0a66992ee2014df894f7a9c538fe727a975fd9538d9e2c949e1a8471" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/39c9ee60097cf8a599bec174b2682ed5> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/195d911f1417b20a4b715b1a54e8ae6e92b9a23cde908f2fb03a0081910d8fce> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/185fa83f793b854700c79aba89da0c707e455b0bd23944d2bb44a2e37bdca940> ;
+    mu:uuid "195d911f1417b20a4b715b1a54e8ae6e92b9a23cde908f2fb03a0081910d8fce" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/d8173ddc7d0d6d47212591a5d1c9e7d1> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/19ac0fa207989c27c3391e327aee16435475292296f010867945bf2987f95477> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/af71781ac6d3430649ea75c478627bff29b8c1bd3d6a079b73c6613bb2bde5e7> ;
+    mu:uuid "19ac0fa207989c27c3391e327aee16435475292296f010867945bf2987f95477" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/d26cb960cf884c6575d8f2f4d28ab659> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/19c1183ad20b9b4023da2eb7d1ab3eb5dda64558e050c8198abf9714463362ff> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/969ca04d7c98dc3702cc693934d2dffc19fb0525c17d85d749befb37ac39411e> ;
+    mu:uuid "19c1183ad20b9b4023da2eb7d1ab3eb5dda64558e050c8198abf9714463362ff" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/8346e73eae6b0c105afce77c797e2059> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/1db0e6fb09e60db1e8534b20c69abb03584870612717a454937717be9b7fd019> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/35711063bb65e5c2fb71cfa048afee0e62bdf640c43a81d149b33238fd750034> ;
+    mu:uuid "1db0e6fb09e60db1e8534b20c69abb03584870612717a454937717be9b7fd019" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/9ecda8461bc9ce7596eda8d44203977c> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/215d1409dda860a1ce4f39f1f6c082c5662620d9d29de456f4242fb6cc6df0b5> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/6f043a6190dde1147bf92a7911f1bdec7c0740f27c428a9180b516a24f3e0ab0> ;
+    mu:uuid "215d1409dda860a1ce4f39f1f6c082c5662620d9d29de456f4242fb6cc6df0b5" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/ff222f8b337d691c3cf81a9328a974d1> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/ea446861-2c51-45fa-afd3-4e4a37b71562> .
+
+<http://data.lblod.info/id/bestuurseenheden/254bbfb6c31a668446c339c0996864d23c3fe129a5aa05e274b463cbbb4a4bc2> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/08e4f8d10ee80e97517fbb11d725054e22e6417045e93f071849042e143f86b1> ;
+    mu:uuid "254bbfb6c31a668446c339c0996864d23c3fe129a5aa05e274b463cbbb4a4bc2" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/3577288ae4b721934732fafd74665db2> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/25572d6c63bc386d742bbb6ac0d8ddc739dc0599e156c6eac68aca492390840e> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/3856d768516bfbcde658dca43f203c0a862fd41f68563fe22e2b59f81e12f2fc> ;
+    mu:uuid "25572d6c63bc386d742bbb6ac0d8ddc739dc0599e156c6eac68aca492390840e" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/9a7791f0b75ccc09d765154f10f9e1a2> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/2ba0f1e28168459a963a81784a8404e94268f70b49f99342d50ff421ab8a06c6> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/d0bca7741ab8b64674f9c36e0164e0e19dc64990a2dd1a0344aef1f5d5f026f6> ;
+    mu:uuid "2ba0f1e28168459a963a81784a8404e94268f70b49f99342d50ff421ab8a06c6" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/c21ee50143527a05e1a2d83f03b376a1> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/2c1fc56876479e83c7b144e98b84174dd10087ae59621204b9d6701d968e8aba> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/e70e4f8b4714f7d01b7c2c1c7e5d3872b5ddd73dc5877505f074b8fd1a5b2404> ;
+    mu:uuid "2c1fc56876479e83c7b144e98b84174dd10087ae59621204b9d6701d968e8aba" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/83ab27697265ebe4ea36e184fca80b8e> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/ea446861-2c51-45fa-afd3-4e4a37b71562> .
+
+<http://data.lblod.info/id/bestuurseenheden/2ca642d589b8012fe65bf54df3a87f740acac78624a902ad378dc4ee6c50a848> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/3742aeacf45a7e1f74766d10d4cafd904ac3b48adfe714c63aa3fb03991f666b> ;
+    mu:uuid "2ca642d589b8012fe65bf54df3a87f740acac78624a902ad378dc4ee6c50a848" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/833bc029cb3760af991662d680f3a7b6> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/2d25be1712e809bbeed7d439c93bace752e0742f6b2ed9802302dec9a8906e2a> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/9aeef0ce24d3a9a7d4da41906fee2e55b244ca656b7786d69f0ac0315ee56dc1> ;
+    mu:uuid "2d25be1712e809bbeed7d439c93bace752e0742f6b2ed9802302dec9a8906e2a" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/b7609d62625f02747c60bac0051973a4> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/ea446861-2c51-45fa-afd3-4e4a37b71562> .
+
+<http://data.lblod.info/id/bestuurseenheden/306340a51c1504e59f1c3b85c1ba1b62de8c70cb94d3998f27819761bcee5a98> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/57ec5904a735959f2296cefdf24c2b6a8fa58d595bda194f5fa90de94f30bf1c> ;
+    mu:uuid "306340a51c1504e59f1c3b85c1ba1b62de8c70cb94d3998f27819761bcee5a98" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/337440202a37cecf8729f76f08c290a1> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/31bceaaaa3f4019e85edfe0e509340aa30554d0f3bb343616841c20641788b6e> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/ad0dfe9d3b06bce9739f991c4f5c7774feca13f311365e51ae619f1b86eac25b> ;
+    mu:uuid "31bceaaaa3f4019e85edfe0e509340aa30554d0f3bb343616841c20641788b6e" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/71609cc8f08fedf5303c5eadcefc9b22> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/330516b323c00851cf4b93e6d5d7a2ef4591f68ae6e71ad9c1f432ee70521bb2> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/245c7249341fa053902cf672f54c3d0a311c402dce9c943d6763ada403d02e94> ;
+    mu:uuid "330516b323c00851cf4b93e6d5d7a2ef4591f68ae6e71ad9c1f432ee70521bb2" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/eea40e2a2e904d8d9006595a9e44abbe> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/35454115a5e3a31059e0c4fd55906df42c75885b0233c1f17eb4bcef6e696908> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/aef3520d20282ff8782febfb42c5897fdd9dd902dde6f0c27b5c79a45a61d553> ;
+    mu:uuid "35454115a5e3a31059e0c4fd55906df42c75885b0233c1f17eb4bcef6e696908" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/a1d4edcf7b02138fb198b042f9656f2d> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/39e0e2e69be463a4628f87bffe7dc6206aa6daa4a5516fb4ce11907f57d77079> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/569650368e864b6e26fb522f00b814280105fdf64127119a09b20163b8de3aef> ;
+    mu:uuid "39e0e2e69be463a4628f87bffe7dc6206aa6daa4a5516fb4ce11907f57d77079" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/03fd634d8549fe96c48a74a3afc3c047> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/39e3e46f7cf031133152e763eaa26cab3df81f842f9912a25c69c445f0c428b8> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/dd59792f747a511c9307e92f92bfacdf27a2f92f6bece00d35c5ffd1277099c5> ;
+    mu:uuid "39e3e46f7cf031133152e763eaa26cab3df81f842f9912a25c69c445f0c428b8" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/e8086576af9a34eb57baaa828d7cf8c2> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/3b2c2151632d84c55dd93372a4e91a7493455a7f77a90fa2066fc618411d0ed6> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/983420e760b887303c3f3b88ce30f0f91b30d038fdeadbb15a0173fe6c94e52e> ;
+    mu:uuid "3b2c2151632d84c55dd93372a4e91a7493455a7f77a90fa2066fc618411d0ed6" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/31fe693ea517aa39adbfa8dd144fa4b4> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/3b7a6d691943806c23f59d22482dea27e451bd440f91f884aeb42e8c72016ee3> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/7ab38b4763ad40046f77c8619abcb491deb883c86657d7305e834cd6c92e68b3> ;
+    mu:uuid "3b7a6d691943806c23f59d22482dea27e451bd440f91f884aeb42e8c72016ee3" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/1283063325557db2e202d20b237c9009> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/3efb7cb7fad9f61917093d42513c8a7153120906e9701b08e3560c8f109e64c1> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/931efddf902c4e9e29bac345a5eac931ffcc4b568d2f66de0aa780f8071ef662> ;
+    mu:uuid "3efb7cb7fad9f61917093d42513c8a7153120906e9701b08e3560c8f109e64c1" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/97214ff8d6fbea8ed22c4003c289fff9> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/3efcad40be18e793d070f78a44f2e63bc105778d6c8c4edc4bfeb5a87f06554c> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/67e94533f141e5b92ddd43d0aba706a8870ac4ae74c70b6d990c6454bd1c3525> ;
+    mu:uuid "3efcad40be18e793d070f78a44f2e63bc105778d6c8c4edc4bfeb5a87f06554c" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/8254f554eabf7df0e61945ee5f6a15b3> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/414f3538e482d3c1c21382ca22de18998ca1d3f5b517ced85946ecf90143149c> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/d34f1ebbe52e1cf6c7b802634dd14aaa3ea0d5229827500188061a2e57f21113> ;
+    mu:uuid "414f3538e482d3c1c21382ca22de18998ca1d3f5b517ced85946ecf90143149c" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/fe5dd392743b85113de1d56862da9e35> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/41d31a2eb697af977aadf64c73e0bcffb094e0f20e4017fe3b49c507079c0976> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/b201ce6f3d999e3c9d7d5cfbb6a82431a3271c13bece38835909172256891abb> ;
+    mu:uuid "41d31a2eb697af977aadf64c73e0bcffb094e0f20e4017fe3b49c507079c0976" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/efb6ab4e0f28730c4ed9e9f5fe92ac92> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/41e3bb71cb1fe2763a64ce47ee758fbeb532fbd4348281f34a86a5f88dd71980> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/2c6abb11f8f9aac51939b00bc3a8c8cc101651ed2c31d116ee52cafefddc286d> ;
+    mu:uuid "41e3bb71cb1fe2763a64ce47ee758fbeb532fbd4348281f34a86a5f88dd71980" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/bf364b140000bb7d60bac8d1d2e2c3f1> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/458df2d318d52e34278e4ce1886b9458351d3a4b06fe28c68a7558b0cdd528c3> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/ef88777f96b74decc1784bd6d94a271af762c7bd436662065b6ca7810f2b4b9a> ;
+    mu:uuid "458df2d318d52e34278e4ce1886b9458351d3a4b06fe28c68a7558b0cdd528c3" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/214a1af365d989c54adb3d7eb8293d06> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/46616861cfaae13b550a36ae5c05187638df0873024f13043d3f40f24cabf4e6> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/5cfdd4a4556916546cc9458633b00417aa8ad405a1224a76febf8163b2b237dd> ;
+    mu:uuid "46616861cfaae13b550a36ae5c05187638df0873024f13043d3f40f24cabf4e6" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/9c8c7031f1fa73e1eca76210c9b8dc99> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/477e468496131b7d35f145b0361bca5c2cad577fd9ec27d385d703942dc944d0> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/b40c4616c87391ac2d23597216bf9f52a8fdd1741cca546ecd3587778a982c01> ;
+    mu:uuid "477e468496131b7d35f145b0361bca5c2cad577fd9ec27d385d703942dc944d0" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/88223fd40246d0e2f31cef20a19e6d0f> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/479036ca47b011e16fefafbe4d3512a44c564804dc26d331ce4dcbe0fa3366d2> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/d3f5c7b929615ff41ab98562f8cbaa5b1b3c21fd264377087d7475ebb80e0748> ;
+    mu:uuid "479036ca47b011e16fefafbe4d3512a44c564804dc26d331ce4dcbe0fa3366d2" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/dc1afbe9facaa8aba30288492f057e13> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/488938bd557800723290a816c51b471fff7f4918237a509f697973af6f509390> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/40e6ed8a858ceca76bf9bdf1fefcfc989cf48c5251c814ff728521ef798d75b3> ;
+    mu:uuid "488938bd557800723290a816c51b471fff7f4918237a509f697973af6f509390" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/7430471371092fd0752c9f12c7129f6e> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/4bb83a0635b69132a4de91667c0a30f228720bda01584b3a01c4cf7ddfc12664> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/8dcee50ac1c53f8a0459281b5683a8245b56d3a1713a4db67e23f5d8d436d7c7> ;
+    mu:uuid "4bb83a0635b69132a4de91667c0a30f228720bda01584b3a01c4cf7ddfc12664" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/a5abfba604274eb2092ebc63691c5710> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/ea446861-2c51-45fa-afd3-4e4a37b71562> .
+
+<http://data.lblod.info/id/bestuurseenheden/4deae42b2b25bff407f5abc7cbb6d62eb02afaf2892086341c324fdf2c0e6e92> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/362e2d4ad790b7d3e177d432ae0de87d24ad1d2e7ee9a95f5411136dbd9a6ae5> ;
+    mu:uuid "4deae42b2b25bff407f5abc7cbb6d62eb02afaf2892086341c324fdf2c0e6e92" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/fa0190f783eddf5ccef9afb483337eab> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/4ffd00c0ba7ceab20db24832a4b9963112ed66914dcca05f3e5dc8b8b9d4479d> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/cfb52a39343880d5a13e1a4dea6a23280d4b693f0e082792b888d906c38b2147> ;
+    mu:uuid "4ffd00c0ba7ceab20db24832a4b9963112ed66914dcca05f3e5dc8b8b9d4479d" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/e05368c77286b626417832073770bb51> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/5018524f9ceca4f9e21764f9e8e4e63d1ad6890c338c090d0dd074faccf1bfb2> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/60f4f5d0c41d32f7c783fa44ecc69f6fbd01679381523adde650d5c20a78036c> ;
+    mu:uuid "5018524f9ceca4f9e21764f9e8e4e63d1ad6890c338c090d0dd074faccf1bfb2" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/e02e7c6a6f387945aafa19b3ef3e3a71> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/505e727b7b078c3eb9a05f754d834fca559d28cb3cdb02d5e4cdb3be300ea699> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/6355d8751fb0333754a9802c23288725efc7d3920080e9459667e8d6a72a55c1> ;
+    mu:uuid "505e727b7b078c3eb9a05f754d834fca559d28cb3cdb02d5e4cdb3be300ea699" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/2ececfff95755cf9848dc8c100d2b671> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/ea446861-2c51-45fa-afd3-4e4a37b71562> .
+
+<http://data.lblod.info/id/bestuurseenheden/5187962dfd40789953d4fbde3634751ee90b48b17147c585ccf4f2ac1ee72fd3> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/ce94eeae827cdc5c00f3f2f4276ff628580edefb3aa5861e4669b0c5d93adc57> ;
+    mu:uuid "5187962dfd40789953d4fbde3634751ee90b48b17147c585ccf4f2ac1ee72fd3" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/bdecfd4ef64102f66a038ef80f7adacd> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/520ae455030cb427fa5dead38ba62d2975fcf2d0f695d365cf9e84b5b5b5b73e> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/202de79f3f7bbd6a6d417fa3774fc081609005cfa24dcde393adcc361ed68c1e> ;
+    mu:uuid "520ae455030cb427fa5dead38ba62d2975fcf2d0f695d365cf9e84b5b5b5b73e" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/0d7d4ac3e33c072bb36448bebac6e12b> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/52bda330e11552b586106748bf652e5dd41163670d5c4226b2c02bfa2f579946> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/99937d077273c7dc90a57c475c5c5465edb3d792e024a0be0be37baa0e1b5938> ;
+    mu:uuid "52bda330e11552b586106748bf652e5dd41163670d5c4226b2c02bfa2f579946" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/55b5d2de5c407e4ce6e5f732b863a1da> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/541c1603eb8c01968f95d1f262854134499e00d135cd7c9147d307ccbd1e20fd> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/93793c639b912b55c877ff9bcb1f3245b436e4319c1be54f5580fbeef59efc94> ;
+    mu:uuid "541c1603eb8c01968f95d1f262854134499e00d135cd7c9147d307ccbd1e20fd" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/03a724595485ecacb006ac6030954671> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/5ba4a42bd459dda75ce452a253ddc09547174265456ad1e3f9389a3ff139a1f9> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/1ec563e0bbfe58217225bd32096081f591294c1b6bbc8a212543aebf2e3feb09> ;
+    mu:uuid "5ba4a42bd459dda75ce452a253ddc09547174265456ad1e3f9389a3ff139a1f9" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/f0e74f742b7cf9a79105eefdaf871e42> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/5d55c0281e70d053158a06a7898bb3e1a89ed48cf111c4b6fc2a9502ebafcade> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/d627c2dfdfc539a95a791916b85b5de4d2cc3ecf5c8dfa44e7c9bad8a7c69824> ;
+    mu:uuid "5d55c0281e70d053158a06a7898bb3e1a89ed48cf111c4b6fc2a9502ebafcade" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/db99845851325d4f9d7f707148b8f30d> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/5dab8a7b0656aaf0db13044fcafc0088f9f0b7776c294a6e9abfdbf7420effae> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/5407254a01ecfded9db9682823d08f39342b2d567ebf09a81e6e0982f908aaea> ;
+    mu:uuid "5dab8a7b0656aaf0db13044fcafc0088f9f0b7776c294a6e9abfdbf7420effae" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/bb2ad676cb45e2bd04608bb4b2e922bf> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/622fa725ba8455b01817c8e48974edeab56607018fce5c1cb3694306d3e7005c> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/817942d34f92eeb0fb9c19a026d2cc61016c532edb54dd75472524e31326b61d> ;
+    mu:uuid "622fa725ba8455b01817c8e48974edeab56607018fce5c1cb3694306d3e7005c" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/83926238381c2c3b4a1a48cb0f884ed9> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/67b25dc29ad301f607aed564241d318de74be7dc1ec15202a67111d7a86becf9> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/ac8f96b85d9764b461769832b8e3d2d1d788e08b36bc336e7097ef75f547e8a6> ;
+    mu:uuid "67b25dc29ad301f607aed564241d318de74be7dc1ec15202a67111d7a86becf9" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/fc62b359c7960acff12ee02b1c84b2cf> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/68ad1301fbb5f209b4ef0fe2b11e77c7bea6011f5e28f8f6875597a7b08f0f1e> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/85a69a219f200c3d7e9c22ad6f468fa3afe2cfe78f4bf159e2a3fc5dc641ca1d> ;
+    mu:uuid "68ad1301fbb5f209b4ef0fe2b11e77c7bea6011f5e28f8f6875597a7b08f0f1e" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/a1ad28a999cdcba822c236030a523c34> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/7271a57b8249b4dd3175f50ea96c66ff536eff057c6bc0acfe40281e2a91ddc2> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/d31ea250ee10a52db737dc607a59b62ac6dc3db37e00252c0e06367c539f80f4> ;
+    mu:uuid "7271a57b8249b4dd3175f50ea96c66ff536eff057c6bc0acfe40281e2a91ddc2" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/1341812c376b5770ce5ec345b37c689b> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/73777b2512fc25f16554612a13b0de2265a56540a5ea6665bf69a8b5a805569a> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/77f479b586de464afaac025433500e2afd00ce6857b6a99e0a6b66fcbbe65b48> ;
+    mu:uuid "73777b2512fc25f16554612a13b0de2265a56540a5ea6665bf69a8b5a805569a" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/1e64d1ab2bde10a85e2d3d91abfceea6> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/77801115dec7f63400134c21d897a41bddb775eb438d81b354ad18fb6d7ab956> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/835a81db466834be5bcc76118685ff7bde04f29f0bcf53da760a998b740a24cc> ;
+    mu:uuid "77801115dec7f63400134c21d897a41bddb775eb438d81b354ad18fb6d7ab956" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/c9053fe425582f69f3f484b1f4a0dda6> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/7800a6f5e9c3f646e274b280703730ed5e83fe0cba1f0d6c7fb18141337fe781> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/d88c1bc1b50518e3895dac7e40a982e034779cccd4754383b9488281b2bea8d3> ;
+    mu:uuid "7800a6f5e9c3f646e274b280703730ed5e83fe0cba1f0d6c7fb18141337fe781" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/95810835b4a24719136051aef1816116> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/ea446861-2c51-45fa-afd3-4e4a37b71562> .
+
+<http://data.lblod.info/id/bestuurseenheden/782682349b24078a97dc181bdb7dc62fb2cabc072878fc75a29f4ed70c86250d> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/270ad4bb9f35ae189346b664c1287183890e2825dea5f5fd4489349992b9cf9f> ;
+    mu:uuid "782682349b24078a97dc181bdb7dc62fb2cabc072878fc75a29f4ed70c86250d" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/66f132a7cb506b64c96f53c146865257> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/7b1c9132de06d5b3626e7118dc16c7f129d7c911b3298a0f4609725372e64588> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/3a98b84c7f0d534580e7cd3b9ffe5358c17481887c48a1403890b4c654929108> ;
+    mu:uuid "7b1c9132de06d5b3626e7118dc16c7f129d7c911b3298a0f4609725372e64588" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/9f8d09cf9f0566deca6fc747ac0e7bd3> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/7b6bbae823b20191525038cd52089d22128163fb3c7f851ce56149938628d941> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/25ddbb6c125536dd63e73248feb5e381811da68cf04030cee87e8750dc6cd8f4> ;
+    mu:uuid "7b6bbae823b20191525038cd52089d22128163fb3c7f851ce56149938628d941" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/11ebd689bd15870b0eb4af3e4626e75e> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/7cb2089a8c6746d514711908abfd38414a2b01f6ad9a83f28be2e835888b3da7> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/e50b04db483e197060598a521bc05beb2e3b689438fcf24c58c1285df12b262a> ;
+    mu:uuid "7cb2089a8c6746d514711908abfd38414a2b01f6ad9a83f28be2e835888b3da7" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/cdf4ee5bf16271aff7b931049b49bbc0> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/7dd1250996188607bb1e28df1ebea0b943e8db59c08ea01e3c57672531c43ec6> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/04e0fa9f835a82dd89d893e6693da8a02b14cc32af05299f7e74ae3479df079a> ;
+    mu:uuid "7dd1250996188607bb1e28df1ebea0b943e8db59c08ea01e3c57672531c43ec6" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/e7c91bbaaf5feed05cab99ff9899dadb> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/7ddda00fc45a0994092bc26f30d97352b7586676438d5557b3f5cc336daab063> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/be39b68572b672ac653d4bdec1eb329db87936cdf1a17a9943468c1633825f34> ;
+    mu:uuid "7ddda00fc45a0994092bc26f30d97352b7586676438d5557b3f5cc336daab063" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/7c266f127e5918cec7e3d5caa8f8b8b7> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/7e526f7f2d12f55a06620b512401826b6855ed478ff0693e04fba59cabba3c4d> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/32b373e7ea31f56cfc8b2199c7fea6655f83b16927beacc2c2f98d0629e44c5d> ;
+    mu:uuid "7e526f7f2d12f55a06620b512401826b6855ed478ff0693e04fba59cabba3c4d" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/f610900d7ee76fc040027b5eaa7aa6bc> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/805a977a29725d94f50bf7f0d91a0de1a727c4eec88940e90035f71c6c9b1655> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/c737024ea8adb2b8ab223928effce35b6fca284741775cdf12d8c5a0cda1e828> ;
+    mu:uuid "805a977a29725d94f50bf7f0d91a0de1a727c4eec88940e90035f71c6c9b1655" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/6ffb900d6cc5243a5f9f4c2a80e13588> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/80a9ab8eb46716ab23c597d13313ce24b17884ffcbdf00d216b877d57a52ade4> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/600c84d05a647f11c72d8aef51b16a18b80e37bd0e5ffce82e733b26a0fb1ac5> ;
+    mu:uuid "80a9ab8eb46716ab23c597d13313ce24b17884ffcbdf00d216b877d57a52ade4" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/3304076ed24822d80392f7f559f7311b> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/81083789b63917e32ab90ef1a45adf893f370ee38da2e0542e5c035db4f60794> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/7be282617d0465b30d663fc9d07d12de36912ea7b552c9e37bf12cff67d30e88> ;
+    mu:uuid "81083789b63917e32ab90ef1a45adf893f370ee38da2e0542e5c035db4f60794" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/be4a753773a6d0d07a8804261c5e05f6> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/81334af3-1b6f-4308-aca3-107121462d56> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/e717f80fd9f828c1e2c972e0bd12bf1ef3c1ec6b896f7a60dc9de9fe9d59ef2e> ;
+    mu:uuid "81334af3-1b6f-4308-aca3-107121462d56" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/cab92201b1673529a0e61212c5d924a4> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/81dd243d-f66c-4157-b105-5407aa83cb62> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/f2bda6eb42c1ab85c4ef36588a043ac2bfeffa31bfb88bb7abc597f01efe270b> ;
+    mu:uuid "81dd243d-f66c-4157-b105-5407aa83cb62" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/b7c20f59e18f7550f9478b78b2ef61d9> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/8a72024e99b1e083aca28a026122ad2bc517372bc18e95210fb54f080136e3f8> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/b68c9161edefe461fe3e61a3fd5fbca3a543e35a3f17f9a0364e28acc6f6cc51> ;
+    mu:uuid "8a72024e99b1e083aca28a026122ad2bc517372bc18e95210fb54f080136e3f8" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/e7a24c0455ef6b5040bdf38a2a977823> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/90688b32e0808b6ebbb7b36030526750236527e8019414449065f57ea384ce71> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/0d8963ea52d954a6c8f7454df99d686c43bca48be98e6f6393ab56d93c3d75a6> ;
+    mu:uuid "90688b32e0808b6ebbb7b36030526750236527e8019414449065f57ea384ce71" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/aa884eecdd407444a44efa104842cdc8> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/92609bcab00475b084e747cb49f942abfb9e737ab023a999c69baf60acb8c06d> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/22658498f757ed03025abf548124246f8a02276dec24911bea7fb90da0280b59> ;
+    mu:uuid "92609bcab00475b084e747cb49f942abfb9e737ab023a999c69baf60acb8c06d" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/8abb98c3d7356a54e12cbded4be3fdad> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/93389f5157ceb037c5e38d7b8119cef632528b870e91e209c033bc2eac220cc1> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/141e9df227d8e62fa8b064cd46e95c45d3a3725474bacb247e7a91a9c3c34cbb> ;
+    mu:uuid "93389f5157ceb037c5e38d7b8119cef632528b870e91e209c033bc2eac220cc1" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/ad55b687f0cf69686392e8fa1cc02f22> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/95871bddebd4ad93db54cb1b40d41af29f7ce08f0b59698b0540be129a9a3433> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/e03b8cf977958b162eadb043a23fc1d82123afbffc561f44500beab33c2aa327> ;
+    mu:uuid "95871bddebd4ad93db54cb1b40d41af29f7ce08f0b59698b0540be129a9a3433" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/3695ad67967bdb64c7f588ff6815725c> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/96d87c4956c98414938dd5fceeb05f65feebf21fbe5918e6d23bc2b58a7fc716> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/1dc6438dce069b638af19f05937dfb910e6a5d87e9cb980d313f313396da6346> ;
+    mu:uuid "96d87c4956c98414938dd5fceeb05f65feebf21fbe5918e6d23bc2b58a7fc716" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/38e20e10e2364cafe2819899ca454b87> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/97028faf77fd95eb5016a13c19f3a3a8ccf97c6c937398ba96976e52d171dbd8> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/69a4c969d38245fa0088ca016b9b2ebf6edb7e913bb44bcae855127618d6fe77> ;
+    mu:uuid "97028faf77fd95eb5016a13c19f3a3a8ccf97c6c937398ba96976e52d171dbd8" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/2950678953d872c253350314c3a59212> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/97a393c64a3c30e619bc115ab8b2bbe0bd7a83265ebb8960c0f1154b9628d340> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/a82bb52d014a5406bb25e9c9d133ee626cf9499362c5b6ad8ad7ed05333e1f26> ;
+    mu:uuid "97a393c64a3c30e619bc115ab8b2bbe0bd7a83265ebb8960c0f1154b9628d340" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/e54133819df671247fd33e4bc107b9b7> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/9893dc25d4b91aef9e2ef6f712e0aac68cdf6f144dbed887c9500e6360df080d> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/7126722b6f0b3371b24d34fe9cc3bb71561878a5185ada4fa257baafcc1c0f7a> ;
+    mu:uuid "9893dc25d4b91aef9e2ef6f712e0aac68cdf6f144dbed887c9500e6360df080d" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/408001ffad09bf2981f305fb7092f469> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/98967d1e1e3dd66ac9e32bd1d536ee8e85c9126cc5fc04354a335d5aabcf9b01> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/4a300e2369f691199695316da3edd1e141d39ade0c64d0ca838d5b10f44767b4> ;
+    mu:uuid "98967d1e1e3dd66ac9e32bd1d536ee8e85c9126cc5fc04354a335d5aabcf9b01" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/38ce51465e465ad5a697cea36e37d731> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/ea446861-2c51-45fa-afd3-4e4a37b71562> .
+
+<http://data.lblod.info/id/bestuurseenheden/9b1af8b3306f7f2966d2326a7a301c149d2a62db4803335aaffae9ff45fe068d> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/56355d5c34866f4c065034f738d405dbb0ad05bd453f58654f1ba0bb1321cd0c> ;
+    mu:uuid "9b1af8b3306f7f2966d2326a7a301c149d2a62db4803335aaffae9ff45fe068d" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/d3ca7836d44ce36f1362788255a63fcb> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/9cb5a65d9190da4bb96d0f59882cbcfb34248d354e6bd27101fccba186f4c7b7> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/5adc6dbcd42aca6eb5b7d7c3ed919455ec08127cad351f5695b21cfa844b78b8> ;
+    mu:uuid "9cb5a65d9190da4bb96d0f59882cbcfb34248d354e6bd27101fccba186f4c7b7" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/755a7542b021db2e500f032781d758a3> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/9d0e3fc23f4fb9c23cbcc30474a1e518c9725c069255090d46eb58c13d62baef> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/066a8a73ed6c520050d15c9452cd0f97c1f2457eb3317515678a7e4da199aef8> ;
+    mu:uuid "9d0e3fc23f4fb9c23cbcc30474a1e518c9725c069255090d46eb58c13d62baef" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/9f9506ba58c077451826e9f73ee5902c> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/ea446861-2c51-45fa-afd3-4e4a37b71562> .
+
+<http://data.lblod.info/id/bestuurseenheden/9e2072f69e9c1ecd1af7f65a234f141ef6cfe36eb63b2758d54d1414618188ff> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/7493af0a6dba4a56774f437fa0ee11485e93cf0d48134c6c84d7b10dcc152a34> ;
+    mu:uuid "9e2072f69e9c1ecd1af7f65a234f141ef6cfe36eb63b2758d54d1414618188ff" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/1032f076c324ab6712a50cfc2aad529c> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/9fdf19f0cfc9e12bd58fc10c4da6e8c6c40e813ec5b9f3bdde92cb00ecd972fe> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/06feed0bcc7449656b007fb536e61b8b046ce8220e762bf6b2bd78f52204f5ab> ;
+    mu:uuid "9fdf19f0cfc9e12bd58fc10c4da6e8c6c40e813ec5b9f3bdde92cb00ecd972fe" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/828eed8108089a7bcc26a7b47d55a55c> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/ea446861-2c51-45fa-afd3-4e4a37b71562> .
+
+<http://data.lblod.info/id/bestuurseenheden/a31131dd72b614c89184b331821c10a0f8feb109881a1b164749e9c8941c5e6b> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/d617f71eee99667889b682601fd6ef48532995ec124c2389efe8e4991b844453> ;
+    mu:uuid "a31131dd72b614c89184b331821c10a0f8feb109881a1b164749e9c8941c5e6b" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/68a9cd93b17b6be60d5007ae3b4b8bf4> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/a32dc005ecbc001abd3338cdacb111895d3053b313654136ef1903035c10a53c> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/8af05d4615b0f3fbe21ecab52301360d847ff61cea5b6b1be33fd84d6484e7fa> ;
+    mu:uuid "a32dc005ecbc001abd3338cdacb111895d3053b313654136ef1903035c10a53c" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/1c8c1e1f968f768eb67efbd3a54c9a28> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/a3b32431cfbb18905e2c7deeaf9ef7af35cd17c55d053a05ed9cd8fdec550724> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/412238a39f8dcf65da0001258efae2be37ba1bfcfc105bd2f5725fb5a40ddb21> ;
+    mu:uuid "a3b32431cfbb18905e2c7deeaf9ef7af35cd17c55d053a05ed9cd8fdec550724" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/95f28b4837d787cd98299f1419b7a8e2> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/ea446861-2c51-45fa-afd3-4e4a37b71562> .
+
+<http://data.lblod.info/id/bestuurseenheden/a62fddadcb0a8fb878c3edbdc71a4eb1e6c419b212d41a8bd589fb1a370eb112> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/980beb536da52e28b1f0d5a8b88678c2f08c17d850b8ab272031cbb3e0b0ec25> ;
+    mu:uuid "a62fddadcb0a8fb878c3edbdc71a4eb1e6c419b212d41a8bd589fb1a370eb112" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/9a383c2edd8b29c492f366c660e1de18> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/a65afe7380499a2c24c2d039f2a97493f2f99bc03836de9bb99c2c267676388f> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/5be128acc6e5d1336fb6eb7e175e774a8c12a75e8ced6f833a36ba7cabd3421a> ;
+    mu:uuid "a65afe7380499a2c24c2d039f2a97493f2f99bc03836de9bb99c2c267676388f" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/9e2699cacacbe84d27b0ae1d04703ce9> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/a691d36ff95b67005d30d5fb89594dab69ec7fdbf975ffdcd36ef9bb39efb06d> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/d72f4ce327716c2306ba4b500b2a9a83fd5506b8642785eda7eeefb7e8933471> ;
+    mu:uuid "a691d36ff95b67005d30d5fb89594dab69ec7fdbf975ffdcd36ef9bb39efb06d" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/4625259581ccf39499c1b0d5c1d6bb66> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/ab9269754d1266e010c1878a1199525898f0846ff0e9a0add9e7fbaed42ac43c> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/57f8de48c686aafc2b259ce47b84c3af41dd1b536a740a49e2c3cf69213f51aa> ;
+    mu:uuid "ab9269754d1266e010c1878a1199525898f0846ff0e9a0add9e7fbaed42ac43c" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/1f6ca76cc6d829865c8f8e31375c8290> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/abca98258a8436dd7f74c633f0b60c7e50b407a1bb27777c102a1963f8843f8b> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/4c23c51cd6e576af4c51017c13fa5c0187df068503c852f1ba77db96e5ba3001> ;
+    mu:uuid "abca98258a8436dd7f74c633f0b60c7e50b407a1bb27777c102a1963f8843f8b" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/ce2d8d86a058d611b92cc28e548dcaca> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/b2fdc615ffb131e53a200e14c74ac92d4ed6dac176e3e6ea2c79d227835077c9> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/ae87d725e78333d3bb8c11de23bcf6ed37189401901069a3426a4c9ce02d85b9> ;
+    mu:uuid "b2fdc615ffb131e53a200e14c74ac92d4ed6dac176e3e6ea2c79d227835077c9" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/77190890193ed72890b2d420f4bb5381> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/b312420a9e4331da36afd70237db5061825cacadcdaa68e6ad0f1ea8a9426f77> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/dfb1fe93c74980724f7fbfbd6b31bcb13f421ed0f349f6e10a158accea3c6f7b> ;
+    mu:uuid "b312420a9e4331da36afd70237db5061825cacadcdaa68e6ad0f1ea8a9426f77" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/ac2e095ddedad9eb5157a695cde1b490> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/ea446861-2c51-45fa-afd3-4e4a37b71562> .
+
+<http://data.lblod.info/id/bestuurseenheden/b3e202bf5ab9d30f1928f7a1ea8911c60da595819774702eb1745e83c25cf106> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/85f2bdfed817f45a6a968aacc4e435552e4bbc687cf2ce009e6ca9477a54ba77> ;
+    mu:uuid "b3e202bf5ab9d30f1928f7a1ea8911c60da595819774702eb1745e83c25cf106" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/b0bdd05cb9b9c1cc669654f82d7694c6> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/ea446861-2c51-45fa-afd3-4e4a37b71562> .
+
+<http://data.lblod.info/id/bestuurseenheden/b5aee7f43fc9c5d0df74e2cbb9214c03c425cf026b1fd77dd1e3b08e5fc7f875> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/4a185d6781bd817e33ed6bb97132445c12d7b220e7f99c7002b6d2354677ade9> ;
+    mu:uuid "b5aee7f43fc9c5d0df74e2cbb9214c03c425cf026b1fd77dd1e3b08e5fc7f875" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/ec41ea9ff2d54d14e2781f1cc3ccbbd1> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/b6fb86dcca01c89d6787801c958d6b8551f3755ec6f1c35bb97c0cf37b9ddc2c> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/425135926db1f63a01686d826efabdb07442615456ecaef3c2f8ee5dba2b5ef2> ;
+    mu:uuid "b6fb86dcca01c89d6787801c958d6b8551f3755ec6f1c35bb97c0cf37b9ddc2c" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/f3da087130feaa62255d5da14a09a229> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/b77b75f239b9a14e40750981aa88976e46df7ddf83c3554103409a4a2291fea3> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/14ba7b137855a27dd8f54d7080e6646a5934b0132795989726a2831105b7df1c> ;
+    mu:uuid "b77b75f239b9a14e40750981aa88976e46df7ddf83c3554103409a4a2291fea3" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/86791f83395c236dfed230dce34c03be> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/b7af3483cb5d0021c6f5864a433b211fce30246ef685621d104b1951915c21c4> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/d5322c74cb8b451d4757ac610de1fc66f175edb5de5067905f0242ee3fdf3d2e> ;
+    mu:uuid "b7af3483cb5d0021c6f5864a433b211fce30246ef685621d104b1951915c21c4" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/9de0b7956e52b55dc3e917f22a8cae35> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/b7e07299d7acf9e78f802915227b243c31fc56eadfb575039b81fb871eec9755> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/39173049fa95c468999d3862c3e6d22184c604d0864d6e56d1660886e17ca3c7> ;
+    mu:uuid "b7e07299d7acf9e78f802915227b243c31fc56eadfb575039b81fb871eec9755" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/3ceefc40281ec80bc1c419f9a1968c21> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/b9fd6a7fa1ddabcaa0eb9d2eac74b41d5671623a6799a520308daabb53d5937d> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/b2210a5a4c983d3d816810c7505a6d88044f339410fd4c5e99840caecf3c56aa> ;
+    mu:uuid "b9fd6a7fa1ddabcaa0eb9d2eac74b41d5671623a6799a520308daabb53d5937d" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/fb4cf3c3a825a7b706f2549eab4ce8df> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/bb9a9db9c00189c27a851f0b772772675cba77e2463ab734477d00e4294db5df> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/91f20335b9abf4a0c889f093e4b3c78b05e91a5521c5c62a9f9c7ce1e781734f> ;
+    mu:uuid "bb9a9db9c00189c27a851f0b772772675cba77e2463ab734477d00e4294db5df" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/44216f927514aab07c470d41feb67590> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/beff71011cde3ac0ee0d94b592462be141cc9f0deb5c6ea996ea191bf79ae2fe> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/6a0c13d42aa0d9b82938428b9edf57d7a774327df537fdc417677e99381523cd> ;
+    mu:uuid "beff71011cde3ac0ee0d94b592462be141cc9f0deb5c6ea996ea191bf79ae2fe" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/9a89385bf476786eb19008c3460ca0dc> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/bfc36f138e0c7d11757eb321d034cfbffce281679eae93c2bc5df1048aa05789> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/89ddf15274eeb22c3c57193da59a9ead20cf58698538174163b9bba5611147d5> ;
+    mu:uuid "bfc36f138e0c7d11757eb321d034cfbffce281679eae93c2bc5df1048aa05789" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/8e79c4be00bc08edef830545809ec4a5> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/ea446861-2c51-45fa-afd3-4e4a37b71562> .
+
+<http://data.lblod.info/id/bestuurseenheden/c16d166294750ae2c48acae9855a49cd3280a3597c0d8f3257021c68fdede345> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/fdf0277aa959274815858b48ea42da6144a81a0aea64ae23b7d7e80579d43a51> ;
+    mu:uuid "c16d166294750ae2c48acae9855a49cd3280a3597c0d8f3257021c68fdede345" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/a240a32bdaae8a60079d2ccf12961ef6> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/c1fcc0a6c6132cb34dff9ed6e6f361d1587c211ac8ec1ddef409510bf68b724b> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/75e9cc3cc64580d9b104488a88a632d1e8b2deb3e1c6a4b7b2da9d9811044d8f> ;
+    mu:uuid "c1fcc0a6c6132cb34dff9ed6e6f361d1587c211ac8ec1ddef409510bf68b724b" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/ffc26b9f7c788d6e358ed828d11ed447> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/ea446861-2c51-45fa-afd3-4e4a37b71562> .
+
+<http://data.lblod.info/id/bestuurseenheden/c5726151c11e3ec6dd94a158ead5e9bd9e4a7307ab76e4f64da20fc526d481aa> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/01a2ca344444cf2de0b39c360d580aa9e693325f999f9e38546d88c06de01da3> ;
+    mu:uuid "c5726151c11e3ec6dd94a158ead5e9bd9e4a7307ab76e4f64da20fc526d481aa" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/f6dc15210d7fb45376069c6882b505d0> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/c747c462297c0fd1d31076b8f5b20e23aa3309ccb0f5b0b072097aa7612950e9> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/8b300836960ce59e3ebf1320e4118c72dedb72661dd8bcba577cf36d892821e2> ;
+    mu:uuid "c747c462297c0fd1d31076b8f5b20e23aa3309ccb0f5b0b072097aa7612950e9" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/dab06c7135dc12adfff963881e06a24e> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/c74e71fb4ccf2e143731873471a890b87076a9b1dcc470b937b339d7c191fce4> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/e45fd61c422cb12a3658329d2800c0454d076f3ef327d85b1770008b63208a88> ;
+    mu:uuid "c74e71fb4ccf2e143731873471a890b87076a9b1dcc470b937b339d7c191fce4" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/9f402948fd27301d1c51899375ce09c0> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/ea446861-2c51-45fa-afd3-4e4a37b71562> .
+
+<http://data.lblod.info/id/bestuurseenheden/c7778ecc532ee037ab821de348f7c6d98ed5b2401abce2e7da64687290c08962> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/de07d26f44dbaca489d9035adf9eb30afce1bfd1abc2e7f7efc630638a053eac> ;
+    mu:uuid "c7778ecc532ee037ab821de348f7c6d98ed5b2401abce2e7da64687290c08962" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/53c6885fc523d80c14c667a2afa26a47> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/c7d15b793e42f0024e56ae7a89d02f8d6f491ec42cd2ece4c856ee24b154559d> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/ecb65bf33d3ba44a6ac92d943055804489338cfd734143efdb626b0aeb50a023> ;
+    mu:uuid "c7d15b793e42f0024e56ae7a89d02f8d6f491ec42cd2ece4c856ee24b154559d" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/e8bc9ec49d3247bc78ff29fc8dbaf33d> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/c8d171d9735146131fcb9e2ad7f4e271585b0bf68f7a43d8873b6848576d13a1> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/cfd9fa4a3f264ad5c078fb8a2b3c95961111f5d72e6f28cf150550b7dbdfbeae> ;
+    mu:uuid "c8d171d9735146131fcb9e2ad7f4e271585b0bf68f7a43d8873b6848576d13a1" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/c0ee05e2ab030bf4f43a35c1cae1d200> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/ea446861-2c51-45fa-afd3-4e4a37b71562> .
+
+<http://data.lblod.info/id/bestuurseenheden/cbb5b8b80d03be75744a41580e5658b3c236fa0a12822bbb334f893c524b5b18> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/b6e251e60b037a47a91d17c6eb425c947a53b6ed3cdd8cabfd658f7e06b052ab> ;
+    mu:uuid "cbb5b8b80d03be75744a41580e5658b3c236fa0a12822bbb334f893c524b5b18" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/9dcdfaeec371810b724d9cf21ab68404> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/cdcd4403-d4cd-4400-80a3-9882d79933f4> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/f693cfc7-cff0-45ba-b14e-5909fa44f53e> ;
+    mu:uuid "cdcd4403-d4cd-4400-80a3-9882d79933f4" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/94b10872cc8d0f8aa5bc759f9b591c80> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/d39a7017044dcf082194095e3b3ec72de112bd47528e32125c697be1aa3c10cd> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/f096935f73c43031f40870a199d16b5c3c3f7fd40175d69b79101166085ac1fb> ;
+    mu:uuid "d39a7017044dcf082194095e3b3ec72de112bd47528e32125c697be1aa3c10cd" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/cc3784430b2cf0129696b0caf7f5d82c> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/d5d6693850ba1a749739c4574e7c75a98820629fdbbbbb143b7a4f7c279247ea> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/c050f157c6245b37e76b6b30ef86366468f35f3246132498cbfa70dfde0595b4> ;
+    mu:uuid "d5d6693850ba1a749739c4574e7c75a98820629fdbbbbb143b7a4f7c279247ea" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/ca9977c725bd71fe8a866da6f41c2420> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/d6fe7204ffe4c6c227156eb34caddcd860f911cc98728f9593d9cd7d28d3161d> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/c5ba07931db18028a4d4cb80d2669af22423b0462fa87ebd6e293db528ef9d94> ;
+    mu:uuid "d6fe7204ffe4c6c227156eb34caddcd860f911cc98728f9593d9cd7d28d3161d" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/8376152c78d9de1afd8f0bb25168a0b5> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/d71ddb7a663a892d7a8cb511d30bf5ae3ba49fda39dd65e39dae9c789bb901fe> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/adb881199e615daa2f40a6f85d3104c9049a11f33586c9206e96c640b645bc9e> ;
+    mu:uuid "d71ddb7a663a892d7a8cb511d30bf5ae3ba49fda39dd65e39dae9c789bb901fe" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/eddcf52c4b91de7bb0da5e886b49a0f5> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/d847f2f345c5e58882e0e468c31de8868e71a73f4cbfa63823de17da3c7f1942> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/55aba9f90468aaf5bf183c372c1e55bd6965bc35d880e6ec81203f4a82556734> ;
+    mu:uuid "d847f2f345c5e58882e0e468c31de8868e71a73f4cbfa63823de17da3c7f1942" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/f93c5874a7e14e733f5f315d963bc69b> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/d8cb6ca314f27d657f4043f27110632e63a9520070728922d3c958f51d70c281> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/4afbdfef4de7314c2637a9f950b13bb9b0b4eaaf3413c0bd5d0600852a9d7cb3> ;
+    mu:uuid "d8cb6ca314f27d657f4043f27110632e63a9520070728922d3c958f51d70c281" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/f830c830aed0783c61771fb1ef424ce1> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/d8d1b52a9170168ad481f2495652e1b9753aea23385f79710abd86549f1373fa> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/48bec23540ae5d2245d91c76f23dcedc81ec2017278bbabc4346a84ec4903270> ;
+    mu:uuid "d8d1b52a9170168ad481f2495652e1b9753aea23385f79710abd86549f1373fa" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/cec61ea09de65d05509c5c129c4788ce> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/da737a74e5094054c3bb3ef077839626a02eb79d148e15cfeee18e10c18ba55a> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/e2de092d6d6f30a83b1b8c91906495d8dcc7cd9680e87ed5cc19b8bf7501a0da> ;
+    mu:uuid "da737a74e5094054c3bb3ef077839626a02eb79d148e15cfeee18e10c18ba55a" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/e1934b2633ba1ebd9fdd409d65ed68bf> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/dad37923-85b4-4c30-8bd6-050061bde51c> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/a567b3fdb462a8513ffeeff0188317003c5bbb7debb8f1ea9245b83e1d43b437> ;
+    mu:uuid "dad37923-85b4-4c30-8bd6-050061bde51c" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/1e19d395b77345c1ec5f10f2f9c999f1> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/db299add14cc24e7a99ce4eb51015f32925690fb9816962e500f3341842ef6fa> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/6b6a521137288cd2f3c5df056e5d8f8c2ca141a8df7f79970570396bd6e10906> ;
+    mu:uuid "db299add14cc24e7a99ce4eb51015f32925690fb9816962e500f3341842ef6fa" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/d752b7f04f2a41da6b2a6b132a94cc30> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/ea446861-2c51-45fa-afd3-4e4a37b71562> .
+
+<http://data.lblod.info/id/bestuurseenheden/db5adb1e2e7ad0e33725b83edda44f9b4638e328a1534a1b4eef2683d337975a> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/3d5480a03b2653c5f9b349ee8647a937d9eb16db9c6468e8e1530b7316c92b02> ;
+    mu:uuid "db5adb1e2e7ad0e33725b83edda44f9b4638e328a1534a1b4eef2683d337975a" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/f891bb0ca0508918b3ac986ad3a4fbee> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/ea446861-2c51-45fa-afd3-4e4a37b71562> .
+
+<http://data.lblod.info/id/bestuurseenheden/dbfedd56289924d8a7cc26a5aada392281547e053a10c0678238fc08a219fb6e> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/6e0773c6a722b0a0b9129c5abd3ef5c1ccb9a971e06f0336a588b51a54eb673d> ;
+    mu:uuid "dbfedd56289924d8a7cc26a5aada392281547e053a10c0678238fc08a219fb6e" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/7b5b05ee65bdc2e4a7f2ea8667fd3b94> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/dce9ffab7edf87d670ce7ec399084fc2e12c6b5bb300b865e87c5237beae4ae0> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/c0b4dbf6f9094005734ed39d822d593e23131a1905cacf06f062b85347bdb808> ;
+    mu:uuid "dce9ffab7edf87d670ce7ec399084fc2e12c6b5bb300b865e87c5237beae4ae0" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/226be29aab090913dda8526c9bbb5164> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/dea71925b69de424a8bb3c90ad5751f39c35df9e85ade437e6f6404b3ba12a42> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/79f91b113626756412f89b63aabf065fd6ea3e01b3363be0b67a14db33306f1d> ;
+    mu:uuid "dea71925b69de424a8bb3c90ad5751f39c35df9e85ade437e6f6404b3ba12a42" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/12ec00c07cdf6d3567fba7a34a940d70> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/e06ce64825e386178b350aa6b2fa869c70ad39aa99ddb3ca2a73d6b103e91161> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/4fc21bc6ce8f7f432898fdbe8744475da7a6fad9795161caafaf7334da9130c0> ;
+    mu:uuid "e06ce64825e386178b350aa6b2fa869c70ad39aa99ddb3ca2a73d6b103e91161" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/496fbf75498761d75f55b7076b92d55f> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/e39d8bf95a03ade08ef25a79ebc050abfc81a69731f1de66fe6d031d27135aac> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/86df93514bd4a67a271ab417360cdd48aef0cde3097e0d2cda530fe0928f7cca> ;
+    mu:uuid "e39d8bf95a03ade08ef25a79ebc050abfc81a69731f1de66fe6d031d27135aac" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/3fffe0228181a34bf7fe853d27cb3afd> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/e4f4aa293734f92302439270cf98805e4b617088cb19144b558db2dff087d886> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/7c9e256f391224a292d4442b5eb8733ea182453cec07b63a8a6f7565d6557edf> ;
+    mu:uuid "e4f4aa293734f92302439270cf98805e4b617088cb19144b558db2dff087d886" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/7ed780f1a51045e1d4759286472aecbb> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/e5f3c3f23f6791de122a5e6f1af83543651d272eba40e138c2fdf91ec05f8a40> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/e60532b5e10070b48664b998e12af31cd4e612a0b8d089804d0bbed3d4ecc969> ;
+    mu:uuid "e5f3c3f23f6791de122a5e6f1af83543651d272eba40e138c2fdf91ec05f8a40" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/0bfaf11d86673964fc07e08c122d29b0> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/e65a70ecf702fb23f1447e234eab584fe788e9618fb7d52cd1d562718207b499> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/ccc9a56fc9b4aac3251ed5246f30adac67f0485de608d8938f70fd0a9a623e4d> ;
+    mu:uuid "e65a70ecf702fb23f1447e234eab584fe788e9618fb7d52cd1d562718207b499" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/322c282d5639892919c47056ec9c3cdf> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/e7692f99-9a36-43e3-af78-b320390318dc> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/f5fb4bfdcace41c988294f5c1d87fed6> ;
+    mu:uuid "e7692f99-9a36-43e3-af78-b320390318dc" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/fc441f679c945f8ab069134677f7b6a0> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/e8bd746e2dc3c5a72fe4fb3da0c92803b0728150bdd66e860d6218bc83098941> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/c0b24dd8a61c37d3282455386eb428da19cb5a42b01d48ef3b9c75fa0953f7d9> ;
+    mu:uuid "e8bd746e2dc3c5a72fe4fb3da0c92803b0728150bdd66e860d6218bc83098941" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/493dce50513610e7942fe2de709d06ad> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/ea446861-2c51-45fa-afd3-4e4a37b71562> .
+
+<http://data.lblod.info/id/bestuurseenheden/ee07affaf869f10517967da1ba7e79151646a1f3621b3cbca591cec2b8c549b7> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/6ed3cb8a5fd176871d49ee6872725e11019b78c718968acbbdd520a660002a49> ;
+    mu:uuid "ee07affaf869f10517967da1ba7e79151646a1f3621b3cbca591cec2b8c549b7" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/04684e5538ff71a3fbb60c54dd2a2c9b> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/eed6ef4fd7723fca33613bb9c9570825be3f8e50c32ce9456ded3d54bc624370> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/e1a7aa197d1fa117ad5fdc30dee57cf95974c149ed0f319237bb8fb1355d911e> ;
+    mu:uuid "eed6ef4fd7723fca33613bb9c9570825be3f8e50c32ce9456ded3d54bc624370" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/0218108d2807608eb1bf0e5a39ceaff7> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/f398f3ebafe08244f84eac783b61eac71c60bd39b8ca9ee8d9c2a4dc8638a772> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/ae494f69be10f82afa1d7b0937abd22f490e09d268c743ea7b8e6a66c516d4fc> ;
+    mu:uuid "f398f3ebafe08244f84eac783b61eac71c60bd39b8ca9ee8d9c2a4dc8638a772" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/8b1571f9a7a322dc7a57f53427016142> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/f4838c2bb548a35f92a6ddcf725676b9f137f3fcb11e6737caa7cab1f1314e27> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/2546a39800c91088ed65bbe14a35d514db3e55359042462741c743a8ff18bda2> ;
+    mu:uuid "f4838c2bb548a35f92a6ddcf725676b9f137f3fcb11e6737caa7cab1f1314e27" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/0c2c60218ee97fb37181139e665db852> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/f5094b8d7f26d69d04ba2c469a09e0c6dc08a78615c9483fd97d6d029e064121> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/b7912bab36c83905f9ec209cb5dcf10acf3ad04c9cc1e110e2e9432974081555> ;
+    mu:uuid "f5094b8d7f26d69d04ba2c469a09e0c6dc08a78615c9483fd97d6d029e064121" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/221952d5a0f44581269e601ef6173bbb> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/fa52110c7c3e70feab724980e2d991a97712a1deeeb25b168ef6de7b16de41ae> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/807b80c2d93f102149c86585cbc8aee2bd56a924a81e5e7408b0208208642f40> ;
+    mu:uuid "fa52110c7c3e70feab724980e2d991a97712a1deeeb25b168ef6de7b16de41ae" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/7563ad99cfac5c8bcd8a7204aa135b99> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuurseenheden/ff7d80dc-ec00-43ac-ac7e-d51694df37ff> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/f5fb4bfdcace41c988294f5c1d87fed6> ;
+    mu:uuid "ff7d80dc-ec00-43ac-ac7e-d51694df37ff" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/2ca564e45451e29d8613495f14aa5d36> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> .
+
+<http://data.lblod.info/id/bestuursorganen/004b987f2b84e3aca78d5e03fba1c76656c4daa206486320ef786cd917ef40fb> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/cbb5b8b80d03be75744a41580e5658b3c236fa0a12822bbb334f893c524b5b18> ;
+    mu:uuid "004b987f2b84e3aca78d5e03fba1c76656c4daa206486320ef786cd917ef40fb" ;
+    skos:prefLabel "Politieraad Politiezone van Beersel" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/0264941d3fa9def69cf7bd61f98087911ada1dc46d7c55ae4427d98b04e7f56d> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/165a9a64a6b84a278806b11c3f760f48198990168f591cf7a7462beb0f2cb16b> ;
+    mu:uuid "0264941d3fa9def69cf7bd61f98087911ada1dc46d7c55ae4427d98b04e7f56d" ;
+    skos:prefLabel "Politieraad POLITIEZONE : DAMME - KNOKKE-HEIST" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/02e41f1ee0b643ee75ec9ee4f09b09b44ba720521dd0ccc2b68ce9e5c58f945a> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/7b1c9132de06d5b3626e7118dc16c7f129d7c911b3298a0f4609725372e64588> ;
+    mu:uuid "02e41f1ee0b643ee75ec9ee4f09b09b44ba720521dd0ccc2b68ce9e5c58f945a" ;
+    skos:prefLabel "Politieraad Politiezone van Ninove" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/06b24bc1d86fdf607eb16266e47d3e9c6c0c1d900eaa07501626e61f12e9c7dc> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/39e3e46f7cf031133152e763eaa26cab3df81f842f9912a25c69c445f0c428b8> ;
+    mu:uuid "06b24bc1d86fdf607eb16266e47d3e9c6c0c1d900eaa07501626e61f12e9c7dc" ;
+    skos:prefLabel "Politieraad POLITIEZONE : ARDOOIE - LICHTERVELDE - PITTEM - RUISELEDE - TIELT - WINGENE" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/08c77182a1b66166f8ffcaa4ac4903cd66d8c10ad587c058b6e229070a7159a4> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/505e727b7b078c3eb9a05f754d834fca559d28cb3cdb02d5e4cdb3be300ea699> ;
+    mu:uuid "08c77182a1b66166f8ffcaa4ac4903cd66d8c10ad587c058b6e229070a7159a4" ;
+    skos:prefLabel "Zoneraad HULPVERLENINGSZONE NOORD-LIMBURG" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/a9e30e31-0cd2-4f4a-9352-545c5d43be83> .
+
+<http://data.lblod.info/id/bestuursorganen/0935eb02a30042b77a03353ba0b546fe64ef129d57eb4b23b511d3da36aef921> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/46616861cfaae13b550a36ae5c05187638df0873024f13043d3f40f24cabf4e6> ;
+    mu:uuid "0935eb02a30042b77a03353ba0b546fe64ef129d57eb4b23b511d3da36aef921" ;
+    skos:prefLabel "Politieraad POLITIEZONE : BOOM - HEMIKSEM - NIEL - RUMST - SCHELLE" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/0945a9bf1486486617901058b957936d5f9a79d7dfce12404a8bc4437674eadd> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/7dd1250996188607bb1e28df1ebea0b943e8db59c08ea01e3c57672531c43ec6> ;
+    mu:uuid "0945a9bf1486486617901058b957936d5f9a79d7dfce12404a8bc4437674eadd" ;
+    skos:prefLabel "Politieraad POLITIEZONE : KRUIBEKE - TEMSE" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/0b2f136de55ce294f4ddeb0e677056180f247d384e50864ed2ca1710a329d53c> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/c5726151c11e3ec6dd94a158ead5e9bd9e4a7307ab76e4f64da20fc526d481aa> ;
+    mu:uuid "0b2f136de55ce294f4ddeb0e677056180f247d384e50864ed2ca1710a329d53c" ;
+    skos:prefLabel "Politieraad POLITIEZONE : DENDERLEEUW - HAALTERT" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/0cf860c877d526d6bd27bac991627e03e2178581f76f3ee7684bfcf8c00f8312> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/9893dc25d4b91aef9e2ef6f712e0aac68cdf6f144dbed887c9500e6360df080d> ;
+    mu:uuid "0cf860c877d526d6bd27bac991627e03e2178581f76f3ee7684bfcf8c00f8312" ;
+    skos:prefLabel "Politieraad POLITIEZONE : BOCHOLT - BREE - KINROOI - MEEUWEN-GRUITRODE" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/12d6dd992c699c1229532d2dbfe600502a2dc42577095ce835b4824037655301> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/beff71011cde3ac0ee0d94b592462be141cc9f0deb5c6ea996ea191bf79ae2fe> ;
+    mu:uuid "12d6dd992c699c1229532d2dbfe600502a2dc42577095ce835b4824037655301" ;
+    skos:prefLabel "Politieraad POLITIEZONE : KRAAINEM - WEZEMBEEK-OPPEM" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/1754b3b92f34e1ec5edd8a92cb62185b087f9a19f4a30634152c92c3f66a10b6> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/479036ca47b011e16fefafbe4d3512a44c564804dc26d331ce4dcbe0fa3366d2> ;
+    mu:uuid "1754b3b92f34e1ec5edd8a92cb62185b087f9a19f4a30634152c92c3f66a10b6" ;
+    skos:prefLabel "Politieraad POLITIEZONE : DEERLIJK - HARELBEKE" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/17ccfb25-d79f-4f85-9380-c677c875e873> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/ff7d80dc-ec00-43ac-ac7e-d51694df37ff> ;
+    mu:uuid "17ccfb25-d79f-4f85-9380-c677c875e873" ;
+    skos:prefLabel "Politieraad Lokale politiezone Hasselt - Zonhoven - Diepenbeek - Halen - Herk-de-Stad - Lummen" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/a9e30e31-0cd2-4f4a-9352-545c5d43be83> .
+
+<http://data.lblod.info/id/bestuursorganen/17d1ecc1-e882-4dd1-9c72-419cb9dbce4a> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/81dd243d-f66c-4157-b105-5407aa83cb62> ;
+    mu:uuid "17d1ecc1-e882-4dd1-9c72-419cb9dbce4a" ;
+    skos:prefLabel "Politieraad Politiezone Rivierenland" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/a9e30e31-0cd2-4f4a-9352-545c5d43be83> .
+
+<http://data.lblod.info/id/bestuursorganen/187722a4ab2900cf7670f6c836bef6e154be17718a8d3ce13fc367d5523ca11b> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/e06ce64825e386178b350aa6b2fa869c70ad39aa99ddb3ca2a73d6b103e91161> ;
+    mu:uuid "187722a4ab2900cf7670f6c836bef6e154be17718a8d3ce13fc367d5523ca11b" ;
+    skos:prefLabel "Politieraad POLITIEZONE : AALTER - KNESSELARE" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/1b2ca21f9ecbd86c0b40f620bfbf5369c09c74934f62f2bddfff1aaa902f5624> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/1db0e6fb09e60db1e8534b20c69abb03584870612717a454937717be9b7fd019> ;
+    mu:uuid "1b2ca21f9ecbd86c0b40f620bfbf5369c09c74934f62f2bddfff1aaa902f5624" ;
+    skos:prefLabel "Politieraad Politiezone Lanaken-Maasmechelen" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/1e2f978c307054084fcdedf5c4be33ab69bbdf9dd35acc68642e47ddac631557> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/f5094b8d7f26d69d04ba2c469a09e0c6dc08a78615c9483fd97d6d029e064121> ;
+    mu:uuid "1e2f978c307054084fcdedf5c4be33ab69bbdf9dd35acc68642e47ddac631557" ;
+    skos:prefLabel "Politieraad Politiezone : Berlaar-Nijlen" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/211936f624c114f75167200429b21b03f90fd73bc2fd2547f710af01f8e07a61> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/dea71925b69de424a8bb3c90ad5751f39c35df9e85ade437e6f6404b3ba12a42> ;
+    mu:uuid "211936f624c114f75167200429b21b03f90fd73bc2fd2547f710af01f8e07a61" ;
+    skos:prefLabel "Politieraad Politiezone van Tervuren" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/26133b05ed497e1947dec9db08433fe4d23f69ff212e73bbe20934fe0c866ba4> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/1298cc0fec62af4dcaa86b44d43fe7e3ee3632247e66e8fccd87c0e5c7b7742f> ;
+    mu:uuid "26133b05ed497e1947dec9db08433fe4d23f69ff212e73bbe20934fe0c866ba4" ;
+    skos:prefLabel "Politieraad Politiezone van Schoten" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/26b6df4738ce1915b1668117c9d28247819f79ecda5d178185f0259d1b37e0ee> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/d8cb6ca314f27d657f4043f27110632e63a9520070728922d3c958f51d70c281> ;
+    mu:uuid "26b6df4738ce1915b1668117c9d28247819f79ecda5d178185f0259d1b37e0ee" ;
+    skos:prefLabel "Politieraad Politiezone van Lokeren" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/29a196a3af4194ae03dfacdfd783b5ec4931448185a12c858e5715ac766db579> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/e5f3c3f23f6791de122a5e6f1af83543651d272eba40e138c2fdf91ec05f8a40> ;
+    mu:uuid "29a196a3af4194ae03dfacdfd783b5ec4931448185a12c858e5715ac766db579" ;
+    skos:prefLabel "Politieraad Politiezone van Aalst" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/2b2bf786c8dc07a9ee59a1bf6170ecaaebf6c67baee55c8677149e6d54fac759> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/d8d1b52a9170168ad481f2495652e1b9753aea23385f79710abd86549f1373fa> ;
+    mu:uuid "2b2bf786c8dc07a9ee59a1bf6170ecaaebf6c67baee55c8677149e6d54fac759" ;
+    skos:prefLabel "Politieraad POLITIEZONE : EEKLO - KAPRIJKE - SINT-LAUREINS" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/2c264a56e7cdaac776517d8162c8fc0c02a0ef22cd1e9b5a51d8e13f56073aa0> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/da737a74e5094054c3bb3ef077839626a02eb79d148e15cfeee18e10c18ba55a> ;
+    mu:uuid "2c264a56e7cdaac776517d8162c8fc0c02a0ef22cd1e9b5a51d8e13f56073aa0" ;
+    skos:prefLabel "Politieraad POLITIEZONE : BIERBEEK - BOUTERSEM - HOLSBEEK - LUBBEEK" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/2c773267a6abad81d35999e1dac030fe573e701fca079c897f6eebccbc4481e1> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/fa52110c7c3e70feab724980e2d991a97712a1deeeb25b168ef6de7b16de41ae> ;
+    mu:uuid "2c773267a6abad81d35999e1dac030fe573e701fca079c897f6eebccbc4481e1" ;
+    skos:prefLabel "Politieraad POLITIEZONE : DENTERGEM - INGELMUNSTER - MEULEBEKE - OOSTROZEBEKE - WIELSBEKE" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/2c83a12918acc239a4d2958a09abfb091cff07b35b651f5e5b55389f43aef448> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/68ad1301fbb5f209b4ef0fe2b11e77c7bea6011f5e28f8f6875597a7b08f0f1e> ;
+    mu:uuid "2c83a12918acc239a4d2958a09abfb091cff07b35b651f5e5b55389f43aef448" ;
+    skos:prefLabel "Politieraad POLITIEZONE : DE PANNE - KOKSIJDE - NIEUWPOORT" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/2e4a5825d4b64ae25ef6d7ad3905b05321d07df2ce6bd3758596d5b9d0ee8e59> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/08b125860dd7716256dd35ba2e38a009206555f29adc44642c655450a471ebef> ;
+    mu:uuid "2e4a5825d4b64ae25ef6d7ad3905b05321d07df2ce6bd3758596d5b9d0ee8e59" ;
+    skos:prefLabel "Politieraad POLITIEZONE : HERZELE - SINT-LIEVENS-HOUTEM - ZOTTEGEM" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/2ff3993d5a331fbbb17a790b8d52eb2c70e9f79955dac42116121f76ff1cadc7> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/520ae455030cb427fa5dead38ba62d2975fcf2d0f695d365cf9e84b5b5b5b73e> ;
+    mu:uuid "2ff3993d5a331fbbb17a790b8d52eb2c70e9f79955dac42116121f76ff1cadc7" ;
+    skos:prefLabel "Politieraad POLITIEZONE : LANDEN - LINTER - ZOUTLEEUW" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/32e6367265dddd8b602418bd0a3fcdade33245036b8042cd20aa9688c3abf3e4> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/c747c462297c0fd1d31076b8f5b20e23aa3309ccb0f5b0b072097aa7612950e9> ;
+    mu:uuid "32e6367265dddd8b602418bd0a3fcdade33245036b8042cd20aa9688c3abf3e4" ;
+    skos:prefLabel "Politieraad POLITIEZONE : LAARNE - WETTEREN - WICHELEN" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/34eef1f5170f387676229e79cc2486446f7607b1ed928d0cd62d81feaccf2924> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/e4f4aa293734f92302439270cf98805e4b617088cb19144b558db2dff087d886> ;
+    mu:uuid "34eef1f5170f387676229e79cc2486446f7607b1ed928d0cd62d81feaccf2924" ;
+    skos:prefLabel "Politieraad Politiezone Zennevallei" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/3539915d9303229e6e9d178499431c08499afed4bd03b80af86bf92adac7425a> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/c74e71fb4ccf2e143731873471a890b87076a9b1dcc470b937b339d7c191fce4> ;
+    mu:uuid "3539915d9303229e6e9d178499431c08499afed4bd03b80af86bf92adac7425a" ;
+    skos:prefLabel "Zoneraad HULPVERLENINGSZONE BRANDWEER WESTHOEK" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/a9e30e31-0cd2-4f4a-9352-545c5d43be83> .
+
+<http://data.lblod.info/id/bestuursorganen/38f52872be00c52972eda82ed35f738b9a4e30e407d31712cbe2188d77341d10> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/4deae42b2b25bff407f5abc7cbb6d62eb02afaf2892086341c324fdf2c0e6e92> ;
+    mu:uuid "38f52872be00c52972eda82ed35f738b9a4e30e407d31712cbe2188d77341d10" ;
+    skos:prefLabel "Politieraad POLITIEZONE : KLUISBERGEN - KRUISHOUTEM - OUDENAARDE - WORTEGEM-PETEGEM - ZINGEM" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/3a22c1079e1d82d832ba4209590adbb910f0a4dea29ecf4900eeeaf0eaf2023e> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/7ddda00fc45a0994092bc26f30d97352b7586676438d5557b3f5cc336daab063> ;
+    mu:uuid "3a22c1079e1d82d832ba4209590adbb910f0a4dea29ecf4900eeeaf0eaf2023e" ;
+    skos:prefLabel "Politieraad POLITIEZONE : KAMPENHOUT - STEENOKKERZEEL - ZEMST" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/3b4188f6e3ac8959cb305c1063d9371f67b3b231173c0dbea27620bba30878bd> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/b6fb86dcca01c89d6787801c958d6b8551f3755ec6f1c35bb97c0cf37b9ddc2c> ;
+    mu:uuid "3b4188f6e3ac8959cb305c1063d9371f67b3b231173c0dbea27620bba30878bd" ;
+    skos:prefLabel "Politieraad POLITIEZONE : HERENT - KORTENBERG" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/3cedfab88e82ad5a694f2628b81966a3d40b1dfba13c0c02f33d0ef877e14254> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/414f3538e482d3c1c21382ca22de18998ca1d3f5b517ced85946ecf90143149c> ;
+    mu:uuid "3cedfab88e82ad5a694f2628b81966a3d40b1dfba13c0c02f33d0ef877e14254" ;
+    skos:prefLabel "Politieraad POLITIEZONE : BERLARE - ZELE" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/3f2c09c994b9153ae8af1cccbe4646558679f26f446b1aa848d1cd8c54f32b89> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/3b7a6d691943806c23f59d22482dea27e451bd440f91f884aeb42e8c72016ee3> ;
+    mu:uuid "3f2c09c994b9153ae8af1cccbe4646558679f26f446b1aa848d1cd8c54f32b89" ;
+    skos:prefLabel "Politieraad Politiezone van Maldegem" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/3f4a8a4e95eb1811a283ff327fa17b24199e60a125cb543244dfd407a89502c0> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/0b1af0370213e4b8ea5c3d5a2ccadcfce1149d092da47a3e447fe383050f9506> ;
+    mu:uuid "3f4a8a4e95eb1811a283ff327fa17b24199e60a125cb543244dfd407a89502c0" ;
+    skos:prefLabel "Politieraad Politiezone van Lommel" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/404211a388065f93cf963479ebd82c8b1c322322a1268586f82cd5139fd66b65> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/9e2072f69e9c1ecd1af7f65a234f141ef6cfe36eb63b2758d54d1414618188ff> ;
+    mu:uuid "404211a388065f93cf963479ebd82c8b1c322322a1268586f82cd5139fd66b65" ;
+    skos:prefLabel "Politieraad POLITIEZONE : DIEPENBEEK - HASSELT - ZONHOVEN" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/40e0181b3b8f67b85087032373a067e2fdade2971c062fbd3b342548377fff74> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/0610b306e95fae751dc07050565e987f31ba06420863bc44616b2e05452d8822> ;
+    mu:uuid "40e0181b3b8f67b85087032373a067e2fdade2971c062fbd3b342548377fff74" ;
+    skos:prefLabel "Politieraad POLITIEZONE : AFFLIGEM - LIEDEKERKE - ROOSDAAL - TERNAT" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/41fd4bf87df07ff3cb1f697a68f240b1464c735cf0d49e1b0f98f7d698753b5f> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/097191c539cc02e6044671221f3ea0a8428c7fbc8dbdd5f38ee8f02ca51c6082> ;
+    mu:uuid "41fd4bf87df07ff3cb1f697a68f240b1464c735cf0d49e1b0f98f7d698753b5f" ;
+    skos:prefLabel "Politieraad Politiezone van Antwerpen" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/422b28a3193cd2a0e656c96c3d003883909d52e828e5abb2235d31e957defe4f> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/215d1409dda860a1ce4f39f1f6c082c5662620d9d29de456f4242fb6cc6df0b5> ;
+    mu:uuid "422b28a3193cd2a0e656c96c3d003883909d52e828e5abb2235d31e957defe4f" ;
+    skos:prefLabel "Zoneraad HULPVERLENINGSZONE BRANDWEER ZONE KEMPEN" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/a9e30e31-0cd2-4f4a-9352-545c5d43be83> .
+
+<http://data.lblod.info/id/bestuursorganen/4253826e1f8aa01e9d6700e0444b7bbcf6f4bdea53f2d48264327d0f1f59502f> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/306340a51c1504e59f1c3b85c1ba1b62de8c70cb94d3998f27819761bcee5a98> ;
+    mu:uuid "4253826e1f8aa01e9d6700e0444b7bbcf6f4bdea53f2d48264327d0f1f59502f" ;
+    skos:prefLabel "Politieraad POLITIEZONE : ARENDONK - RAVELS - RETIE" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/4674408ed3bea722e6b4553f5b53c9aa06805bc625dc949607b25be7967ec351> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/c8d171d9735146131fcb9e2ad7f4e271585b0bf68f7a43d8873b6848576d13a1> ;
+    mu:uuid "4674408ed3bea722e6b4553f5b53c9aa06805bc625dc949607b25be7967ec351" ;
+    skos:prefLabel "Zoneraad Hulpverleningszone Brandweer zone Antwerpen" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/a9e30e31-0cd2-4f4a-9352-545c5d43be83> .
+
+<http://data.lblod.info/id/bestuursorganen/4996e6041d12eafb2487012c627351f6d9056bbc3727aa21928fb6f400b21b55> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/9b1af8b3306f7f2966d2326a7a301c149d2a62db4803335aaffae9ff45fe068d> ;
+    mu:uuid "4996e6041d12eafb2487012c627351f6d9056bbc3727aa21928fb6f400b21b55" ;
+    skos:prefLabel "Politieraad Politiezone van Lanaken" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/4b51012e90f99de11e64330e37243fa137517d0f2dab74f4a3f1dbc71ebbdba8> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/8a72024e99b1e083aca28a026122ad2bc517372bc18e95210fb54f080136e3f8> ;
+    mu:uuid "4b51012e90f99de11e64330e37243fa137517d0f2dab74f4a3f1dbc71ebbdba8" ;
+    skos:prefLabel "Politieraad Politiezone van Heusden-Zolder" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/4c182202196da6c3c4c8ac48799ef1a4716eb6f7b314c50df6b5b43ac2d86adf> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/95871bddebd4ad93db54cb1b40d41af29f7ce08f0b59698b0540be129a9a3433> ;
+    mu:uuid "4c182202196da6c3c4c8ac48799ef1a4716eb6f7b314c50df6b5b43ac2d86adf" ;
+    skos:prefLabel "Politieraad POLITIEZONE : DIKSMUIDE - HOUTHULST - KOEKELARE - KORTEMARK" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/4f68440b-432f-41be-a29a-d1344ba3bab4> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/81334af3-1b6f-4308-aca3-107121462d56> ;
+    mu:uuid "4f68440b-432f-41be-a29a-d1344ba3bab4" ;
+    skos:prefLabel "Politieraad Politiezone Getevallei" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/a9e30e31-0cd2-4f4a-9352-545c5d43be83> .
+
+<http://data.lblod.info/id/bestuursorganen/4fa94fc5d0edc7ed240afe744203039fba6f54d3419ab4b1ce3883f63e9a074e> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/7800a6f5e9c3f646e274b280703730ed5e83fe0cba1f0d6c7fb18141337fe781> ;
+    mu:uuid "4fa94fc5d0edc7ed240afe744203039fba6f54d3419ab4b1ce3883f63e9a074e" ;
+    skos:prefLabel "Zoneraad HULPVERLENINGSZONE BRANDWEERZONE OOST-LIMBURG" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/a9e30e31-0cd2-4f4a-9352-545c5d43be83> .
+
+<http://data.lblod.info/id/bestuursorganen/507a094c51995bc6963861872b45024125aa631cfd733b7266fabbcb3b2cd1fb> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/ab9269754d1266e010c1878a1199525898f0846ff0e9a0add9e7fbaed42ac43c> ;
+    mu:uuid "507a094c51995bc6963861872b45024125aa631cfd733b7266fabbcb3b2cd1fb" ;
+    skos:prefLabel "Politieraad Politiezone van Willebroek" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/51ca586d220ada4e87b51545d1521844006911705581b8da99658471fd357cb0> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/db299add14cc24e7a99ce4eb51015f32925690fb9816962e500f3341842ef6fa> ;
+    mu:uuid "51ca586d220ada4e87b51545d1521844006911705581b8da99658471fd357cb0" ;
+    skos:prefLabel "Zoneraad HULPVERLENINGSZONE OOST" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/a9e30e31-0cd2-4f4a-9352-545c5d43be83> .
+
+<http://data.lblod.info/id/bestuursorganen/5381222906f03160eff7fd29b40bbfd32a02a79dc9e9fcdcf55a87346212509b> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/4bb83a0635b69132a4de91667c0a30f228720bda01584b3a01c4cf7ddfc12664> ;
+    mu:uuid "5381222906f03160eff7fd29b40bbfd32a02a79dc9e9fcdcf55a87346212509b" ;
+    skos:prefLabel "Zoneraad HULPVERLENINGSZONE CENTRUM (OOST-VLAANDEREN)" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/a9e30e31-0cd2-4f4a-9352-545c5d43be83> .
+
+<http://data.lblod.info/id/bestuursorganen/53963fc2687a8c7e92fda2324242c47af3dc04c30c00722bf7087b00f24b3841> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/04e7a09c988feed3cf8df1c51aafe0f0a50811e325f5f5ab8e1b9750f48630fd> ;
+    mu:uuid "53963fc2687a8c7e92fda2324242c47af3dc04c30c00722bf7087b00f24b3841" ;
+    skos:prefLabel "Politieraad Politiezone van Middelkerke" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/53e96e3b-3ace-463a-bf31-4a8ce363e355> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/e7692f99-9a36-43e3-af78-b320390318dc> ;
+    mu:uuid "53e96e3b-3ace-463a-bf31-4a8ce363e355" ;
+    skos:prefLabel "Politieraad POLITIEZONE CARMA: AS - BOCHOLT - BREE - GENK- HOUTHALEN-HELCHTEREN - KINROOI - OUDSBERGEN - ZUTENDAAL" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/a9e30e31-0cd2-4f4a-9352-545c5d43be83> .
+
+<http://data.lblod.info/id/bestuursorganen/541b806a3c4045c5f81edcb4c25200d2fce9e7b692ef6083ee118604d1ddb011> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/488938bd557800723290a816c51b471fff7f4918237a509f697973af6f509390> ;
+    mu:uuid "541b806a3c4045c5f81edcb4c25200d2fce9e7b692ef6083ee118604d1ddb011" ;
+    skos:prefLabel "Politieraad Politiezone Van Beveren" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/55005ebf67b2f2c48ae5e3473eeb06d7fc61c3a4e62405ab8c9bb774bd9a6ac7> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/c16d166294750ae2c48acae9855a49cd3280a3597c0d8f3257021c68fdede345> ;
+    mu:uuid "55005ebf67b2f2c48ae5e3473eeb06d7fc61c3a4e62405ab8c9bb774bd9a6ac7" ;
+    skos:prefLabel "Politieraad POLITIEZONE : DE PINTE - GAVERE - NAZARETH - SINT-MARTENS-LATEM" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/5630c479e87a659fb90e8de670e01be62e79af57aee3c5c15f08b971412a2116> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/d71ddb7a663a892d7a8cb511d30bf5ae3ba49fda39dd65e39dae9c789bb901fe> ;
+    mu:uuid "5630c479e87a659fb90e8de670e01be62e79af57aee3c5c15f08b971412a2116" ;
+    skos:prefLabel "Politieraad Politiezone van Maasmechelen" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/65a8794da5b83d35831749f2cfa9801d3d586cbdf0dfb1252165d21f8daaabea> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/805a977a29725d94f50bf7f0d91a0de1a727c4eec88940e90035f71c6c9b1655> ;
+    mu:uuid "65a8794da5b83d35831749f2cfa9801d3d586cbdf0dfb1252165d21f8daaabea" ;
+    skos:prefLabel "Politieraad POLITIEZONE : RANST - ZANDHOVEN" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/6d354234eb83462afaefcd82fd294669d50e75c4a4487c8388c4ed7a0c381603> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/b312420a9e4331da36afd70237db5061825cacadcdaa68e6ad0f1ea8a9426f77> ;
+    mu:uuid "6d354234eb83462afaefcd82fd294669d50e75c4a4487c8388c4ed7a0c381603" ;
+    skos:prefLabel "Zoneraad HULPVERLENINGSZONE BRANDWEERZONE MIDWEST" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/a9e30e31-0cd2-4f4a-9352-545c5d43be83> .
+
+<http://data.lblod.info/id/bestuursorganen/7108a2070c5e6ca2f3cb2fd09ffc4bd8a86a16321671385210863381f7d4441b> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/195d911f1417b20a4b715b1a54e8ae6e92b9a23cde908f2fb03a0081910d8fce> ;
+    mu:uuid "7108a2070c5e6ca2f3cb2fd09ffc4bd8a86a16321671385210863381f7d4441b" ;
+    skos:prefLabel "Politieraad POLITIEZONE : HEUVELLAND - IEPER - LANGEMARK - POELKAPELLE - MESEN - MOORSLEDE - POPERINGE - STADEN - VLETEREN - WERVIK - ZONNEBEKE" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/71b56a20685680191b2926df026b4f0d4e3783ad914a7ffeeff3c038ed61f1f5> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/c1fcc0a6c6132cb34dff9ed6e6f361d1587c211ac8ec1ddef409510bf68b724b> ;
+    mu:uuid "71b56a20685680191b2926df026b4f0d4e3783ad914a7ffeeff3c038ed61f1f5" ;
+    skos:prefLabel "Zoneraad HULPVERLENINGSZONE TAXANDRIA" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/a9e30e31-0cd2-4f4a-9352-545c5d43be83> .
+
+<http://data.lblod.info/id/bestuursorganen/7339599327f9e9f2e4343765481362b230c40cdf3fc557c94ad8ac0272754b91> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/bb9a9db9c00189c27a851f0b772772675cba77e2463ab734477d00e4294db5df> ;
+    mu:uuid "7339599327f9e9f2e4343765481362b230c40cdf3fc557c94ad8ac0272754b91" ;
+    skos:prefLabel "Politieraad POLITIEZONE : AARTSELAAR - EDEGEM - HOVE - KONTICH - LINT" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/747267050b26f1ed68f3976a31f00bd3bcf623bab12041517f2fcf52663e131f> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/a3b32431cfbb18905e2c7deeaf9ef7af35cd17c55d053a05ed9cd8fdec550724> ;
+    mu:uuid "747267050b26f1ed68f3976a31f00bd3bcf623bab12041517f2fcf52663e131f" ;
+    skos:prefLabel "Zoneraad HULPVERLENINGSZONE ZUIDWEST LIMBURG" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/a9e30e31-0cd2-4f4a-9352-545c5d43be83> .
+
+<http://data.lblod.info/id/bestuursorganen/758ff2bb253ba40d70a4a62da94322a00f67e55d0fb7f921ff83b782f3deba64> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/e65a70ecf702fb23f1447e234eab584fe788e9618fb7d52cd1d562718207b499> ;
+    mu:uuid "758ff2bb253ba40d70a4a62da94322a00f67e55d0fb7f921ff83b782f3deba64" ;
+    skos:prefLabel "Politieraad Politiezone van Dilbeek" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/78749cf2dd2a1bbb21c7bfaca988a5a7e28068e9dc60242ea7d6e7b3c2a4a255> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/97a393c64a3c30e619bc115ab8b2bbe0bd7a83265ebb8960c0f1154b9628d340> ;
+    mu:uuid "78749cf2dd2a1bbb21c7bfaca988a5a7e28068e9dc60242ea7d6e7b3c2a4a255" ;
+    skos:prefLabel "Politieraad POLITIEZONE NETELAND" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/7881c32d87abf297f1dc67539cec5c591ebf575d5ef9d07fc90ed4b80c6c1089> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/81083789b63917e32ab90ef1a45adf893f370ee38da2e0542e5c035db4f60794> ;
+    mu:uuid "7881c32d87abf297f1dc67539cec5c591ebf575d5ef9d07fc90ed4b80c6c1089" ;
+    skos:prefLabel "Politieraad POLITIEZONE : BEGIJNENDIJK - ROTSELAAR - TREMELO" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/7ac3312ad5d3fca9f72841899f31613a547adf28a170483b0f139c1011af0147> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/c7778ecc532ee037ab821de348f7c6d98ed5b2401abce2e7da64687290c08962> ;
+    mu:uuid "7ac3312ad5d3fca9f72841899f31613a547adf28a170483b0f139c1011af0147" ;
+    skos:prefLabel "Politieraad POLITIEZONE : KAPELLE-OP-DEN-BOS - LONDERZEEL - MEISE" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/7adc5c6e3eb50c334f24db19778c27133ecb306c544b6751b1d1012bad479f76> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/5d55c0281e70d053158a06a7898bb3e1a89ed48cf111c4b6fc2a9502ebafcade> ;
+    mu:uuid "7adc5c6e3eb50c334f24db19778c27133ecb306c544b6751b1d1012bad479f76" ;
+    skos:prefLabel "Politieraad Politiezone van Sint-Niklaas" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/7aee63f3ec64c6e55b3f5c4c23397926d7c1e61ec8e652ddd306709e777f7d26> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/08b6bdc2c34dacae28168cf967ef2e13384f032a147ddaea7f1145eff4f0d161> ;
+    mu:uuid "7aee63f3ec64c6e55b3f5c4c23397926d7c1e61ec8e652ddd306709e777f7d26" ;
+    skos:prefLabel "Politieraad POLITIEZONE : BERINGEN - HAM - TESSENDERLO" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/7b5215124b24a9a33df4707169b06b5730ed6fb126b6c37e11ca3f94e037e8d8> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/80a9ab8eb46716ab23c597d13313ce24b17884ffcbdf00d216b877d57a52ade4> ;
+    mu:uuid "7b5215124b24a9a33df4707169b06b5730ed6fb126b6c37e11ca3f94e037e8d8" ;
+    skos:prefLabel "Politieraad POLITIEZONE : BOECHOUT - BORSBEEK - MORTSEL - WIJNEGEM - WOMMELGEM" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/7bf046650a0ef8a7b38818cf3610ee872206f905a20bc1574811af2947ea21e1> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/d6fe7204ffe4c6c227156eb34caddcd860f911cc98728f9593d9cd7d28d3161d> ;
+    mu:uuid "7bf046650a0ef8a7b38818cf3610ee872206f905a20bc1574811af2947ea21e1" ;
+    skos:prefLabel "Politieraad POLITIEZONE : MACHELEN - VILVOORDE" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/7e3cbc1cae3d258a31c15541262cbe1b90dc5bc7cf9029d92451abe503b27333> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/5dab8a7b0656aaf0db13044fcafc0088f9f0b7776c294a6e9abfdbf7420effae> ;
+    mu:uuid "7e3cbc1cae3d258a31c15541262cbe1b90dc5bc7cf9029d92451abe503b27333" ;
+    skos:prefLabel "Politieraad POLITIEZONE : BRECHT - MALLE - SCHILDE - ZOERSEL" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/88e23bccae1f08fddcc8ca1982bff6946d0696fe9090dc1eacdbe68023d91c8d> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/19ac0fa207989c27c3391e327aee16435475292296f010867945bf2987f95477> ;
+    mu:uuid "88e23bccae1f08fddcc8ca1982bff6946d0696fe9090dc1eacdbe68023d91c8d" ;
+    skos:prefLabel "Politieraad POLITIEZONE : BILZEN - HOESELT - RIEMST" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/89453c0cf3385de05258a703220298a0e9d75dd2252beb14edb0f025188ee960> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/35454115a5e3a31059e0c4fd55906df42c75885b0233c1f17eb4bcef6e696908> ;
+    mu:uuid "89453c0cf3385de05258a703220298a0e9d75dd2252beb14edb0f025188ee960" ;
+    skos:prefLabel "Politieraad Politiezone van Leuven" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/89be9e5bcacbdd2ae16ca49530384556eec0c029e6b51a684e3373503d36b864> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/b77b75f239b9a14e40750981aa88976e46df7ddf83c3554103409a4a2291fea3> ;
+    mu:uuid "89be9e5bcacbdd2ae16ca49530384556eec0c029e6b51a684e3373503d36b864" ;
+    skos:prefLabel "Politieraad Politiezone van Lier" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/8d63ee68e96eb864947685aac31dfbae3780af1810ed9ff6fd11d513c1508cca> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/92609bcab00475b084e747cb49f942abfb9e737ab023a999c69baf60acb8c06d> ;
+    mu:uuid "8d63ee68e96eb864947685aac31dfbae3780af1810ed9ff6fd11d513c1508cca" ;
+    skos:prefLabel "Politieraad Politiezone van Voeren" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/8fa0b4e410ca016fdb944c37978f9ee112fe6ad70eed1e1fde9a7aad31ea03f8> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/9fdf19f0cfc9e12bd58fc10c4da6e8c6c40e813ec5b9f3bdde92cb00ecd972fe> ;
+    mu:uuid "8fa0b4e410ca016fdb944c37978f9ee112fe6ad70eed1e1fde9a7aad31ea03f8" ;
+    skos:prefLabel "Zoneraad HULPVERLENINGSZONE OOST (VLAAMS-BRABANT)" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/a9e30e31-0cd2-4f4a-9352-545c5d43be83> .
+
+<http://data.lblod.info/id/bestuursorganen/940f5bdc2899c0006f5f31b7df009408f9b4c0035d2a089e834c17786935fa95> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/abca98258a8436dd7f74c633f0b60c7e50b407a1bb27777c102a1963f8843f8b> ;
+    mu:uuid "940f5bdc2899c0006f5f31b7df009408f9b4c0035d2a089e834c17786935fa95" ;
+    skos:prefLabel "Politieraad POLITIEZONE : HALEN - HERK-DE-STAD - LUMMEN" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/9593e8a4472b19cbadbf8c97cc6c4b9dd93b3534fe2d74ea59fdd432ccfe90f6> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/b9fd6a7fa1ddabcaa0eb9d2eac74b41d5671623a6799a520308daabb53d5937d> ;
+    mu:uuid "9593e8a4472b19cbadbf8c97cc6c4b9dd93b3534fe2d74ea59fdd432ccfe90f6" ;
+    skos:prefLabel "Politieraad Politiezone van Sint-Pieters-Leeuw" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/968a33b1e856d58ddaf843e6db9829450b21be0f05dde0f7a91caec338282a3c> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/e8bd746e2dc3c5a72fe4fb3da0c92803b0728150bdd66e860d6218bc83098941> ;
+    mu:uuid "968a33b1e856d58ddaf843e6db9829450b21be0f05dde0f7a91caec338282a3c" ;
+    skos:prefLabel "Zoneraad HULPVERLENINGSZONE WAASLAND" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/a9e30e31-0cd2-4f4a-9352-545c5d43be83> .
+
+<http://data.lblod.info/id/bestuursorganen/9b1a2ab43fcf8b21768c71f23fd6b3dc5722d611326d1d629b8a771e0be5a975> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/b2fdc615ffb131e53a200e14c74ac92d4ed6dac176e3e6ea2c79d227835077c9> ;
+    mu:uuid "9b1a2ab43fcf8b21768c71f23fd6b3dc5722d611326d1d629b8a771e0be5a975" ;
+    skos:prefLabel "Politieraad POLITIEZONE : HOOGSTRATEN - MERKSPLAS - RIJKEVORSEL" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/9b88397e55811b1692f49da30f220bc30b88fe076c2e44ca3bf04dbf90a2cc71> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/7e526f7f2d12f55a06620b512401826b6855ed478ff0693e04fba59cabba3c4d> ;
+    mu:uuid "9b88397e55811b1692f49da30f220bc30b88fe076c2e44ca3bf04dbf90a2cc71" ;
+    skos:prefLabel "Politieraad POLITIEZONE : BUGGENHOUT - LEBBEKE" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/9c2e36ea480ca2a0ea41ab119b1c7921a31428aebf29bde2d59ee6b5c5a56d87> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/0594a740b99274c7347f3492ae4d05f9b05d057a1cbad30683634296e189cc38> ;
+    mu:uuid "9c2e36ea480ca2a0ea41ab119b1c7921a31428aebf29bde2d59ee6b5c5a56d87" ;
+    skos:prefLabel "Politieraad POLITIEZONE : KAPELLEN - STABROEK" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/9dc5edb53c4e1b72143f5c257f40595d6214f7b8c6681f7cc84d5fc9d81053f3> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/c7d15b793e42f0024e56ae7a89d02f8d6f491ec42cd2ece4c856ee24b154559d> ;
+    mu:uuid "9dc5edb53c4e1b72143f5c257f40595d6214f7b8c6681f7cc84d5fc9d81053f3" ;
+    skos:prefLabel "Politieraad POLITIEZONE : BREDENE - DE HAAN" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/9f532e59a3250a39ec638593724303f00766acb9a8451c67c74eb7ef8cc417c8> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/3efb7cb7fad9f61917093d42513c8a7153120906e9701b08e3560c8f109e64c1> ;
+    mu:uuid "9f532e59a3250a39ec638593724303f00766acb9a8451c67c74eb7ef8cc417c8" ;
+    skos:prefLabel "Politieraad Politiezone Midden-Limburg" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/9fb9c51277ac35fb14673f4cc240047aa65ce7185ab39ed593675eb4b5ccc37e> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/31bceaaaa3f4019e85edfe0e509340aa30554d0f3bb343616841c20641788b6e> ;
+    mu:uuid "9fb9c51277ac35fb14673f4cc240047aa65ce7185ab39ed593675eb4b5ccc37e" ;
+    skos:prefLabel "Politieraad POLITIEZONE : HAMME - WAASMUNSTER" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/9fbfc20d279f6eb9434c7edfc75814827a3fb2316b7dccd6d7b74a46b3081ac2> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/41d31a2eb697af977aadf64c73e0bcffb094e0f20e4017fe3b49c507079c0976> ;
+    mu:uuid "9fbfc20d279f6eb9434c7edfc75814827a3fb2316b7dccd6d7b74a46b3081ac2" ;
+    skos:prefLabel "Politieraad POLITIEZONE : HERSTAPPE - TONGEREN" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/a20c5acfd21334c1b82d78888d913ef16609606a2d3d19257fc5182f9f6df6cb> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/a65afe7380499a2c24c2d039f2a97493f2f99bc03836de9bb99c2c267676388f> ;
+    mu:uuid "a20c5acfd21334c1b82d78888d913ef16609606a2d3d19257fc5182f9f6df6cb" ;
+    skos:prefLabel "Politieraad POLITIEZONE : HOEGAARDEN - TIENEN" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/a36c7aa67ce72f21c3f30cb6d70b0ab4000452ad5a266a7da3a018c906278c95> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/330516b323c00851cf4b93e6d5d7a2ef4591f68ae6e71ad9c1f432ee70521bb2> ;
+    mu:uuid "a36c7aa67ce72f21c3f30cb6d70b0ab4000452ad5a266a7da3a018c906278c95" ;
+    skos:prefLabel "Politieraad Politiezone van Zwijndrecht" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/a64d98e6fbb024936acca5a9bf08adf89cd6ece4eb7c74e2de2a50218283d773> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/5ba4a42bd459dda75ce452a253ddc09547174265456ad1e3f9389a3ff139a1f9> ;
+    mu:uuid "a64d98e6fbb024936acca5a9bf08adf89cd6ece4eb7c74e2de2a50218283d773" ;
+    skos:prefLabel "Politieraad POLITIEZONE : HOOGLEDE - IZEGEM - ROESELARE" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/a6e70030d8819bb7b66cceeef854db6f883db23e3abf27adb1c61884f6d9db92> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/2ba0f1e28168459a963a81784a8404e94268f70b49f99342d50ff421ab8a06c6> ;
+    mu:uuid "a6e70030d8819bb7b66cceeef854db6f883db23e3abf27adb1c61884f6d9db92" ;
+    skos:prefLabel "Politieraad POLITIEZONE : LOVENDEGEM - NEVELE - WAARSCHOOT - ZOMERGEM" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/a76403fa66a665feae46be0fb2b1dd28702a63e70780e7034d265a0679a113c7> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/a32dc005ecbc001abd3338cdacb111895d3053b313654136ef1903035c10a53c> ;
+    mu:uuid "a76403fa66a665feae46be0fb2b1dd28702a63e70780e7034d265a0679a113c7" ;
+    skos:prefLabel "Politieraad POLITIEZONE : GISTEL - ICHTEGEM - JABBEKE - OUDENBURG - TORHOUT" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/a8572ab7614eb52a85fabd156f43eeed3b8bbad0e3f8dde37bde612c20aff8db> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/98967d1e1e3dd66ac9e32bd1d536ee8e85c9126cc5fc04354a335d5aabcf9b01> ;
+    mu:uuid "a8572ab7614eb52a85fabd156f43eeed3b8bbad0e3f8dde37bde612c20aff8db" ;
+    skos:prefLabel "Zoneraad HULPVERLENINGSZONE RIVIERENLAND" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/a9e30e31-0cd2-4f4a-9352-545c5d43be83> .
+
+<http://data.lblod.info/id/bestuursorganen/a93dd23b9b7f46a43bad1e90ea436275d2f3105ad722671fc803d37891251207> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/dbfedd56289924d8a7cc26a5aada392281547e053a10c0678238fc08a219fb6e> ;
+    mu:uuid "a93dd23b9b7f46a43bad1e90ea436275d2f3105ad722671fc803d37891251207" ;
+    skos:prefLabel "Politieraad POLITIEZONE : HERSELT - HULSTHOUT - WESTERLO" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/aa54f465bcad51fc5a644c4aeda21179021a786c6f148d497f56ca9d398986ec> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/5018524f9ceca4f9e21764f9e8e4e63d1ad6890c338c090d0dd074faccf1bfb2> ;
+    mu:uuid "aa54f465bcad51fc5a644c4aeda21179021a786c6f148d497f56ca9d398986ec" ;
+    skos:prefLabel "Politieraad Politiezone van Grimbergen" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/ab33eab78f0ac966f60f266c4263de35ebbc26a94ca210bf48bbf25127453950> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/77801115dec7f63400134c21d897a41bddb775eb438d81b354ad18fb6d7ab956> ;
+    mu:uuid "ab33eab78f0ac966f60f266c4263de35ebbc26a94ca210bf48bbf25127453950" ;
+    skos:prefLabel "Politieraad POLITIEZONE : HAMONT-ACHEL - NEERPELT - OVERPELT" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/ab5e6e3b4a0e4c66047c8968d5326bf72ab4fba2ccbaf7ecd71a1d94892d651f> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/39e0e2e69be463a4628f87bffe7dc6206aa6daa4a5516fb4ce11907f57d77079> ;
+    mu:uuid "ab5e6e3b4a0e4c66047c8968d5326bf72ab4fba2ccbaf7ecd71a1d94892d651f" ;
+    skos:prefLabel "Politieraad POLITIEZONE : BEKKEVOORT - GEETBETS - GLABBEEK - KORTENAKEN - TIELT-WINGE" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/ab9f97152062755b31241908502735be2b0ac4e263ba2e1897fd64d3e9fb12b3> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/a691d36ff95b67005d30d5fb89594dab69ec7fdbf975ffdcd36ef9bb39efb06d> ;
+    mu:uuid "ab9f97152062755b31241908502735be2b0ac4e263ba2e1897fd64d3e9fb12b3" ;
+    skos:prefLabel "Politieraad POLITIEZONE : DROGENBOS - LINKEBEEK - SINT-GENESIUS-RODE" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/abd1184a3846446e7647088a633b082195291322f77c862c76e17929ff430702> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/d847f2f345c5e58882e0e468c31de8868e71a73f4cbfa63823de17da3c7f1942> ;
+    mu:uuid "abd1184a3846446e7647088a633b082195291322f77c862c76e17929ff430702" ;
+    skos:prefLabel "Politieraad POLITIEZONE : BALEN - DESSEL - MOL" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/ac180012457e7741dbee64f40b0cc9d5526517fc9e400f339b6270cd5e000930> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/eed6ef4fd7723fca33613bb9c9570825be3f8e50c32ce9456ded3d54bc624370> ;
+    mu:uuid "ac180012457e7741dbee64f40b0cc9d5526517fc9e400f339b6270cd5e000930" ;
+    skos:prefLabel "Politieraad Politiezone van Brugge" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/ac99fb29603859cfbe1613ed9c0b8c2216a9ef86749225795a141e7cf09c71f8> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/e39d8bf95a03ade08ef25a79ebc050abfc81a69731f1de66fe6d031d27135aac> ;
+    mu:uuid "ac99fb29603859cfbe1613ed9c0b8c2216a9ef86749225795a141e7cf09c71f8" ;
+    skos:prefLabel "Politieraad POLITIEZONE : LEDEGEM - MENEN - WEVELGEM" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/ad298537d9846fce67445cb41e21c367b1073432228e4af76c9f6a9a0f4000f3> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/08293a0d743c13f37e99deddf000e75ba13f70ca6a5ac65cde49ad23d600ab3c> ;
+    mu:uuid "ad298537d9846fce67445cb41e21c367b1073432228e4af76c9f6a9a0f4000f3" ;
+    skos:prefLabel "Politieraad Politiezone van Houthalen-Helchteren" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/ad44799fe1887c1bf17259bcb799085d7e5c0c48ac941bd07451c83e2c4d3514> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/11feae29e6178a2b58ac73bb639360d58248e3e438f2201f219b95b58c6b4ef4> ;
+    mu:uuid "ad44799fe1887c1bf17259bcb799085d7e5c0c48ac941bd07451c83e2c4d3514" ;
+    skos:prefLabel "Politieraad POLITIEZONE : GINGELOM - NIEUWERKERKEN - SINT-TRUIDEN" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/ad95c28d33d2a13a5a06f81e57cfd1d6b512e9d91c5a61dd0316f675f795ff93> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/b7e07299d7acf9e78f802915227b243c31fc56eadfb575039b81fb871eec9755> ;
+    mu:uuid "ad95c28d33d2a13a5a06f81e57cfd1d6b512e9d91c5a61dd0316f675f795ff93" ;
+    skos:prefLabel "Politieraad Politiezone van Oostende" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/ad9954198d1e28df6a09568605dff85cd3a14339b765157839aa4b721497cd72> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/05354d6fcc016d06f988a0e044fb160be7573550c11fe414b3c011961150a686> ;
+    mu:uuid "ad9954198d1e28df6a09568605dff85cd3a14339b765157839aa4b721497cd72" ;
+    skos:prefLabel "Politieraad POLITIEZONE : BLANKENBERGE - ZUIENKERKE" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/afb609343e0e481dfa0a87badd69c5b5cf3f90dc7db78b557e45e9220aa78f4c> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/0cfc443c59ad06e1292b9805d967f181b989913a1ccc3e3f50a4dd8ca16bc772> ;
+    mu:uuid "afb609343e0e481dfa0a87badd69c5b5cf3f90dc7db78b557e45e9220aa78f4c" ;
+    skos:prefLabel "Politieraad POLITIEZONE : SINT-GILLIS-WAAS - STEKENE" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/b0bc13326e46496e51232f0d0c3e9bb7f17fe9d1b15c1941961676328c884591> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/2ca642d589b8012fe65bf54df3a87f740acac78624a902ad378dc4ee6c50a848> ;
+    mu:uuid "b0bc13326e46496e51232f0d0c3e9bb7f17fe9d1b15c1941961676328c884591" ;
+    skos:prefLabel "Politieraad POLITIEZONE : BEERNEM - OOSTKAMP - ZEDELGEM" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/b0c3e6a188884d1a81e2b657efb2dc852218f23051d0a9b416ecabbcb3feec0a> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/90688b32e0808b6ebbb7b36030526750236527e8019414449065f57ea384ce71> ;
+    mu:uuid "b0c3e6a188884d1a81e2b657efb2dc852218f23051d0a9b416ecabbcb3feec0a" ;
+    skos:prefLabel "Politieraad POLITIEZONE : ASSE - MERCHTEM - OPWIJK - WEMMEL" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/b16a63f8daa7b7e88f0a24f89ddee8bffd33370533641872cfeb4057eb40bc97> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/458df2d318d52e34278e4ce1886b9458351d3a4b06fe28c68a7558b0cdd528c3> ;
+    mu:uuid "b16a63f8daa7b7e88f0a24f89ddee8bffd33370533641872cfeb4057eb40bc97" ;
+    skos:prefLabel "Politieraad Politiezone van Halle" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/b2baff6c62b437755e369944c40fd5d28a3be107e78d851945086b80450b8bf7> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/4ffd00c0ba7ceab20db24832a4b9963112ed66914dcca05f3e5dc8b8b9d4479d> ;
+    mu:uuid "b2baff6c62b437755e369944c40fd5d28a3be107e78d851945086b80450b8bf7" ;
+    skos:prefLabel "Politieraad POLITIEZONE : ESSEN - KALMTHOUT - WUUSTWEZEL" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/b2fb65f57be7f634463ecd414b87e8ccc512646c679b8d2b30260f0a881413fc> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/f398f3ebafe08244f84eac783b61eac71c60bd39b8ca9ee8d9c2a4dc8638a772> ;
+    mu:uuid "b2fb65f57be7f634463ecd414b87e8ccc512646c679b8d2b30260f0a881413fc" ;
+    skos:prefLabel "Politieraad Politiezone van Ronse" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/b360183023767a27503c1caa77ea9e1dbb03c7eb7b4a6f74e3b8f6e3b3964120> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/97028faf77fd95eb5016a13c19f3a3a8ccf97c6c937398ba96976e52d171dbd8> ;
+    mu:uuid "b360183023767a27503c1caa77ea9e1dbb03c7eb7b4a6f74e3b8f6e3b3964120" ;
+    skos:prefLabel "Politieraad POLITIEZONE : DILSEN-STOKKEM - MAASEIK" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/b56f7e3603c0883b4a154efb32f1db15fc73ea475fe4057bbfad4b5fefba66bc> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/52bda330e11552b586106748bf652e5dd41163670d5c4226b2c02bfa2f579946> ;
+    mu:uuid "b56f7e3603c0883b4a154efb32f1db15fc73ea475fe4057bbfad4b5fefba66bc" ;
+    skos:prefLabel "Politieraad Politiezone van Heist-op-den-Berg" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/b7b67e8a09ac43ecf65485c89c219b5d501ebb4790dcc05ea5603dbd8ac15678> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/541c1603eb8c01968f95d1f262854134499e00d135cd7c9147d307ccbd1e20fd> ;
+    mu:uuid "b7b67e8a09ac43ecf65485c89c219b5d501ebb4790dcc05ea5603dbd8ac15678" ;
+    skos:prefLabel "Politieraad Politiezone Beveren - Sint-Gillis-Waas - Stekene" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/b7d3654a54cc34984824a41bcc328c283008962389d5247702170cf207443f4c> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/b5aee7f43fc9c5d0df74e2cbb9214c03c425cf026b1fd77dd1e3b08e5fc7f875> ;
+    mu:uuid "b7d3654a54cc34984824a41bcc328c283008962389d5247702170cf207443f4c" ;
+    skos:prefLabel "Politieraad POLITIEZONE : HOEILAART - OVERIJSE" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/b96b772e0f64eb4c56501da6d968fdc8b6dfaa88b15160aa312f5dffb7dfd598> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/3b2c2151632d84c55dd93372a4e91a7493455a7f77a90fa2066fc618411d0ed6> ;
+    mu:uuid "b96b772e0f64eb4c56501da6d968fdc8b6dfaa88b15160aa312f5dffb7dfd598" ;
+    skos:prefLabel "Politieraad POLITIEZONE : BORNEM - PUURS - SINT-AMANDS" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/bb72a29ac24ac0a56df9164c8d6cf249edd45ab79b02c5b12a2492b1eae2f216> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/1915208b0a66992ee2014df894f7a9c538fe727a975fd9538d9e2c949e1a8471> ;
+    mu:uuid "bb72a29ac24ac0a56df9164c8d6cf249edd45ab79b02c5b12a2492b1eae2f216" ;
+    skos:prefLabel "Politieraad Politiezone van Mechelen" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/be543b6840f2f8bbea7c8a73e4ba0516d7b1bc68e20cb67fef64dd9a9f4b8cda> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/7271a57b8249b4dd3175f50ea96c66ff536eff057c6bc0acfe40281e2a91ddc2> ;
+    mu:uuid "be543b6840f2f8bbea7c8a73e4ba0516d7b1bc68e20cb67fef64dd9a9f4b8cda" ;
+    skos:prefLabel "Politieraad POLITIEZONE : GEEL - LAAKDAL - MEERHOUT" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/bf33e5da250eea04c3dcbd657a3cbed1d91d99478cc8c30795bf9ed2e7f1b451> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/bfc36f138e0c7d11757eb321d034cfbffce281679eae93c2bc5df1048aa05789> ;
+    mu:uuid "bf33e5da250eea04c3dcbd657a3cbed1d91d99478cc8c30795bf9ed2e7f1b451" ;
+    skos:prefLabel "Zoneraad HULPVERLENINGSZONE VLAAMSE ARDENNEN" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/a9e30e31-0cd2-4f4a-9352-545c5d43be83> .
+
+<http://data.lblod.info/id/bestuursorganen/c029d98db12366b386c5699466a2e6c7ff6df25e3d9233a1d04c368b204eff9d> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/73777b2512fc25f16554612a13b0de2265a56540a5ea6665bf69a8b5a805569a> ;
+    mu:uuid "c029d98db12366b386c5699466a2e6c7ff6df25e3d9233a1d04c368b204eff9d" ;
+    skos:prefLabel "Politieraad Lokale Politiezone Mechelen - Willebroek" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/c03a73f68f70d447ec6ca07a2319c57e6e961b8ae91c25f7277e79d341cb8c96> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/db5adb1e2e7ad0e33725b83edda44f9b4638e328a1534a1b4eef2683d337975a> ;
+    mu:uuid "c03a73f68f70d447ec6ca07a2319c57e6e961b8ae91c25f7277e79d341cb8c96" ;
+    skos:prefLabel "Zoneraad HULPVERLENINGSZONE ZUID-OOST" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/a9e30e31-0cd2-4f4a-9352-545c5d43be83> .
+
+<http://data.lblod.info/id/bestuursorganen/c1d75d5eb7e1613c82482b16a535581baeade6c855b8fc071c13cd35850bdc6f> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/0e951dd15341d38413bf809f16ef5f1bd163092001ac04ce78a4de5b5e9cdd37> ;
+    mu:uuid "c1d75d5eb7e1613c82482b16a535581baeade6c855b8fc071c13cd35850bdc6f" ;
+    skos:prefLabel "Zoneraad HULPVERLENINGSZONE MEETJESLAND" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/a9e30e31-0cd2-4f4a-9352-545c5d43be83> .
+
+<http://data.lblod.info/id/bestuursorganen/c1fcc12b652bef30c8bc0f94ef48ce3d407354a786bcf6c2267d30f3f5f80309> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/3efcad40be18e793d070f78a44f2e63bc105778d6c8c4edc4bfeb5a87f06554c> ;
+    mu:uuid "c1fcc12b652bef30c8bc0f94ef48ce3d407354a786bcf6c2267d30f3f5f80309" ;
+    skos:prefLabel "Politieraad POLITIEZONE : BERTEM - HULDENBERG - OUD-HEVERLEE" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/c4cfb722c3a4ba20cba22164bc7597340c1c9b1913514ef0ba98f5e61ce38c93> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/41e3bb71cb1fe2763a64ce47ee758fbeb532fbd4348281f34a86a5f88dd71980> ;
+    mu:uuid "c4cfb722c3a4ba20cba22164bc7597340c1c9b1913514ef0ba98f5e61ce38c93" ;
+    skos:prefLabel "Politieraad POLITIEZONE : DIEST- SCHERPENHEUVEL - ZICHEM" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/c6d47f5cad3ec5e6dcb2d1b80d7ea0fdf5a69ebe96960937d0cf132f0cfbfab2> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/d5d6693850ba1a749739c4574e7c75a98820629fdbbbbb143b7a4f7c279247ea> ;
+    mu:uuid "c6d47f5cad3ec5e6dcb2d1b80d7ea0fdf5a69ebe96960937d0cf132f0cfbfab2" ;
+    skos:prefLabel "Politieraad POLITIEZONE : BOORTMEERBEEK - HAACHT - KEERBERGEN" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/ccbe5e3d265dfd3ce8d9285c2503e32e7765c8e828e1c265cdf3a62e1cf34574> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/2d25be1712e809bbeed7d439c93bace752e0742f6b2ed9802302dec9a8906e2a> ;
+    mu:uuid "ccbe5e3d265dfd3ce8d9285c2503e32e7765c8e828e1c265cdf3a62e1cf34574" ;
+    skos:prefLabel "Zoneraad HULPVERLENINGSZONE 3 ZONE RAND" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/a9e30e31-0cd2-4f4a-9352-545c5d43be83> .
+
+<http://data.lblod.info/id/bestuursorganen/ce368a23e7112f17589787d268262c601e571757c01d5093f595a466b6a2f33b> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/150440a8bb763d6f53d24ca1c6f1460cb5817c8a261fd90e74aadac3292c3efe> ;
+    mu:uuid "ce368a23e7112f17589787d268262c601e571757c01d5093f595a466b6a2f33b" ;
+    skos:prefLabel "Politieraad POLITIEZONE : ALKEN - BORGLOON - HEERS - KORTESSEM - WELLEN" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/ce89601ffc39063e9ad5c12ba4f48bcc08abac984770b835a559b2e1ab19de94> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/b7af3483cb5d0021c6f5864a433b211fce30246ef685621d104b1951915c21c4> ;
+    mu:uuid "ce89601ffc39063e9ad5c12ba4f48bcc08abac984770b835a559b2e1ab19de94" ;
+    skos:prefLabel "Politieraad POLITIEZONE : BRAKEL - HOREBEKE - MAARKEDAL - ZWALM" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/cfce8c6db32a54a3624966bb828a392ecc778931b47afdac5cbe498d47d63d62> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/a31131dd72b614c89184b331821c10a0f8feb109881a1b164749e9c8941c5e6b> ;
+    mu:uuid "cfce8c6db32a54a3624966bb828a392ecc778931b47afdac5cbe498d47d63d62" ;
+    skos:prefLabel "Politieraad POLITIEZONE : BAARLE-HERTOG - BEERSE - KASTERLEE - LILLE - OUD-TURNHOUT - TURNHOUT - VOSSELAAR" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/cfeec004a6df1722afc124323465073ad24e06a05bc9c75a49ca2ea304daba9c> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/7b6bbae823b20191525038cd52089d22128163fb3c7f851ce56149938628d941> ;
+    mu:uuid "cfeec004a6df1722afc124323465073ad24e06a05bc9c75a49ca2ea304daba9c" ;
+    skos:prefLabel "Politieraad POLITIEZONE : ANZEGEM - AVELGEM - SPIERE-HELKIJN - WAREGEM - ZWEVEGEM" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/d0537227-526a-4207-bdf2-73c8b429bf87> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/cdcd4403-d4cd-4400-80a3-9882d79933f4> ;
+    mu:uuid "d0537227-526a-4207-bdf2-73c8b429bf87" ;
+    skos:prefLabel "Politieraad POLITIEZONE VOER EN DIJLE" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/a9e30e31-0cd2-4f4a-9352-545c5d43be83> .
+
+<http://data.lblod.info/id/bestuursorganen/d07bdcbb9b05dada8889e5ff93c429c09e537537936cd2ae59a4bee33c07a4d9> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/25572d6c63bc386d742bbb6ac0d8ddc739dc0599e156c6eac68aca492390840e> ;
+    mu:uuid "d07bdcbb9b05dada8889e5ff93c429c09e537537936cd2ae59a4bee33c07a4d9" ;
+    skos:prefLabel "Politieraad POLITIEZONE : GERAARDSBERGEN - LIERDE" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/d23fcee888e47314beee898cec76eca886c07d0413c792718b608d366c0480d1> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/ee07affaf869f10517967da1ba7e79151646a1f3621b3cbca591cec2b8c549b7> ;
+    mu:uuid "d23fcee888e47314beee898cec76eca886c07d0413c792718b608d366c0480d1" ;
+    skos:prefLabel "Politieraad POLITIEZONE : HECHTEL-EKSEL - LEOPOLDSBURG - PEER" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/d3a9b2bff1eb0652e49bf1592a054a6b1d6e20bb8289f49d2b3af53e48e01965> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/5187962dfd40789953d4fbde3634751ee90b48b17147c585ccf4f2ac1ee72fd3> ;
+    mu:uuid "d3a9b2bff1eb0652e49bf1592a054a6b1d6e20bb8289f49d2b3af53e48e01965" ;
+    skos:prefLabel "Politieraad Politiezone van Gent" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/d3f90bedf300b3c9e7a5f5c8e8e58ea71cdde59d54abd03e4b95493b513769ce> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/782682349b24078a97dc181bdb7dc62fb2cabc072878fc75a29f4ed70c86250d> ;
+    mu:uuid "d3f90bedf300b3c9e7a5f5c8e8e58ea71cdde59d54abd03e4b95493b513769ce" ;
+    skos:prefLabel "Politieraad Politiezone van Zaventem" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/d98423cff5784cadd05c42746992d58ebaa69889f78c418a0e42ced64b616faa> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/f4838c2bb548a35f92a6ddcf725676b9f137f3fcb11e6737caa7cab1f1314e27> ;
+    mu:uuid "d98423cff5784cadd05c42746992d58ebaa69889f78c418a0e42ced64b616faa" ;
+    skos:prefLabel "Politieraad POLITIEZONE : BONHEIDEN - DUFFEL - PUTTE - SINT-KATELIJNE-WAVER" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/da092eb82f28e5b9a8ad46e07a685d3933ea02aabb9a74ea16e82b6926e620bc> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/7cb2089a8c6746d514711908abfd38414a2b01f6ad9a83f28be2e835888b3da7> ;
+    mu:uuid "da092eb82f28e5b9a8ad46e07a685d3933ea02aabb9a74ea16e82b6926e620bc" ;
+    skos:prefLabel "Politieraad POLITIEZONE : BEVER - GALMAARDEN - GOOIK - HEME - LENNIK - PEPINGEN" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/dd5a962f3e6aff1e164db672a8131610846bd7aaffe152d5c08b02c15f097011> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/9d0e3fc23f4fb9c23cbcc30474a1e518c9725c069255090d46eb58c13d62baef> ;
+    mu:uuid "dd5a962f3e6aff1e164db672a8131610846bd7aaffe152d5c08b02c15f097011" ;
+    skos:prefLabel "Zoneraad HULPVERLENINGSZONE FLUVIA" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/a9e30e31-0cd2-4f4a-9352-545c5d43be83> .
+
+<http://data.lblod.info/id/bestuursorganen/dd70da7c5ce9d89360ad524dca8351df7089d466577acac0bb4148a631d52c9d> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/477e468496131b7d35f145b0361bca5c2cad577fd9ec27d385d703942dc944d0> ;
+    mu:uuid "dd70da7c5ce9d89360ad524dca8351df7089d466577acac0bb4148a631d52c9d" ;
+    skos:prefLabel "Politieraad POLITIEZONE : KORTRIJK - KUURNE - LENDELEDE" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/df83801b70823aac84d779d91bc91d75ae51f246b2e9d90ae1d231b09a15f0c4> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/93389f5157ceb037c5e38d7b8119cef632528b870e91e209c033bc2eac220cc1> ;
+    mu:uuid "df83801b70823aac84d779d91bc91d75ae51f246b2e9d90ae1d231b09a15f0c4" ;
+    skos:prefLabel "Politieraad POLITIEZONE REGIO RHODE & SCHELDE" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/e1737a57a865e2f0140136f68d9a44dab686277b79ca997ef27f6d23b9efc4c5> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/d39a7017044dcf082194095e3b3ec72de112bd47528e32125c697be1aa3c10cd> ;
+    mu:uuid "e1737a57a865e2f0140136f68d9a44dab686277b79ca997ef27f6d23b9efc4c5" ;
+    skos:prefLabel "Politieraad POLITIEZONE : GENK - AS - OPGLABEEK - ZUTENDAAL" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/e25f74be-d10f-418d-ac4a-60ce47cc64f2> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/dad37923-85b4-4c30-8bd6-050061bde51c> ;
+    mu:uuid "e25f74be-d10f-418d-ac4a-60ce47cc64f2" ;
+    skos:prefLabel "Politieraad Politiezone Deinze – Zulte – Lievegem" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/a9e30e31-0cd2-4f4a-9352-545c5d43be83> .
+
+<http://data.lblod.info/id/bestuursorganen/e45525033ffa6011bc3564afe993eccc94e237daa1b3cd78dec8ecc5c9a30cc2> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/622fa725ba8455b01817c8e48974edeab56607018fce5c1cb3694306d3e7005c> ;
+    mu:uuid "e45525033ffa6011bc3564afe993eccc94e237daa1b3cd78dec8ecc5c9a30cc2" ;
+    skos:prefLabel "Politieraad POLITIEZONE : ERPE-MERE - LEDE" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/e53aba91d448d36d34599d43f00c9b1b25df34ba0cfdfb4504a8633bcdd0aa7e> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/b3e202bf5ab9d30f1928f7a1ea8911c60da595819774702eb1745e83c25cf106> ;
+    mu:uuid "e53aba91d448d36d34599d43f00c9b1b25df34ba0cfdfb4504a8633bcdd0aa7e" ;
+    skos:prefLabel "Zoneraad HULPVERLENINGSZONE WEST (VLAAMS-BRABANT)" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/a9e30e31-0cd2-4f4a-9352-545c5d43be83> .
+
+<http://data.lblod.info/id/bestuursorganen/e53cacd32b83cf8dc141da4198b0a01ca7b6cb224ab8b11b0ca437de6412df3e> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/dce9ffab7edf87d670ce7ec399084fc2e12c6b5bb300b865e87c5237beae4ae0> ;
+    mu:uuid "e53cacd32b83cf8dc141da4198b0a01ca7b6cb224ab8b11b0ca437de6412df3e" ;
+    skos:prefLabel "Politieraad Politiezone van Brasschaat" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/e62c8ff0aef0cd553aab50e784eddd37b1cbee46e4d71e14ec4f25ed63ae5166> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/a62fddadcb0a8fb878c3edbdc71a4eb1e6c419b212d41a8bd589fb1a370eb112> ;
+    mu:uuid "e62c8ff0aef0cd553aab50e784eddd37b1cbee46e4d71e14ec4f25ed63ae5166" ;
+    skos:prefLabel "Politieraad POLITIEZONE : ALVERINGEM - LO-RENINGEN - VEURNE" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/e67a3e7f21dece7b29f9ee0ee5414f3f2d17cf931b0beaf7d50d3f381f50dc92> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/2c1fc56876479e83c7b144e98b84174dd10087ae59621204b9d6701d968e8aba> ;
+    mu:uuid "e67a3e7f21dece7b29f9ee0ee5414f3f2d17cf931b0beaf7d50d3f381f50dc92" ;
+    skos:prefLabel "Zoneraad HULPVERLENINGSZONE 1 (WEST-VLAANDEREN)" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/a9e30e31-0cd2-4f4a-9352-545c5d43be83> .
+
+<http://data.lblod.info/id/bestuursorganen/e88b7ff83522145f4c933546db0ce10e93aea1a93c2553970a1ae263394b11a8> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/254bbfb6c31a668446c339c0996864d23c3fe129a5aa05e274b463cbbb4a4bc2> ;
+    mu:uuid "e88b7ff83522145f4c933546db0ce10e93aea1a93c2553970a1ae263394b11a8" ;
+    skos:prefLabel "Politieraad Politiezone van Aarschot" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/ed76c22d67b3ebacc3798c1851a9a354b5db0ba80293b574d5162026b5ee0ab0> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/19c1183ad20b9b4023da2eb7d1ab3eb5dda64558e050c8198abf9714463362ff> ;
+    mu:uuid "ed76c22d67b3ebacc3798c1851a9a354b5db0ba80293b574d5162026b5ee0ab0" ;
+    skos:prefLabel "Politieraad POLITIEZONE : DEINZE - ZULTE" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/f33df35271289024049289d3fd0f84a907b9d6266ccbc84b9eec1ece5aa39f30> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/9cb5a65d9190da4bb96d0f59882cbcfb34248d354e6bd27101fccba186f4c7b7> ;
+    mu:uuid "f33df35271289024049289d3fd0f84a907b9d6266ccbc84b9eec1ece5aa39f30" ;
+    skos:prefLabel "Politieraad POLITIEZONE : LOCHRISTIE - MOERBEKE - WACHTEBEKE - ZELZATE" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/f67ce180da03b62f5a7e77e801eeb2c01182f8968922e27500beee76b51c659d> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/96d87c4956c98414938dd5fceeb05f65feebf21fbe5918e6d23bc2b58a7fc716> ;
+    mu:uuid "f67ce180da03b62f5a7e77e801eeb2c01182f8968922e27500beee76b51c659d" ;
+    skos:prefLabel "Politieraad POLITIEZONE : ASSENEDE - EVERGEM" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/bestuursorganen/fba2239d017ed85faba473682254fac7fa3308e4971b4dfd86c623a627b13567> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/67b25dc29ad301f607aed564241d318de74be7dc1ec15202a67111d7a86becf9> ;
+    mu:uuid "fba2239d017ed85faba473682254fac7fa3308e4971b4dfd86c623a627b13567" ;
+    skos:prefLabel "Politieraad Politiezone van Dendermonde" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/1afce932-53c1-46d8-8aab-90dcc331e67d> .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/01cb6a0b61a750d3c1e2285fd3f79dcb> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "01cb6a0b61a750d3c1e2285fd3f79dcb" ;
+    generiek:lokaleIdentificator "0500927893" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/0296c2df776576b428080882edc96f68> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "0296c2df776576b428080882edc96f68" ;
+    generiek:lokaleIdentificator "0500928388" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/02f80df432b67c04bc1bf2f57f04b770> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "02f80df432b67c04bc1bf2f57f04b770" ;
+    generiek:lokaleIdentificator "0267352091" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/0424b17cb44d698273045ab4b59425f8> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "0424b17cb44d698273045ab4b59425f8" ;
+    generiek:lokaleIdentificator "0267354863" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/0427ea291026b3fba2c81b417e4a5ade> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "0427ea291026b3fba2c81b417e4a5ade" ;
+    generiek:lokaleIdentificator "0500913839" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/04c4ee2e9291d254c20d7444cd5953c8> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "04c4ee2e9291d254c20d7444cd5953c8" ;
+    generiek:lokaleIdentificator "0862885175" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/0520a515669c64de3a51803674827051> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "0520a515669c64de3a51803674827051" ;
+    generiek:lokaleIdentificator "0642781089" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/05d13fb321a97d796551263f7c71bcbf> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "05d13fb321a97d796551263f7c71bcbf" ;
+    generiek:lokaleIdentificator "0862902397" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/0702282dfa4c4e52e1e53a378387ed32> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "0702282dfa4c4e52e1e53a378387ed32" ;
+    generiek:lokaleIdentificator "0862891709" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/09a979bcdef5f13c12277cce96b0afb6> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "09a979bcdef5f13c12277cce96b0afb6" ;
+    generiek:lokaleIdentificator "0862894281" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/09dcd3bfe94d9d1e391083535966265c> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "09dcd3bfe94d9d1e391083535966265c" ;
+    generiek:lokaleIdentificator "0267368424" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/0ea002c46232c6fd76310dcb1bc19016> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "0ea002c46232c6fd76310dcb1bc19016" ;
+    generiek:lokaleIdentificator "0862891907" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/1666254ccdc4afcf145264cce0f26324> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "1666254ccdc4afcf145264cce0f26324" ;
+    generiek:lokaleIdentificator "0267341601" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/1c3fc51fae099bd4c13563de6cc45e11> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "1c3fc51fae099bd4c13563de6cc45e11" ;
+    generiek:lokaleIdentificator "0267356447" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/20873cd3ee12186fa4162745adfc6b30> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "20873cd3ee12186fa4162745adfc6b30" ;
+    generiek:lokaleIdentificator "0267357239" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/213eb98bbcd89e4e755be9d25c5b5165> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "213eb98bbcd89e4e755be9d25c5b5165" ;
+    generiek:lokaleIdentificator "0500919876" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/21c6125f57dc85fc4eec4811bfd2f604> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "21c6125f57dc85fc4eec4811bfd2f604" ;
+    generiek:lokaleIdentificator "0267355259" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/24d581b00c8dfd77f785650f3876390a> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "24d581b00c8dfd77f785650f3876390a" ;
+    generiek:lokaleIdentificator "0267370008" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/2725bae19bad401818796f1bf641772e> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "2725bae19bad401818796f1bf641772e" ;
+    generiek:lokaleIdentificator "0862887650" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/2911d81f901a62e7ea5b699a34624663> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "2911d81f901a62e7ea5b699a34624663" ;
+    generiek:lokaleIdentificator "0862884878" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/2b998b631caf05f0155cc5a848069302> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "2b998b631caf05f0155cc5a848069302" ;
+    generiek:lokaleIdentificator "0500914928" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/2ce49bb04da4cf2b5d147b3697d17fde> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "2ce49bb04da4cf2b5d147b3697d17fde" ;
+    generiek:lokaleIdentificator "0563660565" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/2f17e8ce3caf9f9f790ec5a13b17d7c6> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "2f17e8ce3caf9f9f790ec5a13b17d7c6" ;
+    generiek:lokaleIdentificator "0862888145" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/30c67bfab15ef2e535d5f447348d9e4c> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "30c67bfab15ef2e535d5f447348d9e4c" ;
+    generiek:lokaleIdentificator "0862894677" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/33a0cb610450adc24a054655cd0f32eb> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "33a0cb610450adc24a054655cd0f32eb" ;
+    generiek:lokaleIdentificator "0267352883" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/35913f0e492b7b87dd3ac5e6698504f2> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "35913f0e492b7b87dd3ac5e6698504f2" ;
+    generiek:lokaleIdentificator "0500907802" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/36362abbe86a26020a41f7f4dcf6ddc1> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "36362abbe86a26020a41f7f4dcf6ddc1" ;
+    generiek:lokaleIdentificator "0267334473" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/3c6c2d906099a367176a2efd38b46801> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "3c6c2d906099a367176a2efd38b46801" ;
+    generiek:lokaleIdentificator "0267344470" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/3c9c0fd7dad6d29302fdf21a520ab2fb> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "3c9c0fd7dad6d29302fdf21a520ab2fb" ;
+    generiek:lokaleIdentificator "0267351695" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/3d8654720951d3ce3d8bb4a9b9e94e40> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "3d8654720951d3ce3d8bb4a9b9e94e40" ;
+    generiek:lokaleIdentificator "0267340809" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/3f4eb805a9f6551154f6f8a2b29aa5de> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "3f4eb805a9f6551154f6f8a2b29aa5de" ;
+    generiek:lokaleIdentificator "0267373669" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/42b90507d3464900fcfdb2185af81faa> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "42b90507d3464900fcfdb2185af81faa" ;
+    generiek:lokaleIdentificator "0862895073" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/43efb09a0d486da0159b6fe50b1ee1e8> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "43efb09a0d486da0159b6fe50b1ee1e8" ;
+    generiek:lokaleIdentificator "0267337245" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/4529530e731736233480e5282407f496> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "4529530e731736233480e5282407f496" ;
+    generiek:lokaleIdentificator "0267356843" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/46d6b9b4f5dbe043ec84215719cadc2c> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "46d6b9b4f5dbe043ec84215719cadc2c" ;
+    generiek:lokaleIdentificator "0663623421" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/470cab901355371efda686f59f03d7a8> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "470cab901355371efda686f59f03d7a8" ;
+    generiek:lokaleIdentificator "0862899528" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/47742fb7d4c36926773124f685ec0082> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "47742fb7d4c36926773124f685ec0082" ;
+    generiek:lokaleIdentificator "0862892303" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/48c456f5f96d52e1d7c0bbd157119437> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "48c456f5f96d52e1d7c0bbd157119437" ;
+    generiek:lokaleIdentificator "0267362880" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/4a931380c0a90c0e40189d5b93c552c5> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "4a931380c0a90c0e40189d5b93c552c5" ;
+    generiek:lokaleIdentificator "0267359219" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/4c332d018da8dfd8b0f6282eeef39a75> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "4c332d018da8dfd8b0f6282eeef39a75" ;
+    generiek:lokaleIdentificator "0267354071" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/4d297cf05dd4723869564bdc72d89111> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "4d297cf05dd4723869564bdc72d89111" ;
+    generiek:lokaleIdentificator "0552731041" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/4d3efc8a7f44eb0ae4ad23602739389a> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "4d3efc8a7f44eb0ae4ad23602739389a" ;
+    generiek:lokaleIdentificator "0267349618" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/4e01c5d906acdbb7e19e1c9bc0e055c3> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "4e01c5d906acdbb7e19e1c9bc0e055c3" ;
+    generiek:lokaleIdentificator "0500929081" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/4f312fe11f316f6eca3dd36818b5f28f> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "4f312fe11f316f6eca3dd36818b5f28f" ;
+    generiek:lokaleIdentificator "0267359615" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/4fa0442e8ce25218cce6c1dedaa5a5b3> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "4fa0442e8ce25218cce6c1dedaa5a5b3" ;
+    generiek:lokaleIdentificator "0862884680" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/529d3002bf61e4b9a3f1df4903a557f3> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "529d3002bf61e4b9a3f1df4903a557f3" ;
+    generiek:lokaleIdentificator "0267332493" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/55f23db3dc6a1a7246d763c4db6a6368> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "55f23db3dc6a1a7246d763c4db6a6368" ;
+    generiek:lokaleIdentificator "0267372877" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/59a20e7f487d25f05bb4eb832ce3c004> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "59a20e7f487d25f05bb4eb832ce3c004" ;
+    generiek:lokaleIdentificator "0500929279" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/59ed722d9addaff46ef03c7f9f20b75a> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "59ed722d9addaff46ef03c7f9f20b75a" ;
+    generiek:lokaleIdentificator "0267361692" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/5e4dc0523cd4362a36f3f9c6de112793> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "5e4dc0523cd4362a36f3f9c6de112793" ;
+    generiek:lokaleIdentificator "0862897350" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/6170eaa56a2fdf6771412906fe5200c5> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "6170eaa56a2fdf6771412906fe5200c5" ;
+    generiek:lokaleIdentificator "0862888640" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/6271235af04ea7bb43fe979b247e12e5> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "6271235af04ea7bb43fe979b247e12e5" ;
+    generiek:lokaleIdentificator "0862888343" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/64d4b8502adbeafba37424d098b426ed> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "64d4b8502adbeafba37424d098b426ed" ;
+    generiek:lokaleIdentificator "0267344074" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/653fc48ae170789767d5c34a60aecb3f> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "653fc48ae170789767d5c34a60aecb3f" ;
+    generiek:lokaleIdentificator "0267364464" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/65a050ff3aff24a2535acbad6d1f761a> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "65a050ff3aff24a2535acbad6d1f761a" ;
+    generiek:lokaleIdentificator "0267360803" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/65c8714835838d899daf0cb2a694ef6e> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "65c8714835838d899daf0cb2a694ef6e" ;
+    generiek:lokaleIdentificator "0500928190" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/67d91dc4bc643e67dd6ba9f3da24b763> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "67d91dc4bc643e67dd6ba9f3da24b763" ;
+    generiek:lokaleIdentificator "0862902793" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/6915e4b53d76edfb5ab8b3d0dd0de59c> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "6915e4b53d76edfb5ab8b3d0dd0de59c" ;
+    generiek:lokaleIdentificator "0267362088" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/692d125cd40172ea7210df3c86ac6f7f> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "692d125cd40172ea7210df3c86ac6f7f" ;
+    generiek:lokaleIdentificator "0682824867" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/69612b72ca422503d857a639b5d97a8e> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "69612b72ca422503d857a639b5d97a8e" ;
+    generiek:lokaleIdentificator "0267365256" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/69c87c79a897a58ac0118c69a0fe5d4d> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "69c87c79a897a58ac0118c69a0fe5d4d" ;
+    generiek:lokaleIdentificator "0267343678" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/6a61037749c0b0e86d6ad6434fc982ef> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "6a61037749c0b0e86d6ad6434fc982ef" ;
+    generiek:lokaleIdentificator "0267334077" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/6b8197150adb2ece219753a2531f869a> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "6b8197150adb2ece219753a2531f869a" ;
+    generiek:lokaleIdentificator "0267361296" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/6f357c1640e8dd98ef42b048592f06a8> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "6f357c1640e8dd98ef42b048592f06a8" ;
+    generiek:lokaleIdentificator "0267343282" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/6f540701374ce4664a2f96dc378ac270> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "6f540701374ce4664a2f96dc378ac270" ;
+    generiek:lokaleIdentificator "0637961278" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/708d434232c97b8124c82ff50735244f> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "708d434232c97b8124c82ff50735244f" ;
+    generiek:lokaleIdentificator "0267335265" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/72cf52c9080e4adf3746c79466d64b90> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "72cf52c9080e4adf3746c79466d64b90" ;
+    generiek:lokaleIdentificator "0267340017" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/73a19f0592ecf5d15072cb36a6b5be11> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "73a19f0592ecf5d15072cb36a6b5be11" ;
+    generiek:lokaleIdentificator "0862897746" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/7950aec22b0d9412e64931703c05f519> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "7950aec22b0d9412e64931703c05f519" ;
+    generiek:lokaleIdentificator "0862887749" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/7a2682406178de906005b5593921143f> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "7a2682406178de906005b5593921143f" ;
+    generiek:lokaleIdentificator "0267369612" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/7c4f56ac3783b2cad0c71c6e77f0e61d> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "7c4f56ac3783b2cad0c71c6e77f0e61d" ;
+    generiek:lokaleIdentificator "0267351202" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/7d00d2dde5a866df4658ce2011241b74> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "7d00d2dde5a866df4658ce2011241b74" ;
+    generiek:lokaleIdentificator "0862893588" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/7f7d86296faf02c17f018ae4777b296c> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "7f7d86296faf02c17f018ae4777b296c" ;
+    generiek:lokaleIdentificator "0712571007" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/811778877b28a29d5d2a8c6e18ba0dd5> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "811778877b28a29d5d2a8c6e18ba0dd5" ;
+    generiek:lokaleIdentificator "0500929873" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/85577c9f88e3cd222e2127da1a8c137a> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "85577c9f88e3cd222e2127da1a8c137a" ;
+    generiek:lokaleIdentificator "0267363672" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/86e840975256d5b4f166c07542aa15ca> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "86e840975256d5b4f166c07542aa15ca" ;
+    generiek:lokaleIdentificator "0267370897" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/8b9526d3b82991f146c6c7957a320be3> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "8b9526d3b82991f146c6c7957a320be3" ;
+    generiek:lokaleIdentificator "0267342886" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/8c0c9caef6d4efb4d7acf49fe23003c9> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "8c0c9caef6d4efb4d7acf49fe23003c9" ;
+    generiek:lokaleIdentificator "0267373273" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/8e43f23609c0ec57032147ed55dba8a0> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "8e43f23609c0ec57032147ed55dba8a0" ;
+    generiek:lokaleIdentificator "0267352487" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/8f8e49236d80d5c77e2049fbad8ba983> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "8f8e49236d80d5c77e2049fbad8ba983" ;
+    generiek:lokaleIdentificator "0793243531" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/8fac3de9245db95a3176c09c0c87a345> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "8fac3de9245db95a3176c09c0c87a345" ;
+    generiek:lokaleIdentificator "0267342094" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/941cdf8957c05d560da0728eadd6a36d> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "941cdf8957c05d560da0728eadd6a36d" ;
+    generiek:lokaleIdentificator "0267354467" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/95033071b09fb68773ee70aa91f13139> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "95033071b09fb68773ee70aa91f13139" ;
+    generiek:lokaleIdentificator "0862901013" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/96bf909e1591f4f47e7fd73dce83f85e> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "96bf909e1591f4f47e7fd73dce83f85e" ;
+    generiek:lokaleIdentificator "0862885472" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/971109ab69596fbf352ca778bfef3fc1> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "971109ab69596fbf352ca778bfef3fc1" ;
+    generiek:lokaleIdentificator "0267360011" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/980752d849ec6cbd9d411549b5bd74a7> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "980752d849ec6cbd9d411549b5bd74a7" ;
+    generiek:lokaleIdentificator "0500913443" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/9a215de2a80f904c791939c087651226> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "9a215de2a80f904c791939c087651226" ;
+    generiek:lokaleIdentificator "0267353279" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/9adccb75c951e74a0f80390737407a67> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "9adccb75c951e74a0f80390737407a67" ;
+    generiek:lokaleIdentificator "0267366444" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/9bfc5c849b46c62ed78924b4371dc56a> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "9bfc5c849b46c62ed78924b4371dc56a" ;
+    generiek:lokaleIdentificator "0831514187" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/a27be508862b9367526c9368e6b1a560> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "a27be508862b9367526c9368e6b1a560" ;
+    generiek:lokaleIdentificator "0267364068" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/a36c6fcf00d2a6997ceb692d5aae3d62> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "a36c6fcf00d2a6997ceb692d5aae3d62" ;
+    generiek:lokaleIdentificator "0267353675" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/a71c5f3ef2ba7565236b6708d0d03a6f> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "a71c5f3ef2ba7565236b6708d0d03a6f" ;
+    generiek:lokaleIdentificator "0862900023" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/a74aaf1209270e859d0811c2a68e4fc8> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "a74aaf1209270e859d0811c2a68e4fc8" ;
+    generiek:lokaleIdentificator "0267374065" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/a964dedc26286e9053119e70abd7b9bb> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "a964dedc26286e9053119e70abd7b9bb" ;
+    generiek:lokaleIdentificator "0267333681" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/ab82415ea8dbc5b06953e176d9049397> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "ab82415ea8dbc5b06953e176d9049397" ;
+    generiek:lokaleIdentificator "0500927497" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/ac4fecfb065a9b2c6502dd64df608c4c> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "ac4fecfb065a9b2c6502dd64df608c4c" ;
+    generiek:lokaleIdentificator "0267360407" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/af9393a0a69a0969b53a3187bb64cf8e> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "af9393a0a69a0969b53a3187bb64cf8e" ;
+    generiek:lokaleIdentificator "0267336057" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/b26133210bee3170851414a6a018317a> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "b26133210bee3170851414a6a018317a" ;
+    generiek:lokaleIdentificator "0267356051" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/b5013e00032916fa942e8c2d27a421b5> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "b5013e00032916fa942e8c2d27a421b5" ;
+    generiek:lokaleIdentificator "0707694578" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/b8f698524492b404902ac4110c2e4aa2> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "b8f698524492b404902ac4110c2e4aa2" ;
+    generiek:lokaleIdentificator "0862900518" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/ba466e8745a0e71d129cf80bcc616273> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "ba466e8745a0e71d129cf80bcc616273" ;
+    generiek:lokaleIdentificator "0267367236" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/bc4583d2c2764518b61f20167bf5fe01> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "bc4583d2c2764518b61f20167bf5fe01" ;
+    generiek:lokaleIdentificator "0862903288" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/bc4bff7d458ef784231ad194ed059358> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "bc4bff7d458ef784231ad194ed059358" ;
+    generiek:lokaleIdentificator "0267363276" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/bd34251f042748a6f9013be095552618> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "bd34251f042748a6f9013be095552618" ;
+    generiek:lokaleIdentificator "0267365652" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/bd6bc58828a75afc9b137edb254fc93d> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "bd6bc58828a75afc9b137edb254fc93d" ;
+    generiek:lokaleIdentificator "0564935720" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/bd6c97a1665ac397605839483e0f54fa> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "bd6c97a1665ac397605839483e0f54fa" ;
+    generiek:lokaleIdentificator "0267371293" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/beba02e19805b8d5770e990f76aea21c> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "beba02e19805b8d5770e990f76aea21c" ;
+    generiek:lokaleIdentificator "0267338829" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/c2413842260ac1d13fb9dc0a2a24cd3c> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "c2413842260ac1d13fb9dc0a2a24cd3c" ;
+    generiek:lokaleIdentificator "0500929774" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/c387aa5093696c55eb28fc31526e641c> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "c387aa5093696c55eb28fc31526e641c" ;
+    generiek:lokaleIdentificator "0267369216" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/c3e260fab3aec195eadf4e79a2f7f279> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "c3e260fab3aec195eadf4e79a2f7f279" ;
+    generiek:lokaleIdentificator "0267350410" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/c437affbd190b107fe9c2375b3be7543> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "c437affbd190b107fe9c2375b3be7543" ;
+    generiek:lokaleIdentificator "0267362484" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/c48f707f0bd1d5d9f928d9dfedb4677c> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "c48f707f0bd1d5d9f928d9dfedb4677c" ;
+    generiek:lokaleIdentificator "0267364860" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/c68002d569063804f2ec8a11ada5c628> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "c68002d569063804f2ec8a11ada5c628" ;
+    generiek:lokaleIdentificator "0862897944" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/cc3ca5e91596ff51178aa826d980fad2> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "cc3ca5e91596ff51178aa826d980fad2" ;
+    generiek:lokaleIdentificator "0862892006" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/cc3f9899929a7f91f2a198b5f9ca04c1> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "cc3f9899929a7f91f2a198b5f9ca04c1" ;
+    generiek:lokaleIdentificator "0267358427" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/cdd66b891c68105f6554f2e5f1f679d8> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "cdd66b891c68105f6554f2e5f1f679d8" ;
+    generiek:lokaleIdentificator "0862898241" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/ce8db7b1a95a86fb68f0fda0afece425> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "ce8db7b1a95a86fb68f0fda0afece425" ;
+    generiek:lokaleIdentificator "0267366048" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/d00e48a678fcda5979cf656f4a8479d5> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "d00e48a678fcda5979cf656f4a8479d5" ;
+    generiek:lokaleIdentificator "0267366840" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/d16d4b430e020c7e52b9b785c8d04825> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "d16d4b430e020c7e52b9b785c8d04825" ;
+    generiek:lokaleIdentificator "0500906812" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/d17b7544497f155cab8bdac1df1543a5> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "d17b7544497f155cab8bdac1df1543a5" ;
+    generiek:lokaleIdentificator "0267370404" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/d1d4f99ce43e566601485b889a93c55e> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "d1d4f99ce43e566601485b889a93c55e" ;
+    generiek:lokaleIdentificator "0267358823" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/d392253dce5c70782d0e25c452aa5f43> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "d392253dce5c70782d0e25c452aa5f43" ;
+    generiek:lokaleIdentificator "0267342490" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/d47b2f7d7d9023f3b3ab9b2f8a4ca908> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "d47b2f7d7d9023f3b3ab9b2f8a4ca908" ;
+    generiek:lokaleIdentificator "0267372085" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/d9c92def3bdd46e4cb9ec15445aebd87> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "d9c92def3bdd46e4cb9ec15445aebd87" ;
+    generiek:lokaleIdentificator "0267350806" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/da4ea859a1e386676288d5710418cb98> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "da4ea859a1e386676288d5710418cb98" ;
+    generiek:lokaleIdentificator "0267350014" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/dbe2a8ee5554834783fd8a8dfe2e45ae> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "dbe2a8ee5554834783fd8a8dfe2e45ae" ;
+    generiek:lokaleIdentificator "0267368820" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/dec04c1170111fa8c8077de3f1a891d6> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "dec04c1170111fa8c8077de3f1a891d6" ;
+    generiek:lokaleIdentificator "0862898538" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/dfce6be02bbb86efd3a1bcc3522bc90f> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "dfce6be02bbb86efd3a1bcc3522bc90f" ;
+    generiek:lokaleIdentificator "0500929378" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/e027ba62c440675d0977febb89f4ed8d> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "e027ba62c440675d0977febb89f4ed8d" ;
+    generiek:lokaleIdentificator "0267374461" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/e0a8e36c6ef633ee0f6b4cf02f2704d1> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "e0a8e36c6ef633ee0f6b4cf02f2704d1" ;
+    generiek:lokaleIdentificator "0267341205" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/e2447477a8f9dcb12738e4da5015085c> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "e2447477a8f9dcb12738e4da5015085c" ;
+    generiek:lokaleIdentificator "0862896954" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/e4b0d66f9d7866c421d44124c26fc68a> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "e4b0d66f9d7866c421d44124c26fc68a" ;
+    generiek:lokaleIdentificator "0862899132" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/e705cbd35e3bafcb528a7ca08ce43649> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "e705cbd35e3bafcb528a7ca08ce43649" ;
+    generiek:lokaleIdentificator "0500915126" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/e965b83130a976005b7b4304b7b85357> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "e965b83130a976005b7b4304b7b85357" ;
+    generiek:lokaleIdentificator "0267371689" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/e9f11ad696ddbda7e19e6ca743aa3449> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "e9f11ad696ddbda7e19e6ca743aa3449" ;
+    generiek:lokaleIdentificator "0500914730" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/ea0ff269ca5a7b6a0bf88732ac88406e> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "ea0ff269ca5a7b6a0bf88732ac88406e" ;
+    generiek:lokaleIdentificator "0267358031" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/ea8286ba6c761222f12b883fddc6ea17> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "ea8286ba6c761222f12b883fddc6ea17" ;
+    generiek:lokaleIdentificator "0500928586" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/ebc091fdca3351193ffa7c35e4bf32d2> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "ebc091fdca3351193ffa7c35e4bf32d2" ;
+    generiek:lokaleIdentificator "0862887551" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/eccadcda428aca92d732d8207497b45f> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "eccadcda428aca92d732d8207497b45f" ;
+    generiek:lokaleIdentificator "0267355655" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/ed6a442c991b5f55d9500eb9374e13c1> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "ed6a442c991b5f55d9500eb9374e13c1" ;
+    generiek:lokaleIdentificator "0500928982" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/f0ecfb00326b69deed81175b0eaa75b7> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "f0ecfb00326b69deed81175b0eaa75b7" ;
+    generiek:lokaleIdentificator "0862899726" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/f4bd2ec0f9c685614d4c63ab8f844519> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "f4bd2ec0f9c685614d4c63ab8f844519" ;
+    generiek:lokaleIdentificator "0267339225" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/f5a293a22fbf060a80f60529bf59208b> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "f5a293a22fbf060a80f60529bf59208b" ;
+    generiek:lokaleIdentificator "0267368028" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/f5acbe3061e23d81c9c7b8ff0321d38c> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "f5acbe3061e23d81c9c7b8ff0321d38c" ;
+    generiek:lokaleIdentificator "0862895667" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/f803dd5fb7896f3f27afe64b63d24310> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "f803dd5fb7896f3f27afe64b63d24310" ;
+    generiek:lokaleIdentificator "0862884185" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/fbb565c4a10e2800ed6b8a7f4b048d1e> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "fbb565c4a10e2800ed6b8a7f4b048d1e" ;
+    generiek:lokaleIdentificator "0267357635" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/fc75f2182a85f56e85919df0a140df11> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "fc75f2182a85f56e85919df0a140df11" ;
+    generiek:lokaleIdentificator "0267372481" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/fcb08ab5228162b1146cc6bfe06a3048> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "fcb08ab5228162b1146cc6bfe06a3048" ;
+    generiek:lokaleIdentificator "0267367632" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/fd3d71f4a7dfd0cb8bb29299d8ffa7a1> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "fd3d71f4a7dfd0cb8bb29299d8ffa7a1" ;
+    generiek:lokaleIdentificator "0500927596" .
+
+<http://data.lblod.info/id/identificatoren/0218108d2807608eb1bf0e5a39ceaff7> a adms:Identifier ;
+    mu:uuid "0218108d2807608eb1bf0e5a39ceaff7" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/05d13fb321a97d796551263f7c71bcbf> .
+
+<http://data.lblod.info/id/identificatoren/03a724595485ecacb006ac6030954671> a adms:Identifier ;
+    mu:uuid "03a724595485ecacb006ac6030954671" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/bd6bc58828a75afc9b137edb254fc93d> .
+
+<http://data.lblod.info/id/identificatoren/03fd634d8549fe96c48a74a3afc3c047> a adms:Identifier ;
+    mu:uuid "03fd634d8549fe96c48a74a3afc3c047" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/a74aaf1209270e859d0811c2a68e4fc8> .
+
+<http://data.lblod.info/id/identificatoren/04684e5538ff71a3fbb60c54dd2a2c9b> a adms:Identifier ;
+    mu:uuid "04684e5538ff71a3fbb60c54dd2a2c9b" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/e965b83130a976005b7b4304b7b85357> .
+
+<http://data.lblod.info/id/identificatoren/0bfaf11d86673964fc07e08c122d29b0> a adms:Identifier ;
+    mu:uuid "0bfaf11d86673964fc07e08c122d29b0" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/a71c5f3ef2ba7565236b6708d0d03a6f> .
+
+<http://data.lblod.info/id/identificatoren/0c2c60218ee97fb37181139e665db852> a adms:Identifier ;
+    mu:uuid "0c2c60218ee97fb37181139e665db852" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/ce8db7b1a95a86fb68f0fda0afece425> .
+
+<http://data.lblod.info/id/identificatoren/0d7d4ac3e33c072bb36448bebac6e12b> a adms:Identifier ;
+    mu:uuid "0d7d4ac3e33c072bb36448bebac6e12b" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/e027ba62c440675d0977febb89f4ed8d> .
+
+<http://data.lblod.info/id/identificatoren/1032f076c324ab6712a50cfc2aad529c> a adms:Identifier ;
+    mu:uuid "1032f076c324ab6712a50cfc2aad529c" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/24d581b00c8dfd77f785650f3876390a> .
+
+<http://data.lblod.info/id/identificatoren/1152fcfd9dde3278de59dfa17d468d75> a adms:Identifier ;
+    mu:uuid "1152fcfd9dde3278de59dfa17d468d75" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/d17b7544497f155cab8bdac1df1543a5> .
+
+<http://data.lblod.info/id/identificatoren/11ebd689bd15870b0eb4af3e4626e75e> a adms:Identifier ;
+    mu:uuid "11ebd689bd15870b0eb4af3e4626e75e" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/ac4fecfb065a9b2c6502dd64df608c4c> .
+
+<http://data.lblod.info/id/identificatoren/1283063325557db2e202d20b237c9009> a adms:Identifier ;
+    mu:uuid "1283063325557db2e202d20b237c9009" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/cdd66b891c68105f6554f2e5f1f679d8> .
+
+<http://data.lblod.info/id/identificatoren/12ec00c07cdf6d3567fba7a34a940d70> a adms:Identifier ;
+    mu:uuid "12ec00c07cdf6d3567fba7a34a940d70" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/09a979bcdef5f13c12277cce96b0afb6> .
+
+<http://data.lblod.info/id/identificatoren/1341812c376b5770ce5ec345b37c689b> a adms:Identifier ;
+    mu:uuid "1341812c376b5770ce5ec345b37c689b" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/09dcd3bfe94d9d1e391083535966265c> .
+
+<http://data.lblod.info/id/identificatoren/1c8c1e1f968f768eb67efbd3a54c9a28> a adms:Identifier ;
+    mu:uuid "1c8c1e1f968f768eb67efbd3a54c9a28" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/ea0ff269ca5a7b6a0bf88732ac88406e> .
+
+<http://data.lblod.info/id/identificatoren/1e19d395b77345c1ec5f10f2f9c999f1> a adms:Identifier ;
+    mu:uuid "1e19d395b77345c1ec5f10f2f9c999f1" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/b5013e00032916fa942e8c2d27a421b5> .
+
+<http://data.lblod.info/id/identificatoren/1e64d1ab2bde10a85e2d3d91abfceea6> a adms:Identifier ;
+    mu:uuid "1e64d1ab2bde10a85e2d3d91abfceea6" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/2ce49bb04da4cf2b5d147b3697d17fde> .
+
+<http://data.lblod.info/id/identificatoren/1f6ca76cc6d829865c8f8e31375c8290> a adms:Identifier ;
+    mu:uuid "1f6ca76cc6d829865c8f8e31375c8290" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/96bf909e1591f4f47e7fd73dce83f85e> .
+
+<http://data.lblod.info/id/identificatoren/214a1af365d989c54adb3d7eb8293d06> a adms:Identifier ;
+    mu:uuid "214a1af365d989c54adb3d7eb8293d06" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/5e4dc0523cd4362a36f3f9c6de112793> .
+
+<http://data.lblod.info/id/identificatoren/221952d5a0f44581269e601ef6173bbb> a adms:Identifier ;
+    mu:uuid "221952d5a0f44581269e601ef6173bbb" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/9adccb75c951e74a0f80390737407a67> .
+
+<http://data.lblod.info/id/identificatoren/226be29aab090913dda8526c9bbb5164> a adms:Identifier ;
+    mu:uuid "226be29aab090913dda8526c9bbb5164" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/2911d81f901a62e7ea5b699a34624663> .
+
+<http://data.lblod.info/id/identificatoren/2950678953d872c253350314c3a59212> a adms:Identifier ;
+    mu:uuid "2950678953d872c253350314c3a59212" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/8c0c9caef6d4efb4d7acf49fe23003c9> .
+
+<http://data.lblod.info/id/identificatoren/2ca564e45451e29d8613495f14aa5d36> a adms:Identifier ;
+    mu:uuid "2ca564e45451e29d8613495f14aa5d36" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/0520a515669c64de3a51803674827051> .
+
+<http://data.lblod.info/id/identificatoren/2ececfff95755cf9848dc8c100d2b671> a adms:Identifier ;
+    mu:uuid "2ececfff95755cf9848dc8c100d2b671" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/d16d4b430e020c7e52b9b785c8d04825> .
+
+<http://data.lblod.info/id/identificatoren/31fe693ea517aa39adbfa8dd144fa4b4> a adms:Identifier ;
+    mu:uuid "31fe693ea517aa39adbfa8dd144fa4b4" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/65a050ff3aff24a2535acbad6d1f761a> .
+
+<http://data.lblod.info/id/identificatoren/322c282d5639892919c47056ec9c3cdf> a adms:Identifier ;
+    mu:uuid "322c282d5639892919c47056ec9c3cdf" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/f5acbe3061e23d81c9c7b8ff0321d38c> .
+
+<http://data.lblod.info/id/identificatoren/3304076ed24822d80392f7f559f7311b> a adms:Identifier ;
+    mu:uuid "3304076ed24822d80392f7f559f7311b" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/c48f707f0bd1d5d9f928d9dfedb4677c> .
+
+<http://data.lblod.info/id/identificatoren/337440202a37cecf8729f76f08c290a1> a adms:Identifier ;
+    mu:uuid "337440202a37cecf8729f76f08c290a1" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/dbe2a8ee5554834783fd8a8dfe2e45ae> .
+
+<http://data.lblod.info/id/identificatoren/3577288ae4b721934732fafd74665db2> a adms:Identifier ;
+    mu:uuid "3577288ae4b721934732fafd74665db2" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/7d00d2dde5a866df4658ce2011241b74> .
+
+<http://data.lblod.info/id/identificatoren/3695ad67967bdb64c7f588ff6815725c> a adms:Identifier ;
+    mu:uuid "3695ad67967bdb64c7f588ff6815725c" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/6915e4b53d76edfb5ab8b3d0dd0de59c> .
+
+<http://data.lblod.info/id/identificatoren/38ce51465e465ad5a697cea36e37d731> a adms:Identifier ;
+    mu:uuid "38ce51465e465ad5a697cea36e37d731" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/0427ea291026b3fba2c81b417e4a5ade> .
+
+<http://data.lblod.info/id/identificatoren/38e20e10e2364cafe2819899ca454b87> a adms:Identifier ;
+    mu:uuid "38e20e10e2364cafe2819899ca454b87" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/da4ea859a1e386676288d5710418cb98> .
+
+<http://data.lblod.info/id/identificatoren/39c9ee60097cf8a599bec174b2682ed5> a adms:Identifier ;
+    mu:uuid "39c9ee60097cf8a599bec174b2682ed5" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/ebc091fdca3351193ffa7c35e4bf32d2> .
+
+<http://data.lblod.info/id/identificatoren/3ceefc40281ec80bc1c419f9a1968c21> a adms:Identifier ;
+    mu:uuid "3ceefc40281ec80bc1c419f9a1968c21" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/67d91dc4bc643e67dd6ba9f3da24b763> .
+
+<http://data.lblod.info/id/identificatoren/3fffe0228181a34bf7fe853d27cb3afd> a adms:Identifier ;
+    mu:uuid "3fffe0228181a34bf7fe853d27cb3afd" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/4a931380c0a90c0e40189d5b93c552c5> .
+
+<http://data.lblod.info/id/identificatoren/408001ffad09bf2981f305fb7092f469> a adms:Identifier ;
+    mu:uuid "408001ffad09bf2981f305fb7092f469" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/ba466e8745a0e71d129cf80bcc616273> .
+
+<http://data.lblod.info/id/identificatoren/44216f927514aab07c470d41feb67590> a adms:Identifier ;
+    mu:uuid "44216f927514aab07c470d41feb67590" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/a27be508862b9367526c9368e6b1a560> .
+
+<http://data.lblod.info/id/identificatoren/4625259581ccf39499c1b0d5c1d6bb66> a adms:Identifier ;
+    mu:uuid "4625259581ccf39499c1b0d5c1d6bb66" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/f4bd2ec0f9c685614d4c63ab8f844519> .
+
+<http://data.lblod.info/id/identificatoren/47dc67156a24f0c9e51c1c18db9610c0> a adms:Identifier ;
+    mu:uuid "47dc67156a24f0c9e51c1c18db9610c0" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/33a0cb610450adc24a054655cd0f32eb> .
+
+<http://data.lblod.info/id/identificatoren/493dce50513610e7942fe2de709d06ad> a adms:Identifier ;
+    mu:uuid "493dce50513610e7942fe2de709d06ad" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/0296c2df776576b428080882edc96f68> .
+
+<http://data.lblod.info/id/identificatoren/496fbf75498761d75f55b7076b92d55f> a adms:Identifier ;
+    mu:uuid "496fbf75498761d75f55b7076b92d55f" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/d9c92def3bdd46e4cb9ec15445aebd87> .
+
+<http://data.lblod.info/id/identificatoren/53c6885fc523d80c14c667a2afa26a47> a adms:Identifier ;
+    mu:uuid "53c6885fc523d80c14c667a2afa26a47" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/8fac3de9245db95a3176c09c0c87a345> .
+
+<http://data.lblod.info/id/identificatoren/55b5d2de5c407e4ce6e5f732b863a1da> a adms:Identifier ;
+    mu:uuid "55b5d2de5c407e4ce6e5f732b863a1da" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/7950aec22b0d9412e64931703c05f519> .
+
+<http://data.lblod.info/id/identificatoren/5c800a8ffa1bdbfec09aa47caa4af039> a adms:Identifier ;
+    mu:uuid "5c800a8ffa1bdbfec09aa47caa4af039" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/fd3d71f4a7dfd0cb8bb29299d8ffa7a1> .
+
+<http://data.lblod.info/id/identificatoren/63d11d63c5f29336fe4d1186dd54a643> a adms:Identifier ;
+    mu:uuid "63d11d63c5f29336fe4d1186dd54a643" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/f803dd5fb7896f3f27afe64b63d24310> .
+
+<http://data.lblod.info/id/identificatoren/66f132a7cb506b64c96f53c146865257> a adms:Identifier ;
+    mu:uuid "66f132a7cb506b64c96f53c146865257" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/30c67bfab15ef2e535d5f447348d9e4c> .
+
+<http://data.lblod.info/id/identificatoren/68a9cd93b17b6be60d5007ae3b4b8bf4> a adms:Identifier ;
+    mu:uuid "68a9cd93b17b6be60d5007ae3b4b8bf4" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/fcb08ab5228162b1146cc6bfe06a3048> .
+
+<http://data.lblod.info/id/identificatoren/6ffb900d6cc5243a5f9f4c2a80e13588> a adms:Identifier ;
+    mu:uuid "6ffb900d6cc5243a5f9f4c2a80e13588" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/69612b72ca422503d857a639b5d97a8e> .
+
+<http://data.lblod.info/id/identificatoren/71609cc8f08fedf5303c5eadcefc9b22> a adms:Identifier ;
+    mu:uuid "71609cc8f08fedf5303c5eadcefc9b22" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/a36c6fcf00d2a6997ceb692d5aae3d62> .
+
+<http://data.lblod.info/id/identificatoren/728dbeb4587d377486a1332e9b8fbc4d> a adms:Identifier ;
+    mu:uuid "728dbeb4587d377486a1332e9b8fbc4d" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/85577c9f88e3cd222e2127da1a8c137a> .
+
+<http://data.lblod.info/id/identificatoren/7430471371092fd0752c9f12c7129f6e> a adms:Identifier ;
+    mu:uuid "7430471371092fd0752c9f12c7129f6e" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/e4b0d66f9d7866c421d44124c26fc68a> .
+
+<http://data.lblod.info/id/identificatoren/755a7542b021db2e500f032781d758a3> a adms:Identifier ;
+    mu:uuid "755a7542b021db2e500f032781d758a3" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/6f357c1640e8dd98ef42b048592f06a8> .
+
+<http://data.lblod.info/id/identificatoren/7563ad99cfac5c8bcd8a7204aa135b99> a adms:Identifier ;
+    mu:uuid "7563ad99cfac5c8bcd8a7204aa135b99" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/d1d4f99ce43e566601485b889a93c55e> .
+
+<http://data.lblod.info/id/identificatoren/77190890193ed72890b2d420f4bb5381> a adms:Identifier ;
+    mu:uuid "77190890193ed72890b2d420f4bb5381" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/d00e48a678fcda5979cf656f4a8479d5> .
+
+<http://data.lblod.info/id/identificatoren/7b5b05ee65bdc2e4a7f2ea8667fd3b94> a adms:Identifier ;
+    mu:uuid "7b5b05ee65bdc2e4a7f2ea8667fd3b94" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/f5a293a22fbf060a80f60529bf59208b> .
+
+<http://data.lblod.info/id/identificatoren/7b6dd8db087c6eaa6c800d8f3363c007> a adms:Identifier ;
+    mu:uuid "7b6dd8db087c6eaa6c800d8f3363c007" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/2f17e8ce3caf9f9f790ec5a13b17d7c6> .
+
+<http://data.lblod.info/id/identificatoren/7c266f127e5918cec7e3d5caa8f8b8b7> a adms:Identifier ;
+    mu:uuid "7c266f127e5918cec7e3d5caa8f8b8b7" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/8b9526d3b82991f146c6c7957a320be3> .
+
+<http://data.lblod.info/id/identificatoren/7ed780f1a51045e1d4759286472aecbb> a adms:Identifier ;
+    mu:uuid "7ed780f1a51045e1d4759286472aecbb" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/6f540701374ce4664a2f96dc378ac270> .
+
+<http://data.lblod.info/id/identificatoren/8254f554eabf7df0e61945ee5f6a15b3> a adms:Identifier ;
+    mu:uuid "8254f554eabf7df0e61945ee5f6a15b3" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/af9393a0a69a0969b53a3187bb64cf8e> .
+
+<http://data.lblod.info/id/identificatoren/828eed8108089a7bcc26a7b47d55a55c> a adms:Identifier ;
+    mu:uuid "828eed8108089a7bcc26a7b47d55a55c" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/ed6a442c991b5f55d9500eb9374e13c1> .
+
+<http://data.lblod.info/id/identificatoren/833bc029cb3760af991662d680f3a7b6> a adms:Identifier ;
+    mu:uuid "833bc029cb3760af991662d680f3a7b6" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/4529530e731736233480e5282407f496> .
+
+<http://data.lblod.info/id/identificatoren/8346e73eae6b0c105afce77c797e2059> a adms:Identifier ;
+    mu:uuid "8346e73eae6b0c105afce77c797e2059" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/4d3efc8a7f44eb0ae4ad23602739389a> .
+
+<http://data.lblod.info/id/identificatoren/8376152c78d9de1afd8f0bb25168a0b5> a adms:Identifier ;
+    mu:uuid "8376152c78d9de1afd8f0bb25168a0b5" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/d392253dce5c70782d0e25c452aa5f43> .
+
+<http://data.lblod.info/id/identificatoren/83926238381c2c3b4a1a48cb0f884ed9> a adms:Identifier ;
+    mu:uuid "83926238381c2c3b4a1a48cb0f884ed9" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/eccadcda428aca92d732d8207497b45f> .
+
+<http://data.lblod.info/id/identificatoren/83ab27697265ebe4ea36e184fca80b8e> a adms:Identifier ;
+    mu:uuid "83ab27697265ebe4ea36e184fca80b8e" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/59a20e7f487d25f05bb4eb832ce3c004> .
+
+<http://data.lblod.info/id/identificatoren/86791f83395c236dfed230dce34c03be> a adms:Identifier ;
+    mu:uuid "86791f83395c236dfed230dce34c03be" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/2725bae19bad401818796f1bf641772e> .
+
+<http://data.lblod.info/id/identificatoren/86cc19bb579e960317920536c0af08aa> a adms:Identifier ;
+    mu:uuid "86cc19bb579e960317920536c0af08aa" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/6170eaa56a2fdf6771412906fe5200c5> .
+
+<http://data.lblod.info/id/identificatoren/88223fd40246d0e2f31cef20a19e6d0f> a adms:Identifier ;
+    mu:uuid "88223fd40246d0e2f31cef20a19e6d0f" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/971109ab69596fbf352ca778bfef3fc1> .
+
+<http://data.lblod.info/id/identificatoren/8abb98c3d7356a54e12cbded4be3fdad> a adms:Identifier ;
+    mu:uuid "8abb98c3d7356a54e12cbded4be3fdad" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/0702282dfa4c4e52e1e53a378387ed32> .
+
+<http://data.lblod.info/id/identificatoren/8b1571f9a7a322dc7a57f53427016142> a adms:Identifier ;
+    mu:uuid "8b1571f9a7a322dc7a57f53427016142" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/dec04c1170111fa8c8077de3f1a891d6> .
+
+<http://data.lblod.info/id/identificatoren/8e79c4be00bc08edef830545809ec4a5> a adms:Identifier ;
+    mu:uuid "8e79c4be00bc08edef830545809ec4a5" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/65c8714835838d899daf0cb2a694ef6e> .
+
+<http://data.lblod.info/id/identificatoren/94b10872cc8d0f8aa5bc759f9b591c80> a adms:Identifier ;
+    mu:uuid "94b10872cc8d0f8aa5bc759f9b591c80" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/46d6b9b4f5dbe043ec84215719cadc2c> .
+
+<http://data.lblod.info/id/identificatoren/95810835b4a24719136051aef1816116> a adms:Identifier ;
+    mu:uuid "95810835b4a24719136051aef1816116" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/35913f0e492b7b87dd3ac5e6698504f2> .
+
+<http://data.lblod.info/id/identificatoren/95f28b4837d787cd98299f1419b7a8e2> a adms:Identifier ;
+    mu:uuid "95f28b4837d787cd98299f1419b7a8e2" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/213eb98bbcd89e4e755be9d25c5b5165> .
+
+<http://data.lblod.info/id/identificatoren/97214ff8d6fbea8ed22c4003c289fff9> a adms:Identifier ;
+    mu:uuid "97214ff8d6fbea8ed22c4003c289fff9" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/4d297cf05dd4723869564bdc72d89111> .
+
+<http://data.lblod.info/id/identificatoren/9795027f003b708f81b89420af4cb836> a adms:Identifier ;
+    mu:uuid "9795027f003b708f81b89420af4cb836" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/1c3fc51fae099bd4c13563de6cc45e11> .
+
+<http://data.lblod.info/id/identificatoren/9a383c2edd8b29c492f366c660e1de18> a adms:Identifier ;
+    mu:uuid "9a383c2edd8b29c492f366c660e1de18" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/59ed722d9addaff46ef03c7f9f20b75a> .
+
+<http://data.lblod.info/id/identificatoren/9a7791f0b75ccc09d765154f10f9e1a2> a adms:Identifier ;
+    mu:uuid "9a7791f0b75ccc09d765154f10f9e1a2" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/02f80df432b67c04bc1bf2f57f04b770> .
+
+<http://data.lblod.info/id/identificatoren/9a89385bf476786eb19008c3460ca0dc> a adms:Identifier ;
+    mu:uuid "9a89385bf476786eb19008c3460ca0dc" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/72cf52c9080e4adf3746c79466d64b90> .
+
+<http://data.lblod.info/id/identificatoren/9c8c7031f1fa73e1eca76210c9b8dc99> a adms:Identifier ;
+    mu:uuid "9c8c7031f1fa73e1eca76210c9b8dc99" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/bc4bff7d458ef784231ad194ed059358> .
+
+<http://data.lblod.info/id/identificatoren/9dcdfaeec371810b724d9cf21ab68404> a adms:Identifier ;
+    mu:uuid "9dcdfaeec371810b724d9cf21ab68404" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/42b90507d3464900fcfdb2185af81faa> .
+
+<http://data.lblod.info/id/identificatoren/9de0b7956e52b55dc3e917f22a8cae35> a adms:Identifier ;
+    mu:uuid "9de0b7956e52b55dc3e917f22a8cae35" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/3c9c0fd7dad6d29302fdf21a520ab2fb> .
+
+<http://data.lblod.info/id/identificatoren/9e2699cacacbe84d27b0ae1d04703ce9> a adms:Identifier ;
+    mu:uuid "9e2699cacacbe84d27b0ae1d04703ce9" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/a964dedc26286e9053119e70abd7b9bb> .
+
+<http://data.lblod.info/id/identificatoren/9ecda8461bc9ce7596eda8d44203977c> a adms:Identifier ;
+    mu:uuid "9ecda8461bc9ce7596eda8d44203977c" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/9bfc5c849b46c62ed78924b4371dc56a> .
+
+<http://data.lblod.info/id/identificatoren/9f402948fd27301d1c51899375ce09c0> a adms:Identifier ;
+    mu:uuid "9f402948fd27301d1c51899375ce09c0" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/811778877b28a29d5d2a8c6e18ba0dd5> .
+
+<http://data.lblod.info/id/identificatoren/9f8d09cf9f0566deca6fc747ac0e7bd3> a adms:Identifier ;
+    mu:uuid "9f8d09cf9f0566deca6fc747ac0e7bd3" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/b8f698524492b404902ac4110c2e4aa2> .
+
+<http://data.lblod.info/id/identificatoren/9f9506ba58c077451826e9f73ee5902c> a adms:Identifier ;
+    mu:uuid "9f9506ba58c077451826e9f73ee5902c" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/c2413842260ac1d13fb9dc0a2a24cd3c> .
+
+<http://data.lblod.info/id/identificatoren/a1ad28a999cdcba822c236030a523c34> a adms:Identifier ;
+    mu:uuid "a1ad28a999cdcba822c236030a523c34" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/c437affbd190b107fe9c2375b3be7543> .
+
+<http://data.lblod.info/id/identificatoren/a1d4edcf7b02138fb198b042f9656f2d> a adms:Identifier ;
+    mu:uuid "a1d4edcf7b02138fb198b042f9656f2d" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/47742fb7d4c36926773124f685ec0082> .
+
+<http://data.lblod.info/id/identificatoren/a240a32bdaae8a60079d2ccf12961ef6> a adms:Identifier ;
+    mu:uuid "a240a32bdaae8a60079d2ccf12961ef6" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/3c6c2d906099a367176a2efd38b46801> .
+
+<http://data.lblod.info/id/identificatoren/a52fc1a9c6da49e113dffc60ddb01646> a adms:Identifier ;
+    mu:uuid "a52fc1a9c6da49e113dffc60ddb01646" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/04c4ee2e9291d254c20d7444cd5953c8> .
+
+<http://data.lblod.info/id/identificatoren/a5abfba604274eb2092ebc63691c5710> a adms:Identifier ;
+    mu:uuid "a5abfba604274eb2092ebc63691c5710" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/ab82415ea8dbc5b06953e176d9049397> .
+
+<http://data.lblod.info/id/identificatoren/aa884eecdd407444a44efa104842cdc8> a adms:Identifier ;
+    mu:uuid "aa884eecdd407444a44efa104842cdc8" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/1666254ccdc4afcf145264cce0f26324> .
+
+<http://data.lblod.info/id/identificatoren/ac2e095ddedad9eb5157a695cde1b490> a adms:Identifier ;
+    mu:uuid "ac2e095ddedad9eb5157a695cde1b490" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/dfce6be02bbb86efd3a1bcc3522bc90f> .
+
+<http://data.lblod.info/id/identificatoren/ad55b687f0cf69686392e8fa1cc02f22> a adms:Identifier ;
+    mu:uuid "ad55b687f0cf69686392e8fa1cc02f22" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/64d4b8502adbeafba37424d098b426ed> .
+
+<http://data.lblod.info/id/identificatoren/ae04b3ad890a8fedd85fdb7670f1c348> a adms:Identifier ;
+    mu:uuid "ae04b3ad890a8fedd85fdb7670f1c348" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/bd6c97a1665ac397605839483e0f54fa> .
+
+<http://data.lblod.info/id/identificatoren/b0bdd05cb9b9c1cc669654f82d7694c6> a adms:Identifier ;
+    mu:uuid "b0bdd05cb9b9c1cc669654f82d7694c6" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/4e01c5d906acdbb7e19e1c9bc0e055c3> .
+
+<http://data.lblod.info/id/identificatoren/b521662ee00b84161caf451435c1395c> a adms:Identifier ;
+    mu:uuid "b521662ee00b84161caf451435c1395c" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/b26133210bee3170851414a6a018317a> .
+
+<http://data.lblod.info/id/identificatoren/b7609d62625f02747c60bac0051973a4> a adms:Identifier ;
+    mu:uuid "b7609d62625f02747c60bac0051973a4" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/e9f11ad696ddbda7e19e6ca743aa3449> .
+
+<http://data.lblod.info/id/identificatoren/b7c20f59e18f7550f9478b78b2ef61d9> a adms:Identifier ;
+    mu:uuid "b7c20f59e18f7550f9478b78b2ef61d9" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/8f8e49236d80d5c77e2049fbad8ba983> .
+
+<http://data.lblod.info/id/identificatoren/b7e2a357e05d4cdae817179bf3d05a0e> a adms:Identifier ;
+    mu:uuid "b7e2a357e05d4cdae817179bf3d05a0e" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/e0a8e36c6ef633ee0f6b4cf02f2704d1> .
+
+<http://data.lblod.info/id/identificatoren/b7e6e9c6ff101a62874a8dd2f3730d33> a adms:Identifier ;
+    mu:uuid "b7e6e9c6ff101a62874a8dd2f3730d33" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/d47b2f7d7d9023f3b3ab9b2f8a4ca908> .
+
+<http://data.lblod.info/id/identificatoren/b8eb0c081b2d719746c0c30f20fa6037> a adms:Identifier ;
+    mu:uuid "b8eb0c081b2d719746c0c30f20fa6037" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/8e43f23609c0ec57032147ed55dba8a0> .
+
+<http://data.lblod.info/id/identificatoren/bb2ad676cb45e2bd04608bb4b2e922bf> a adms:Identifier ;
+    mu:uuid "bb2ad676cb45e2bd04608bb4b2e922bf" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/bd34251f042748a6f9013be095552618> .
+
+<http://data.lblod.info/id/identificatoren/bdecfd4ef64102f66a038ef80f7adacd> a adms:Identifier ;
+    mu:uuid "bdecfd4ef64102f66a038ef80f7adacd" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/c68002d569063804f2ec8a11ada5c628> .
+
+<http://data.lblod.info/id/identificatoren/be4a753773a6d0d07a8804261c5e05f6> a adms:Identifier ;
+    mu:uuid "be4a753773a6d0d07a8804261c5e05f6" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/43efb09a0d486da0159b6fe50b1ee1e8> .
+
+<http://data.lblod.info/id/identificatoren/bf364b140000bb7d60bac8d1d2e2c3f1> a adms:Identifier ;
+    mu:uuid "bf364b140000bb7d60bac8d1d2e2c3f1" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/708d434232c97b8124c82ff50735244f> .
+
+<http://data.lblod.info/id/identificatoren/c0ee05e2ab030bf4f43a35c1cae1d200> a adms:Identifier ;
+    mu:uuid "c0ee05e2ab030bf4f43a35c1cae1d200" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/980752d849ec6cbd9d411549b5bd74a7> .
+
+<http://data.lblod.info/id/identificatoren/c21ee50143527a05e1a2d83f03b376a1> a adms:Identifier ;
+    mu:uuid "c21ee50143527a05e1a2d83f03b376a1" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/c3e260fab3aec195eadf4e79a2f7f279> .
+
+<http://data.lblod.info/id/identificatoren/c9053fe425582f69f3f484b1f4a0dda6> a adms:Identifier ;
+    mu:uuid "c9053fe425582f69f3f484b1f4a0dda6" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/4f312fe11f316f6eca3dd36818b5f28f> .
+
+<http://data.lblod.info/id/identificatoren/ca9977c725bd71fe8a866da6f41c2420> a adms:Identifier ;
+    mu:uuid "ca9977c725bd71fe8a866da6f41c2420" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/36362abbe86a26020a41f7f4dcf6ddc1> .
+
+<http://data.lblod.info/id/identificatoren/cab92201b1673529a0e61212c5d924a4> a adms:Identifier ;
+    mu:uuid "cab92201b1673529a0e61212c5d924a4" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/7f7d86296faf02c17f018ae4777b296c> .
+
+<http://data.lblod.info/id/identificatoren/cc3784430b2cf0129696b0caf7f5d82c> a adms:Identifier ;
+    mu:uuid "cc3784430b2cf0129696b0caf7f5d82c" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/3f4eb805a9f6551154f6f8a2b29aa5de> .
+
+<http://data.lblod.info/id/identificatoren/cdf4ee5bf16271aff7b931049b49bbc0> a adms:Identifier ;
+    mu:uuid "cdf4ee5bf16271aff7b931049b49bbc0" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/3d8654720951d3ce3d8bb4a9b9e94e40> .
+
+<http://data.lblod.info/id/identificatoren/ce2d8d86a058d611b92cc28e548dcaca> a adms:Identifier ;
+    mu:uuid "ce2d8d86a058d611b92cc28e548dcaca" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/86e840975256d5b4f166c07542aa15ca> .
+
+<http://data.lblod.info/id/identificatoren/cec61ea09de65d05509c5c129c4788ce> a adms:Identifier ;
+    mu:uuid "cec61ea09de65d05509c5c129c4788ce" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/69c87c79a897a58ac0118c69a0fe5d4d> .
+
+<http://data.lblod.info/id/identificatoren/d26cb960cf884c6575d8f2f4d28ab659> a adms:Identifier ;
+    mu:uuid "d26cb960cf884c6575d8f2f4d28ab659" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/55f23db3dc6a1a7246d763c4db6a6368> .
+
+<http://data.lblod.info/id/identificatoren/d3ca7836d44ce36f1362788255a63fcb> a adms:Identifier ;
+    mu:uuid "d3ca7836d44ce36f1362788255a63fcb" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/0ea002c46232c6fd76310dcb1bc19016> .
+
+<http://data.lblod.info/id/identificatoren/d752b7f04f2a41da6b2a6b132a94cc30> a adms:Identifier ;
+    mu:uuid "d752b7f04f2a41da6b2a6b132a94cc30" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/01cb6a0b61a750d3c1e2285fd3f79dcb> .
+
+<http://data.lblod.info/id/identificatoren/d8173ddc7d0d6d47212591a5d1c9e7d1> a adms:Identifier ;
+    mu:uuid "d8173ddc7d0d6d47212591a5d1c9e7d1" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/48c456f5f96d52e1d7c0bbd157119437> .
+
+<http://data.lblod.info/id/identificatoren/dab06c7135dc12adfff963881e06a24e> a adms:Identifier ;
+    mu:uuid "dab06c7135dc12adfff963881e06a24e" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/0424b17cb44d698273045ab4b59425f8> .
+
+<http://data.lblod.info/id/identificatoren/db99845851325d4f9d7f707148b8f30d> a adms:Identifier ;
+    mu:uuid "db99845851325d4f9d7f707148b8f30d" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/470cab901355371efda686f59f03d7a8> .
+
+<http://data.lblod.info/id/identificatoren/dc1afbe9facaa8aba30288492f057e13> a adms:Identifier ;
+    mu:uuid "dc1afbe9facaa8aba30288492f057e13" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/6b8197150adb2ece219753a2531f869a> .
+
+<http://data.lblod.info/id/identificatoren/e02e7c6a6f387945aafa19b3ef3e3a71> a adms:Identifier ;
+    mu:uuid "e02e7c6a6f387945aafa19b3ef3e3a71" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/e2447477a8f9dcb12738e4da5015085c> .
+
+<http://data.lblod.info/id/identificatoren/e05368c77286b626417832073770bb51> a adms:Identifier ;
+    mu:uuid "e05368c77286b626417832073770bb51" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/653fc48ae170789767d5c34a60aecb3f> .
+
+<http://data.lblod.info/id/identificatoren/e1934b2633ba1ebd9fdd409d65ed68bf> a adms:Identifier ;
+    mu:uuid "e1934b2633ba1ebd9fdd409d65ed68bf" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/529d3002bf61e4b9a3f1df4903a557f3> .
+
+<http://data.lblod.info/id/identificatoren/e54133819df671247fd33e4bc107b9b7> a adms:Identifier ;
+    mu:uuid "e54133819df671247fd33e4bc107b9b7" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/7a2682406178de906005b5593921143f> .
+
+<http://data.lblod.info/id/identificatoren/e7a24c0455ef6b5040bdf38a2a977823> a adms:Identifier ;
+    mu:uuid "e7a24c0455ef6b5040bdf38a2a977823" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/6271235af04ea7bb43fe979b247e12e5> .
+
+<http://data.lblod.info/id/identificatoren/e7c91bbaaf5feed05cab99ff9899dadb> a adms:Identifier ;
+    mu:uuid "e7c91bbaaf5feed05cab99ff9899dadb" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/9a215de2a80f904c791939c087651226> .
+
+<http://data.lblod.info/id/identificatoren/e8086576af9a34eb57baaa828d7cf8c2> a adms:Identifier ;
+    mu:uuid "e8086576af9a34eb57baaa828d7cf8c2" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/20873cd3ee12186fa4162745adfc6b30> .
+
+<http://data.lblod.info/id/identificatoren/e8bc9ec49d3247bc78ff29fc8dbaf33d> a adms:Identifier ;
+    mu:uuid "e8bc9ec49d3247bc78ff29fc8dbaf33d" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/fbb565c4a10e2800ed6b8a7f4b048d1e> .
+
+<http://data.lblod.info/id/identificatoren/ec41ea9ff2d54d14e2781f1cc3ccbbd1> a adms:Identifier ;
+    mu:uuid "ec41ea9ff2d54d14e2781f1cc3ccbbd1" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/beba02e19805b8d5770e990f76aea21c> .
+
+<http://data.lblod.info/id/identificatoren/eddcf52c4b91de7bb0da5e886b49a0f5> a adms:Identifier ;
+    mu:uuid "eddcf52c4b91de7bb0da5e886b49a0f5" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/cc3ca5e91596ff51178aa826d980fad2> .
+
+<http://data.lblod.info/id/identificatoren/eea40e2a2e904d8d9006595a9e44abbe> a adms:Identifier ;
+    mu:uuid "eea40e2a2e904d8d9006595a9e44abbe" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/4fa0442e8ce25218cce6c1dedaa5a5b3> .
+
+<http://data.lblod.info/id/identificatoren/efb6ab4e0f28730c4ed9e9f5fe92ac92> a adms:Identifier ;
+    mu:uuid "efb6ab4e0f28730c4ed9e9f5fe92ac92" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/fc75f2182a85f56e85919df0a140df11> .
+
+<http://data.lblod.info/id/identificatoren/f0e74f742b7cf9a79105eefdaf871e42> a adms:Identifier ;
+    mu:uuid "f0e74f742b7cf9a79105eefdaf871e42" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/cc3f9899929a7f91f2a198b5f9ca04c1> .
+
+<http://data.lblod.info/id/identificatoren/f3da087130feaa62255d5da14a09a229> a adms:Identifier ;
+    mu:uuid "f3da087130feaa62255d5da14a09a229" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/6a61037749c0b0e86d6ad6434fc982ef> .
+
+<http://data.lblod.info/id/identificatoren/f610900d7ee76fc040027b5eaa7aa6bc> a adms:Identifier ;
+    mu:uuid "f610900d7ee76fc040027b5eaa7aa6bc" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/941cdf8957c05d560da0728eadd6a36d> .
+
+<http://data.lblod.info/id/identificatoren/f6dc15210d7fb45376069c6882b505d0> a adms:Identifier ;
+    mu:uuid "f6dc15210d7fb45376069c6882b505d0" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/21c6125f57dc85fc4eec4811bfd2f604> .
+
+<http://data.lblod.info/id/identificatoren/f830c830aed0783c61771fb1ef424ce1> a adms:Identifier ;
+    mu:uuid "f830c830aed0783c61771fb1ef424ce1" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/f0ecfb00326b69deed81175b0eaa75b7> .
+
+<http://data.lblod.info/id/identificatoren/f891bb0ca0508918b3ac986ad3a4fbee> a adms:Identifier ;
+    mu:uuid "f891bb0ca0508918b3ac986ad3a4fbee" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/ea8286ba6c761222f12b883fddc6ea17> .
+
+<http://data.lblod.info/id/identificatoren/f93c5874a7e14e733f5f315d963bc69b> a adms:Identifier ;
+    mu:uuid "f93c5874a7e14e733f5f315d963bc69b" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/c387aa5093696c55eb28fc31526e641c> .
+
+<http://data.lblod.info/id/identificatoren/fa0190f783eddf5ccef9afb483337eab> a adms:Identifier ;
+    mu:uuid "fa0190f783eddf5ccef9afb483337eab" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/7c4f56ac3783b2cad0c71c6e77f0e61d> .
+
+<http://data.lblod.info/id/identificatoren/fb4cf3c3a825a7b706f2549eab4ce8df> a adms:Identifier ;
+    mu:uuid "fb4cf3c3a825a7b706f2549eab4ce8df" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/73a19f0592ecf5d15072cb36a6b5be11> .
+
+<http://data.lblod.info/id/identificatoren/fbf4493931eed8c035056b0cf9ddbbf8> a adms:Identifier ;
+    mu:uuid "fbf4493931eed8c035056b0cf9ddbbf8" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/bc4583d2c2764518b61f20167bf5fe01> .
+
+<http://data.lblod.info/id/identificatoren/fc441f679c945f8ab069134677f7b6a0> a adms:Identifier ;
+    mu:uuid "fc441f679c945f8ab069134677f7b6a0" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/692d125cd40172ea7210df3c86ac6f7f> .
+
+<http://data.lblod.info/id/identificatoren/fc62b359c7960acff12ee02b1c84b2cf> a adms:Identifier ;
+    mu:uuid "fc62b359c7960acff12ee02b1c84b2cf" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/95033071b09fb68773ee70aa91f13139> .
+
+<http://data.lblod.info/id/identificatoren/fe5dd392743b85113de1d56862da9e35> a adms:Identifier ;
+    mu:uuid "fe5dd392743b85113de1d56862da9e35" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/4c332d018da8dfd8b0f6282eeef39a75> .
+
+<http://data.lblod.info/id/identificatoren/ff222f8b337d691c3cf81a9328a974d1> a adms:Identifier ;
+    mu:uuid "ff222f8b337d691c3cf81a9328a974d1" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/e705cbd35e3bafcb528a7ca08ce43649> .
+
+<http://data.lblod.info/id/identificatoren/ffc26b9f7c788d6e358ed828d11ed447> a adms:Identifier ;
+    mu:uuid "ffc26b9f7c788d6e358ed828d11ed447" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/2b998b631caf05f0155cc5a848069302> .
+

--- a/config/migrations/2023/20231005111600-onboarding-pz-hvz/20231005111625-import-pz-and-hvp.graph
+++ b/config/migrations/2023/20231005111600-onboarding-pz-hvz/20231005111625-import-pz-and-hvp.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/administrative-unit

--- a/config/migrations/2023/20231005111600-onboarding-pz-hvz/20231005111625-import-pz-and-hvp.ttl
+++ b/config/migrations/2023/20231005111600-onboarding-pz-hvz/20231005111625-import-pz-and-hvp.ttl
@@ -1,0 +1,5379 @@
+
+          @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+          @prefix mu: <http://mu.semte.ch/vocabularies/core/> .
+          @prefix persoon: <https://data.vlaanderen.be/ns/persoon#> .
+          @prefix ext: <http://mu.semte.ch/vocabularies/ext/>.
+          @prefix person: <http://www.w3.org/ns/person#>.
+          @prefix session: <http://mu.semte.ch/vocabularies/session/>.
+          @prefix foaf: <http://xmlns.com/foaf/0.1/>.
+          @prefix besluit: <http://data.vlaanderen.be/ns/besluit#>.
+          @prefix ere: <http://data.lblod.info/vocabularies/erediensten/>.
+          @prefix mandaat: <http://data.vlaanderen.be/ns/mandaat#>.
+          @prefix org: <http://www.w3.org/ns/org#>.
+          @prefix dcterms: <http://purl.org/dc/terms/>.
+          @prefix generiek: <https://data.vlaanderen.be/ns/generiek#>.
+          @prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+        
+      <http://data.lblod.info/id/identificatoren/c2b20a26-42c9-4de1-9daf-271b916e6b7b> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "c2b20a26-42c9-4de1-9daf-271b916e6b7b";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/82560c17-d053-4c33-80b1-fec89b3e7c6d>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/82560c17-d053-4c33-80b1-fec89b3e7c6d> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "82560c17-d053-4c33-80b1-fec89b3e7c6d";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1174".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/99b4a1e8-dd21-43ae-8ff3-ab5d00265c20> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "99b4a1e8-dd21-43ae-8ff3-ab5d00265c20";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/317f4147-2566-46b5-b464-b125cec08e59>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/88f3945f-db83-4296-b236-cae925bad503>,
+                        <http://data.lblod.info/id/contact-punten/2addcf54-64d8-4046-a62e-f301d0526481>.
+
+      <http://data.lblod.info/id/contact-punten/88f3945f-db83-4296-b236-cae925bad503> a <http://schema.org/ContactPoint>;
+        mu:uuid "88f3945f-db83-4296-b236-cae925bad503";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/2addcf54-64d8-4046-a62e-f301d0526481> a <http://schema.org/ContactPoint>;
+        mu:uuid "2addcf54-64d8-4046-a62e-f301d0526481";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/317f4147-2566-46b5-b464-b125cec08e59> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "317f4147-2566-46b5-b464-b125cec08e59".
+
+      <http://data.lblod.info/id/bestuurseenheden/0e951dd15341d38413bf809f16ef5f1bd163092001ac04ce78a4de5b5e9cdd37> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "0e951dd15341d38413bf809f16ef5f1bd163092001ac04ce78a4de5b5e9cdd37";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/ea446861-2c51-45fa-afd3-4e4a37b71562>;
+        skos:prefLabel  "HVZ Meetjesland";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/c2b20a26-42c9-4de1-9daf-271b916e6b7b>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/99b4a1e8-dd21-43ae-8ff3-ab5d00265c20> .
+    
+
+      <http://data.lblod.info/id/identificatoren/dde9ee0d-daba-4ed0-aef8-18eebd867511> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "dde9ee0d-daba-4ed0-aef8-18eebd867511";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/27249411-edc7-4416-b445-9da4fe40fdcb>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/27249411-edc7-4416-b445-9da4fe40fdcb> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "27249411-edc7-4416-b445-9da4fe40fdcb";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1175".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/b2fb3570-0d02-4b53-ab83-55ba5792783e> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "b2fb3570-0d02-4b53-ab83-55ba5792783e";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/5d5e9c65-684a-4b05-805d-a0ad9bb270cd>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/94dd99b4-9706-41a9-9c56-0c5d91f3b9b0>,
+                        <http://data.lblod.info/id/contact-punten/fefacad4-1af2-4471-b29c-73a9a7f30fb8>.
+
+      <http://data.lblod.info/id/contact-punten/94dd99b4-9706-41a9-9c56-0c5d91f3b9b0> a <http://schema.org/ContactPoint>;
+        mu:uuid "94dd99b4-9706-41a9-9c56-0c5d91f3b9b0";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/fefacad4-1af2-4471-b29c-73a9a7f30fb8> a <http://schema.org/ContactPoint>;
+        mu:uuid "fefacad4-1af2-4471-b29c-73a9a7f30fb8";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/5d5e9c65-684a-4b05-805d-a0ad9bb270cd> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "5d5e9c65-684a-4b05-805d-a0ad9bb270cd".
+
+      <http://data.lblod.info/id/bestuurseenheden/215d1409dda860a1ce4f39f1f6c082c5662620d9d29de456f4242fb6cc6df0b5> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "215d1409dda860a1ce4f39f1f6c082c5662620d9d29de456f4242fb6cc6df0b5";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/ea446861-2c51-45fa-afd3-4e4a37b71562>;
+        skos:prefLabel  "HVZ Brandweer Zone Kempen";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/dde9ee0d-daba-4ed0-aef8-18eebd867511>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/b2fb3570-0d02-4b53-ab83-55ba5792783e> .
+    
+
+      <http://data.lblod.info/id/identificatoren/872419d6-a6f4-4b0f-970d-e96dada0a4ff> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "872419d6-a6f4-4b0f-970d-e96dada0a4ff";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/63067556-b5fb-4def-bb44-d0b34d916d89>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/63067556-b5fb-4def-bb44-d0b34d916d89> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "63067556-b5fb-4def-bb44-d0b34d916d89";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1177".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/6a87e0c7-3c1f-4a67-8680-2534c395414c> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "6a87e0c7-3c1f-4a67-8680-2534c395414c";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/fddb90f3-3201-4d54-a863-399be64938cd>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/f682295e-d5a7-4f6e-8e53-da845490cd44>,
+                        <http://data.lblod.info/id/contact-punten/338d38e3-9f4d-4087-8827-8b1df678f8d8>.
+
+      <http://data.lblod.info/id/contact-punten/f682295e-d5a7-4f6e-8e53-da845490cd44> a <http://schema.org/ContactPoint>;
+        mu:uuid "f682295e-d5a7-4f6e-8e53-da845490cd44";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/338d38e3-9f4d-4087-8827-8b1df678f8d8> a <http://schema.org/ContactPoint>;
+        mu:uuid "338d38e3-9f4d-4087-8827-8b1df678f8d8";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/fddb90f3-3201-4d54-a863-399be64938cd> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "fddb90f3-3201-4d54-a863-399be64938cd".
+
+      <http://data.lblod.info/id/bestuurseenheden/2d25be1712e809bbeed7d439c93bace752e0742f6b2ed9802302dec9a8906e2a> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "2d25be1712e809bbeed7d439c93bace752e0742f6b2ed9802302dec9a8906e2a";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/ea446861-2c51-45fa-afd3-4e4a37b71562>;
+        skos:prefLabel  "HVZ Brandweer Zone Rand";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/872419d6-a6f4-4b0f-970d-e96dada0a4ff>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/6a87e0c7-3c1f-4a67-8680-2534c395414c> .
+    
+
+      <http://data.lblod.info/id/identificatoren/ddb67280-8334-480f-acaf-18ac8af0e746> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "ddb67280-8334-480f-acaf-18ac8af0e746";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/772466af-baa5-476b-8362-6ab509512094>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/772466af-baa5-476b-8362-6ab509512094> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "772466af-baa5-476b-8362-6ab509512094";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1178".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/a54f2310-aabe-48a6-9dc0-52d82a67139a> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "a54f2310-aabe-48a6-9dc0-52d82a67139a";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/c8745530-8a49-4d34-bea3-8154f6295770>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/e93f02e0-3881-4791-bf1f-c8bece142a94>,
+                        <http://data.lblod.info/id/contact-punten/e5bd6512-f51f-4906-ac99-57683005f791>.
+
+      <http://data.lblod.info/id/contact-punten/e93f02e0-3881-4791-bf1f-c8bece142a94> a <http://schema.org/ContactPoint>;
+        mu:uuid "e93f02e0-3881-4791-bf1f-c8bece142a94";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/e5bd6512-f51f-4906-ac99-57683005f791> a <http://schema.org/ContactPoint>;
+        mu:uuid "e5bd6512-f51f-4906-ac99-57683005f791";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/c8745530-8a49-4d34-bea3-8154f6295770> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "c8745530-8a49-4d34-bea3-8154f6295770".
+
+      <http://data.lblod.info/id/bestuurseenheden/4bb83a0635b69132a4de91667c0a30f228720bda01584b3a01c4cf7ddfc12664> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "4bb83a0635b69132a4de91667c0a30f228720bda01584b3a01c4cf7ddfc12664";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/ea446861-2c51-45fa-afd3-4e4a37b71562>;
+        skos:prefLabel  "HVZ Brandweer Zone Centrum";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/ddb67280-8334-480f-acaf-18ac8af0e746>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/a54f2310-aabe-48a6-9dc0-52d82a67139a> .
+    
+
+      <http://data.lblod.info/id/identificatoren/8c53374d-3b76-4258-982f-d691e275824e> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "8c53374d-3b76-4258-982f-d691e275824e";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/3ae131d0-5ec6-4b62-8cfa-e5ed9aca3a8e>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/3ae131d0-5ec6-4b62-8cfa-e5ed9aca3a8e> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "3ae131d0-5ec6-4b62-8cfa-e5ed9aca3a8e";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1179".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/505ca3d1-d9e2-4bba-b5a6-fdab5fa9b77b> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "505ca3d1-d9e2-4bba-b5a6-fdab5fa9b77b";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/fea3273c-4f95-4bf5-8c82-f7d96b7350af>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/098e0f37-6c8a-4fbb-976a-6fd819c7fbf1>,
+                        <http://data.lblod.info/id/contact-punten/affdab9c-7ba9-4143-b77e-bbfc3e28ee54>.
+
+      <http://data.lblod.info/id/contact-punten/098e0f37-6c8a-4fbb-976a-6fd819c7fbf1> a <http://schema.org/ContactPoint>;
+        mu:uuid "098e0f37-6c8a-4fbb-976a-6fd819c7fbf1";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/affdab9c-7ba9-4143-b77e-bbfc3e28ee54> a <http://schema.org/ContactPoint>;
+        mu:uuid "affdab9c-7ba9-4143-b77e-bbfc3e28ee54";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/fea3273c-4f95-4bf5-8c82-f7d96b7350af> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "fea3273c-4f95-4bf5-8c82-f7d96b7350af".
+
+      <http://data.lblod.info/id/bestuurseenheden/505e727b7b078c3eb9a05f754d834fca559d28cb3cdb02d5e4cdb3be300ea699> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "505e727b7b078c3eb9a05f754d834fca559d28cb3cdb02d5e4cdb3be300ea699";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/ea446861-2c51-45fa-afd3-4e4a37b71562>;
+        skos:prefLabel  "HVZ Noord-Limburg";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/8c53374d-3b76-4258-982f-d691e275824e>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/505ca3d1-d9e2-4bba-b5a6-fdab5fa9b77b> .
+    
+
+      <http://data.lblod.info/id/identificatoren/d8e75412-e91f-4ccf-9820-9d9aa68180b1> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "d8e75412-e91f-4ccf-9820-9d9aa68180b1";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/3b230951-dc28-4c22-a3e3-ba04cef1e2a7>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/3b230951-dc28-4c22-a3e3-ba04cef1e2a7> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "3b230951-dc28-4c22-a3e3-ba04cef1e2a7";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1180".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/16cd05d3-4de9-4b8b-a079-0406216ca0ba> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "16cd05d3-4de9-4b8b-a079-0406216ca0ba";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/0be51ce7-ed6f-4f4c-9f0f-dcb7acde1154>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/64abc744-9923-4ef6-b3e0-dbfe348b7c86>,
+                        <http://data.lblod.info/id/contact-punten/34f6e61b-719a-4c9c-af1a-8bfc0782cb54>.
+
+      <http://data.lblod.info/id/contact-punten/64abc744-9923-4ef6-b3e0-dbfe348b7c86> a <http://schema.org/ContactPoint>;
+        mu:uuid "64abc744-9923-4ef6-b3e0-dbfe348b7c86";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/34f6e61b-719a-4c9c-af1a-8bfc0782cb54> a <http://schema.org/ContactPoint>;
+        mu:uuid "34f6e61b-719a-4c9c-af1a-8bfc0782cb54";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/0be51ce7-ed6f-4f4c-9f0f-dcb7acde1154> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "0be51ce7-ed6f-4f4c-9f0f-dcb7acde1154".
+
+      <http://data.lblod.info/id/bestuurseenheden/7800a6f5e9c3f646e274b280703730ed5e83fe0cba1f0d6c7fb18141337fe781> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "7800a6f5e9c3f646e274b280703730ed5e83fe0cba1f0d6c7fb18141337fe781";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/ea446861-2c51-45fa-afd3-4e4a37b71562>;
+        skos:prefLabel  "HVZ Brandweer Zone Oost-Limburg";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/d8e75412-e91f-4ccf-9820-9d9aa68180b1>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/16cd05d3-4de9-4b8b-a079-0406216ca0ba> .
+    
+
+      <http://data.lblod.info/id/identificatoren/886b8604-0ba9-44ea-94fb-7474eed11e46> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "886b8604-0ba9-44ea-94fb-7474eed11e46";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/1b92705a-c66e-4327-9c76-8519836d2099>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/1b92705a-c66e-4327-9c76-8519836d2099> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "1b92705a-c66e-4327-9c76-8519836d2099";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1181".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/71713887-dbdb-481e-821c-a5c705a39079> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "71713887-dbdb-481e-821c-a5c705a39079";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/a97df9bd-8815-4d5c-b6c7-cee4ce1af6b8>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/d08cb166-a408-4dad-ad22-169586eefe3a>,
+                        <http://data.lblod.info/id/contact-punten/6aae27d9-52a5-47d9-85c5-a9ba202d006f>.
+
+      <http://data.lblod.info/id/contact-punten/d08cb166-a408-4dad-ad22-169586eefe3a> a <http://schema.org/ContactPoint>;
+        mu:uuid "d08cb166-a408-4dad-ad22-169586eefe3a";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/6aae27d9-52a5-47d9-85c5-a9ba202d006f> a <http://schema.org/ContactPoint>;
+        mu:uuid "6aae27d9-52a5-47d9-85c5-a9ba202d006f";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/a97df9bd-8815-4d5c-b6c7-cee4ce1af6b8> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "a97df9bd-8815-4d5c-b6c7-cee4ce1af6b8".
+
+      <http://data.lblod.info/id/bestuurseenheden/98967d1e1e3dd66ac9e32bd1d536ee8e85c9126cc5fc04354a335d5aabcf9b01> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "98967d1e1e3dd66ac9e32bd1d536ee8e85c9126cc5fc04354a335d5aabcf9b01";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/ea446861-2c51-45fa-afd3-4e4a37b71562>;
+        skos:prefLabel  "HVZ Rivierenland";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/886b8604-0ba9-44ea-94fb-7474eed11e46>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/71713887-dbdb-481e-821c-a5c705a39079> .
+    
+
+      <http://data.lblod.info/id/identificatoren/a6444127-32b6-46fc-a7c3-41896277464f> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "a6444127-32b6-46fc-a7c3-41896277464f";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/ac9d6885-2fda-4f26-902e-6f4fed46de4f>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/ac9d6885-2fda-4f26-902e-6f4fed46de4f> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "ac9d6885-2fda-4f26-902e-6f4fed46de4f";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1182".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/a308109b-3ae5-49ba-b6b8-88ea991e2dbf> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "a308109b-3ae5-49ba-b6b8-88ea991e2dbf";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/660a0198-ca31-4df4-8b36-e82e7f64aae8>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/4488ed35-fa67-497a-8ec8-2fe1cf3ca2a5>,
+                        <http://data.lblod.info/id/contact-punten/1787987c-dda4-4fa7-bfe2-7375735a8f7c>.
+
+      <http://data.lblod.info/id/contact-punten/4488ed35-fa67-497a-8ec8-2fe1cf3ca2a5> a <http://schema.org/ContactPoint>;
+        mu:uuid "4488ed35-fa67-497a-8ec8-2fe1cf3ca2a5";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/1787987c-dda4-4fa7-bfe2-7375735a8f7c> a <http://schema.org/ContactPoint>;
+        mu:uuid "1787987c-dda4-4fa7-bfe2-7375735a8f7c";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/660a0198-ca31-4df4-8b36-e82e7f64aae8> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "660a0198-ca31-4df4-8b36-e82e7f64aae8".
+
+      <http://data.lblod.info/id/bestuurseenheden/9d0e3fc23f4fb9c23cbcc30474a1e518c9725c069255090d46eb58c13d62baef> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "9d0e3fc23f4fb9c23cbcc30474a1e518c9725c069255090d46eb58c13d62baef";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/ea446861-2c51-45fa-afd3-4e4a37b71562>;
+        skos:prefLabel  "HVZ Fluvia";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/a6444127-32b6-46fc-a7c3-41896277464f>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/a308109b-3ae5-49ba-b6b8-88ea991e2dbf> .
+    
+
+      <http://data.lblod.info/id/identificatoren/9b8e46fe-0e76-4e91-bc9e-1c4db961221e> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "9b8e46fe-0e76-4e91-bc9e-1c4db961221e";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/29182702-6b26-4f53-bc42-ccee1c20ee3b>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/29182702-6b26-4f53-bc42-ccee1c20ee3b> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "29182702-6b26-4f53-bc42-ccee1c20ee3b";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1183".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/1bb3029b-727c-401e-8b26-2269f5a05479> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "1bb3029b-727c-401e-8b26-2269f5a05479";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/ca6930d4-6a3f-44a7-98df-5686d5c4b8fd>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/5c67653e-fc5c-4e02-bccd-93988a6d9171>,
+                        <http://data.lblod.info/id/contact-punten/28ad6d6b-5033-4df7-b72d-ec6430eb9e67>.
+
+      <http://data.lblod.info/id/contact-punten/5c67653e-fc5c-4e02-bccd-93988a6d9171> a <http://schema.org/ContactPoint>;
+        mu:uuid "5c67653e-fc5c-4e02-bccd-93988a6d9171";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/28ad6d6b-5033-4df7-b72d-ec6430eb9e67> a <http://schema.org/ContactPoint>;
+        mu:uuid "28ad6d6b-5033-4df7-b72d-ec6430eb9e67";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/ca6930d4-6a3f-44a7-98df-5686d5c4b8fd> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "ca6930d4-6a3f-44a7-98df-5686d5c4b8fd".
+
+      <http://data.lblod.info/id/bestuurseenheden/9fdf19f0cfc9e12bd58fc10c4da6e8c6c40e813ec5b9f3bdde92cb00ecd972fe> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "9fdf19f0cfc9e12bd58fc10c4da6e8c6c40e813ec5b9f3bdde92cb00ecd972fe";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/ea446861-2c51-45fa-afd3-4e4a37b71562>;
+        skos:prefLabel  "HVZ Oost-Vlaams-Brabant";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/9b8e46fe-0e76-4e91-bc9e-1c4db961221e>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/1bb3029b-727c-401e-8b26-2269f5a05479> .
+    
+
+      <http://data.lblod.info/id/identificatoren/3770c257-439b-4c5b-afbc-1ee1165ff65e> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "3770c257-439b-4c5b-afbc-1ee1165ff65e";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/659f362f-bf38-4902-ad5a-e4865183664a>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/659f362f-bf38-4902-ad5a-e4865183664a> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "659f362f-bf38-4902-ad5a-e4865183664a";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1184".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/68157213-8c99-4076-b3a1-9d812061c596> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "68157213-8c99-4076-b3a1-9d812061c596";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/8bf49c2e-5702-4dcf-95ec-b02fd6673cd4>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/35ffc7a8-dd5b-4879-b23c-eaa1804686b1>,
+                        <http://data.lblod.info/id/contact-punten/3e3f8a80-a6b0-4470-b4e8-a67ffc0d05f6>.
+
+      <http://data.lblod.info/id/contact-punten/35ffc7a8-dd5b-4879-b23c-eaa1804686b1> a <http://schema.org/ContactPoint>;
+        mu:uuid "35ffc7a8-dd5b-4879-b23c-eaa1804686b1";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/3e3f8a80-a6b0-4470-b4e8-a67ffc0d05f6> a <http://schema.org/ContactPoint>;
+        mu:uuid "3e3f8a80-a6b0-4470-b4e8-a67ffc0d05f6";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/8bf49c2e-5702-4dcf-95ec-b02fd6673cd4> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "8bf49c2e-5702-4dcf-95ec-b02fd6673cd4".
+
+      <http://data.lblod.info/id/bestuurseenheden/a3b32431cfbb18905e2c7deeaf9ef7af35cd17c55d053a05ed9cd8fdec550724> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "a3b32431cfbb18905e2c7deeaf9ef7af35cd17c55d053a05ed9cd8fdec550724";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/ea446861-2c51-45fa-afd3-4e4a37b71562>;
+        skos:prefLabel  "HVZ Zuid-West-Limburg";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/3770c257-439b-4c5b-afbc-1ee1165ff65e>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/68157213-8c99-4076-b3a1-9d812061c596> .
+    
+
+      <http://data.lblod.info/id/identificatoren/cf0dbf2f-62e9-466d-966e-11e84670dcbd> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "cf0dbf2f-62e9-466d-966e-11e84670dcbd";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/dbf50b70-94e9-4d5c-b8d9-769c8ae3883e>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/dbf50b70-94e9-4d5c-b8d9-769c8ae3883e> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "dbf50b70-94e9-4d5c-b8d9-769c8ae3883e";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1185".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/66dcf153-a424-41a1-92ed-964032022598> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "66dcf153-a424-41a1-92ed-964032022598";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/46861ee4-6d16-4c68-8128-79af90001d2c>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/25e7d796-0728-4c8a-913b-6f5e8c9e4f31>,
+                        <http://data.lblod.info/id/contact-punten/3a93cadf-6e80-4588-a23a-4f9f91d9db81>.
+
+      <http://data.lblod.info/id/contact-punten/25e7d796-0728-4c8a-913b-6f5e8c9e4f31> a <http://schema.org/ContactPoint>;
+        mu:uuid "25e7d796-0728-4c8a-913b-6f5e8c9e4f31";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/3a93cadf-6e80-4588-a23a-4f9f91d9db81> a <http://schema.org/ContactPoint>;
+        mu:uuid "3a93cadf-6e80-4588-a23a-4f9f91d9db81";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/46861ee4-6d16-4c68-8128-79af90001d2c> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "46861ee4-6d16-4c68-8128-79af90001d2c".
+
+      <http://data.lblod.info/id/bestuurseenheden/b312420a9e4331da36afd70237db5061825cacadcdaa68e6ad0f1ea8a9426f77> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "b312420a9e4331da36afd70237db5061825cacadcdaa68e6ad0f1ea8a9426f77";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/ea446861-2c51-45fa-afd3-4e4a37b71562>;
+        skos:prefLabel  "HVZ Brandweer Zone Midwest";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/cf0dbf2f-62e9-466d-966e-11e84670dcbd>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/66dcf153-a424-41a1-92ed-964032022598> .
+    
+
+      <http://data.lblod.info/id/identificatoren/24c39a8a-5e1d-46ba-9cc4-b531ce7bc53f> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "24c39a8a-5e1d-46ba-9cc4-b531ce7bc53f";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/99c8e73b-d8b2-47f9-90e0-547ea6384a35>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/99c8e73b-d8b2-47f9-90e0-547ea6384a35> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "99c8e73b-d8b2-47f9-90e0-547ea6384a35";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1186".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/14d1ea7b-b0ec-4c4d-bec4-556ada5fd850> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "14d1ea7b-b0ec-4c4d-bec4-556ada5fd850";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/f7ba6064-82b5-4df4-83e0-38447429742f>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/ff3489bd-0559-47b0-8f7b-32b7bacf91bd>,
+                        <http://data.lblod.info/id/contact-punten/43f62c35-1ad7-4f35-bbff-ebb82400b588>.
+
+      <http://data.lblod.info/id/contact-punten/ff3489bd-0559-47b0-8f7b-32b7bacf91bd> a <http://schema.org/ContactPoint>;
+        mu:uuid "ff3489bd-0559-47b0-8f7b-32b7bacf91bd";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/43f62c35-1ad7-4f35-bbff-ebb82400b588> a <http://schema.org/ContactPoint>;
+        mu:uuid "43f62c35-1ad7-4f35-bbff-ebb82400b588";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/f7ba6064-82b5-4df4-83e0-38447429742f> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "f7ba6064-82b5-4df4-83e0-38447429742f".
+
+      <http://data.lblod.info/id/bestuurseenheden/b3e202bf5ab9d30f1928f7a1ea8911c60da595819774702eb1745e83c25cf106> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "b3e202bf5ab9d30f1928f7a1ea8911c60da595819774702eb1745e83c25cf106";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/ea446861-2c51-45fa-afd3-4e4a37b71562>;
+        skos:prefLabel  "HVZ Brandweer Zone Vlaams-Brabant West";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/24c39a8a-5e1d-46ba-9cc4-b531ce7bc53f>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/14d1ea7b-b0ec-4c4d-bec4-556ada5fd850> .
+    
+
+      <http://data.lblod.info/id/identificatoren/d8a7c8aa-382a-495c-8b29-7d51c88c9b28> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "d8a7c8aa-382a-495c-8b29-7d51c88c9b28";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/331dec67-fb23-412a-b1af-9f6ca405a4e9>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/331dec67-fb23-412a-b1af-9f6ca405a4e9> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "331dec67-fb23-412a-b1af-9f6ca405a4e9";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1187".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/5426473d-b36f-4dab-8265-8f51444ae053> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "5426473d-b36f-4dab-8265-8f51444ae053";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/98f46cbd-0dd1-42b5-85f3-c00a9c2df16d>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/c134e5c4-9e37-4794-885d-d0302c19d735>,
+                        <http://data.lblod.info/id/contact-punten/28a16157-73e3-4250-a85b-8acb02244718>.
+
+      <http://data.lblod.info/id/contact-punten/c134e5c4-9e37-4794-885d-d0302c19d735> a <http://schema.org/ContactPoint>;
+        mu:uuid "c134e5c4-9e37-4794-885d-d0302c19d735";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/28a16157-73e3-4250-a85b-8acb02244718> a <http://schema.org/ContactPoint>;
+        mu:uuid "28a16157-73e3-4250-a85b-8acb02244718";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/98f46cbd-0dd1-42b5-85f3-c00a9c2df16d> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "98f46cbd-0dd1-42b5-85f3-c00a9c2df16d".
+
+      <http://data.lblod.info/id/bestuurseenheden/bfc36f138e0c7d11757eb321d034cfbffce281679eae93c2bc5df1048aa05789> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "bfc36f138e0c7d11757eb321d034cfbffce281679eae93c2bc5df1048aa05789";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/ea446861-2c51-45fa-afd3-4e4a37b71562>;
+        skos:prefLabel  "HVZ Vlaamse Ardennen";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/d8a7c8aa-382a-495c-8b29-7d51c88c9b28>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/5426473d-b36f-4dab-8265-8f51444ae053> .
+    
+
+      <http://data.lblod.info/id/identificatoren/12fa3e43-58f8-49fd-8457-81ea2364afa6> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "12fa3e43-58f8-49fd-8457-81ea2364afa6";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/a2b70cba-bdcd-4ffe-9c24-d910a47ae93f>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/a2b70cba-bdcd-4ffe-9c24-d910a47ae93f> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "a2b70cba-bdcd-4ffe-9c24-d910a47ae93f";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1188".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/62d34221-d5fc-41ae-a656-fad074b0c974> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "62d34221-d5fc-41ae-a656-fad074b0c974";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/48bfd9ad-fb54-4105-a096-f0dc48cca6c0>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/5f429ec4-43c3-4f3a-a0ad-0b75e09eedc7>,
+                        <http://data.lblod.info/id/contact-punten/c3bebd45-7660-4bad-af60-ba6399ccdb33>.
+
+      <http://data.lblod.info/id/contact-punten/5f429ec4-43c3-4f3a-a0ad-0b75e09eedc7> a <http://schema.org/ContactPoint>;
+        mu:uuid "5f429ec4-43c3-4f3a-a0ad-0b75e09eedc7";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/c3bebd45-7660-4bad-af60-ba6399ccdb33> a <http://schema.org/ContactPoint>;
+        mu:uuid "c3bebd45-7660-4bad-af60-ba6399ccdb33";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/48bfd9ad-fb54-4105-a096-f0dc48cca6c0> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "48bfd9ad-fb54-4105-a096-f0dc48cca6c0".
+
+      <http://data.lblod.info/id/bestuurseenheden/c1fcc0a6c6132cb34dff9ed6e6f361d1587c211ac8ec1ddef409510bf68b724b> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "c1fcc0a6c6132cb34dff9ed6e6f361d1587c211ac8ec1ddef409510bf68b724b";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/ea446861-2c51-45fa-afd3-4e4a37b71562>;
+        skos:prefLabel  "HVZ Taxandria";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/12fa3e43-58f8-49fd-8457-81ea2364afa6>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/62d34221-d5fc-41ae-a656-fad074b0c974> .
+    
+
+      <http://data.lblod.info/id/identificatoren/4c4d950f-de11-4c75-9d73-03fdeee26e37> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "4c4d950f-de11-4c75-9d73-03fdeee26e37";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/c83d1668-2e17-4ec1-9299-a6d9e465c019>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/c83d1668-2e17-4ec1-9299-a6d9e465c019> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "c83d1668-2e17-4ec1-9299-a6d9e465c019";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1189".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/10c3230b-2b1d-4df1-8e69-3404a851894d> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "10c3230b-2b1d-4df1-8e69-3404a851894d";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/91d4a707-8d66-469a-8579-a0ad19570fd9>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/ec65d4ca-563a-47c5-a86b-9119ea1e8fe1>,
+                        <http://data.lblod.info/id/contact-punten/50f5b134-9cd2-42d7-82b8-b85130219bf3>.
+
+      <http://data.lblod.info/id/contact-punten/ec65d4ca-563a-47c5-a86b-9119ea1e8fe1> a <http://schema.org/ContactPoint>;
+        mu:uuid "ec65d4ca-563a-47c5-a86b-9119ea1e8fe1";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/50f5b134-9cd2-42d7-82b8-b85130219bf3> a <http://schema.org/ContactPoint>;
+        mu:uuid "50f5b134-9cd2-42d7-82b8-b85130219bf3";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/91d4a707-8d66-469a-8579-a0ad19570fd9> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "91d4a707-8d66-469a-8579-a0ad19570fd9".
+
+      <http://data.lblod.info/id/bestuurseenheden/c74e71fb4ccf2e143731873471a890b87076a9b1dcc470b937b339d7c191fce4> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "c74e71fb4ccf2e143731873471a890b87076a9b1dcc470b937b339d7c191fce4";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/ea446861-2c51-45fa-afd3-4e4a37b71562>;
+        skos:prefLabel  "HVZ Brandweer Westhoek";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/4c4d950f-de11-4c75-9d73-03fdeee26e37>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/10c3230b-2b1d-4df1-8e69-3404a851894d> .
+    
+
+      <http://data.lblod.info/id/identificatoren/94b45ddb-c709-4809-8278-1835e4308715> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "94b45ddb-c709-4809-8278-1835e4308715";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/0851b7cb-7672-4e78-875e-114908482c81>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/0851b7cb-7672-4e78-875e-114908482c81> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "0851b7cb-7672-4e78-875e-114908482c81";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1190".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/8c817c8f-f05b-42fe-9361-6eac5588d543> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "8c817c8f-f05b-42fe-9361-6eac5588d543";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/f69838e2-7814-4bf7-b795-9ba339a58c66>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/43c5edee-9d76-40f4-8df7-c4fb4512c298>,
+                        <http://data.lblod.info/id/contact-punten/876d0254-2774-48d9-8dcc-adccd70df472>.
+
+      <http://data.lblod.info/id/contact-punten/43c5edee-9d76-40f4-8df7-c4fb4512c298> a <http://schema.org/ContactPoint>;
+        mu:uuid "43c5edee-9d76-40f4-8df7-c4fb4512c298";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/876d0254-2774-48d9-8dcc-adccd70df472> a <http://schema.org/ContactPoint>;
+        mu:uuid "876d0254-2774-48d9-8dcc-adccd70df472";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/f69838e2-7814-4bf7-b795-9ba339a58c66> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "f69838e2-7814-4bf7-b795-9ba339a58c66".
+
+      <http://data.lblod.info/id/bestuurseenheden/c8d171d9735146131fcb9e2ad7f4e271585b0bf68f7a43d8873b6848576d13a1> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "c8d171d9735146131fcb9e2ad7f4e271585b0bf68f7a43d8873b6848576d13a1";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/ea446861-2c51-45fa-afd3-4e4a37b71562>;
+        skos:prefLabel  "HVZ Brandweer Zone Antwerpen";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/94b45ddb-c709-4809-8278-1835e4308715>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/8c817c8f-f05b-42fe-9361-6eac5588d543> .
+    
+
+      <http://data.lblod.info/id/identificatoren/edb88179-996c-41b2-8ac9-c6f640064197> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "edb88179-996c-41b2-8ac9-c6f640064197";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/a867d5c1-e9c1-4870-bcd4-99cf26d7c9e4>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/a867d5c1-e9c1-4870-bcd4-99cf26d7c9e4> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "a867d5c1-e9c1-4870-bcd4-99cf26d7c9e4";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1191".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/b95232ef-8167-4883-9bc2-4fb534b10fb7> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "b95232ef-8167-4883-9bc2-4fb534b10fb7";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/66ddaf4e-3262-4fe0-91a7-0bd25dda42a3>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/0553aa51-480f-4297-944e-bf65e67b422e>,
+                        <http://data.lblod.info/id/contact-punten/07715151-8f94-496d-86a4-f10e1b9666e3>.
+
+      <http://data.lblod.info/id/contact-punten/0553aa51-480f-4297-944e-bf65e67b422e> a <http://schema.org/ContactPoint>;
+        mu:uuid "0553aa51-480f-4297-944e-bf65e67b422e";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/07715151-8f94-496d-86a4-f10e1b9666e3> a <http://schema.org/ContactPoint>;
+        mu:uuid "07715151-8f94-496d-86a4-f10e1b9666e3";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/66ddaf4e-3262-4fe0-91a7-0bd25dda42a3> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "66ddaf4e-3262-4fe0-91a7-0bd25dda42a3".
+
+      <http://data.lblod.info/id/bestuurseenheden/db299add14cc24e7a99ce4eb51015f32925690fb9816962e500f3341842ef6fa> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "db299add14cc24e7a99ce4eb51015f32925690fb9816962e500f3341842ef6fa";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/ea446861-2c51-45fa-afd3-4e4a37b71562>;
+        skos:prefLabel  "HVZ Oost";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/edb88179-996c-41b2-8ac9-c6f640064197>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/b95232ef-8167-4883-9bc2-4fb534b10fb7> .
+    
+
+      <http://data.lblod.info/id/identificatoren/7b4bae0d-9132-4e71-9007-24cc6ccbfd48> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "7b4bae0d-9132-4e71-9007-24cc6ccbfd48";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/bb143a21-d854-40a1-b466-08231cc0c523>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/bb143a21-d854-40a1-b466-08231cc0c523> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "bb143a21-d854-40a1-b466-08231cc0c523";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1192".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/6a269754-2405-4939-8c79-cea6b81dcb4b> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "6a269754-2405-4939-8c79-cea6b81dcb4b";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/78bc12ba-62a3-4c43-ab32-487557a58cb1>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/cd233ffa-5ca0-4faf-8391-75550635a394>,
+                        <http://data.lblod.info/id/contact-punten/179f829e-9858-458d-93d0-7dee21f28848>.
+
+      <http://data.lblod.info/id/contact-punten/cd233ffa-5ca0-4faf-8391-75550635a394> a <http://schema.org/ContactPoint>;
+        mu:uuid "cd233ffa-5ca0-4faf-8391-75550635a394";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/179f829e-9858-458d-93d0-7dee21f28848> a <http://schema.org/ContactPoint>;
+        mu:uuid "179f829e-9858-458d-93d0-7dee21f28848";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/78bc12ba-62a3-4c43-ab32-487557a58cb1> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "78bc12ba-62a3-4c43-ab32-487557a58cb1".
+
+      <http://data.lblod.info/id/bestuurseenheden/db5adb1e2e7ad0e33725b83edda44f9b4638e328a1534a1b4eef2683d337975a> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "db5adb1e2e7ad0e33725b83edda44f9b4638e328a1534a1b4eef2683d337975a";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/ea446861-2c51-45fa-afd3-4e4a37b71562>;
+        skos:prefLabel  "HVZ Zuid-Oost";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/7b4bae0d-9132-4e71-9007-24cc6ccbfd48>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/6a269754-2405-4939-8c79-cea6b81dcb4b> .
+    
+
+      <http://data.lblod.info/id/identificatoren/24e359d1-b760-43a4-8cdb-c63dadc0eba1> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "24e359d1-b760-43a4-8cdb-c63dadc0eba1";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/2ba89f74-52e4-41b2-aebc-402ddecac449>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/2ba89f74-52e4-41b2-aebc-402ddecac449> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "2ba89f74-52e4-41b2-aebc-402ddecac449";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1193".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/7d4947ed-7edc-47df-84c7-7895df113224> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "7d4947ed-7edc-47df-84c7-7895df113224";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/b373defe-6ba1-4ff0-8ba4-d73bca4f08d7>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/03e8b8b6-8b81-484c-a0ac-9e3ce6338c74>,
+                        <http://data.lblod.info/id/contact-punten/d2a67d1c-7022-4dab-96d0-32081bebc7ab>.
+
+      <http://data.lblod.info/id/contact-punten/03e8b8b6-8b81-484c-a0ac-9e3ce6338c74> a <http://schema.org/ContactPoint>;
+        mu:uuid "03e8b8b6-8b81-484c-a0ac-9e3ce6338c74";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/d2a67d1c-7022-4dab-96d0-32081bebc7ab> a <http://schema.org/ContactPoint>;
+        mu:uuid "d2a67d1c-7022-4dab-96d0-32081bebc7ab";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/b373defe-6ba1-4ff0-8ba4-d73bca4f08d7> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "b373defe-6ba1-4ff0-8ba4-d73bca4f08d7".
+
+      <http://data.lblod.info/id/bestuurseenheden/e8bd746e2dc3c5a72fe4fb3da0c92803b0728150bdd66e860d6218bc83098941> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "e8bd746e2dc3c5a72fe4fb3da0c92803b0728150bdd66e860d6218bc83098941";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/ea446861-2c51-45fa-afd3-4e4a37b71562>;
+        skos:prefLabel  "HVZ Waasland";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/24e359d1-b760-43a4-8cdb-c63dadc0eba1>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/7d4947ed-7edc-47df-84c7-7895df113224> .
+    
+
+      <http://data.lblod.info/id/identificatoren/ffe8cd96-d6dc-41c8-a783-4f7e1a9b8d30> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "ffe8cd96-d6dc-41c8-a783-4f7e1a9b8d30";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/2b16b79b-6698-436e-ac32-683196c555fb>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/2b16b79b-6698-436e-ac32-683196c555fb> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "2b16b79b-6698-436e-ac32-683196c555fb";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1176".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/5b766403-b57d-48f4-b3de-13cd35cd2550> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "5b766403-b57d-48f4-b3de-13cd35cd2550";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/8f2715e6-32f1-44a5-a18d-0cece8e60475>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/cbae210a-75f5-45ab-857b-59a7c418bdbb>,
+                        <http://data.lblod.info/id/contact-punten/c5a66b99-ca91-4ee6-8221-1e168a859e96>.
+
+      <http://data.lblod.info/id/contact-punten/cbae210a-75f5-45ab-857b-59a7c418bdbb> a <http://schema.org/ContactPoint>;
+        mu:uuid "cbae210a-75f5-45ab-857b-59a7c418bdbb";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/c5a66b99-ca91-4ee6-8221-1e168a859e96> a <http://schema.org/ContactPoint>;
+        mu:uuid "c5a66b99-ca91-4ee6-8221-1e168a859e96";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/8f2715e6-32f1-44a5-a18d-0cece8e60475> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "8f2715e6-32f1-44a5-a18d-0cece8e60475".
+
+      <http://data.lblod.info/id/bestuurseenheden/2c1fc56876479e83c7b144e98b84174dd10087ae59621204b9d6701d968e8aba> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "2c1fc56876479e83c7b144e98b84174dd10087ae59621204b9d6701d968e8aba";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/ea446861-2c51-45fa-afd3-4e4a37b71562>;
+        skos:prefLabel  "HVZ Zone 1";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/ffe8cd96-d6dc-41c8-a783-4f7e1a9b8d30>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/5b766403-b57d-48f4-b3de-13cd35cd2550> .
+    
+
+      <http://data.lblod.info/id/identificatoren/6957c4d1-ffd3-4b63-8c7f-3dc4eb714b03> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "6957c4d1-ffd3-4b63-8c7f-3dc4eb714b03";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/a4a52282-2ade-476f-9b78-c09221bcfc7c>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/a4a52282-2ade-476f-9b78-c09221bcfc7c> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "a4a52282-2ade-476f-9b78-c09221bcfc7c";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1194".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/be127b96-7278-43b7-a127-5cc7554a94d4> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "be127b96-7278-43b7-a127-5cc7554a94d4";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/1ffdc477-f954-4c3b-8fc2-3a3b56503a9e>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/28dce85a-5a55-4da3-bbde-0a2e143b18af>,
+                        <http://data.lblod.info/id/contact-punten/149740c4-fcb9-43a5-8cf7-c4aca2626fcc>.
+
+      <http://data.lblod.info/id/contact-punten/28dce85a-5a55-4da3-bbde-0a2e143b18af> a <http://schema.org/ContactPoint>;
+        mu:uuid "28dce85a-5a55-4da3-bbde-0a2e143b18af";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/149740c4-fcb9-43a5-8cf7-c4aca2626fcc> a <http://schema.org/ContactPoint>;
+        mu:uuid "149740c4-fcb9-43a5-8cf7-c4aca2626fcc";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/1ffdc477-f954-4c3b-8fc2-3a3b56503a9e> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "1ffdc477-f954-4c3b-8fc2-3a3b56503a9e".
+
+      <http://data.lblod.info/id/bestuurseenheden/e5f3c3f23f6791de122a5e6f1af83543651d272eba40e138c2fdf91ec05f8a40> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "e5f3c3f23f6791de122a5e6f1af83543651d272eba40e138c2fdf91ec05f8a40";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Aalst: Aalst";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/6957c4d1-ffd3-4b63-8c7f-3dc4eb714b03>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/be127b96-7278-43b7-a127-5cc7554a94d4> .
+    
+
+      <http://data.lblod.info/id/identificatoren/034ba63b-53f5-4e01-99fa-aeacd40e425b> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "034ba63b-53f5-4e01-99fa-aeacd40e425b";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/2c660bd3-b2f9-475f-9d8d-b87c7b42a35d>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/2c660bd3-b2f9-475f-9d8d-b87c7b42a35d> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "2c660bd3-b2f9-475f-9d8d-b87c7b42a35d";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1195".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/722f4e54-4e86-42a5-94df-459ceeb23165> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "722f4e54-4e86-42a5-94df-459ceeb23165";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/a16a6e38-6501-451f-af35-175b64b11312>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/49e38289-aedb-477a-ba5a-b3bd05871c64>,
+                        <http://data.lblod.info/id/contact-punten/027da17e-afdc-4f9b-81f6-9535727aa88a>.
+
+      <http://data.lblod.info/id/contact-punten/49e38289-aedb-477a-ba5a-b3bd05871c64> a <http://schema.org/ContactPoint>;
+        mu:uuid "49e38289-aedb-477a-ba5a-b3bd05871c64";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/027da17e-afdc-4f9b-81f6-9535727aa88a> a <http://schema.org/ContactPoint>;
+        mu:uuid "027da17e-afdc-4f9b-81f6-9535727aa88a";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/a16a6e38-6501-451f-af35-175b64b11312> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "a16a6e38-6501-451f-af35-175b64b11312".
+
+      <http://data.lblod.info/id/bestuurseenheden/e06ce64825e386178b350aa6b2fa869c70ad39aa99ddb3ca2a73d6b103e91161> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "e06ce64825e386178b350aa6b2fa869c70ad39aa99ddb3ca2a73d6b103e91161";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Aalter: Aalter";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/034ba63b-53f5-4e01-99fa-aeacd40e425b>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/722f4e54-4e86-42a5-94df-459ceeb23165> .
+    
+
+      <http://data.lblod.info/id/identificatoren/b235dcdd-c059-4ea1-927e-6eafd4ec52c8> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "b235dcdd-c059-4ea1-927e-6eafd4ec52c8";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/dbe5efb1-3f85-47c4-a9bd-4eab0fc5e8ce>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/dbe5efb1-3f85-47c4-a9bd-4eab0fc5e8ce> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "dbe5efb1-3f85-47c4-a9bd-4eab0fc5e8ce";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1196".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/2e6debc8-7d13-42ff-bc2e-df0a2cc0ce69> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "2e6debc8-7d13-42ff-bc2e-df0a2cc0ce69";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/735617dc-a378-4fa3-bf10-ed7816550a0e>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/89376aa7-14df-4d22-9346-8598dd549662>,
+                        <http://data.lblod.info/id/contact-punten/97c0a991-37af-49b6-bb9d-036555b80755>.
+
+      <http://data.lblod.info/id/contact-punten/89376aa7-14df-4d22-9346-8598dd549662> a <http://schema.org/ContactPoint>;
+        mu:uuid "89376aa7-14df-4d22-9346-8598dd549662";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/97c0a991-37af-49b6-bb9d-036555b80755> a <http://schema.org/ContactPoint>;
+        mu:uuid "97c0a991-37af-49b6-bb9d-036555b80755";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/735617dc-a378-4fa3-bf10-ed7816550a0e> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "735617dc-a378-4fa3-bf10-ed7816550a0e".
+
+      <http://data.lblod.info/id/bestuurseenheden/254bbfb6c31a668446c339c0996864d23c3fe129a5aa05e274b463cbbb4a4bc2> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "254bbfb6c31a668446c339c0996864d23c3fe129a5aa05e274b463cbbb4a4bc2";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Aarschot: Aarschot";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/b235dcdd-c059-4ea1-927e-6eafd4ec52c8>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/2e6debc8-7d13-42ff-bc2e-df0a2cc0ce69> .
+    
+
+      <http://data.lblod.info/id/identificatoren/86bc6a1c-fddb-4fcd-8e36-c1eb40a69fbc> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "86bc6a1c-fddb-4fcd-8e36-c1eb40a69fbc";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/f57bffba-ed10-4079-a68a-58fe376820f5>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/f57bffba-ed10-4079-a68a-58fe376820f5> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "f57bffba-ed10-4079-a68a-58fe376820f5";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1197".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/22e3b7b7-2d30-4cc7-9ed8-4656dba4716a> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "22e3b7b7-2d30-4cc7-9ed8-4656dba4716a";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/442f7e0a-e9f1-425c-a7f9-b2e2847fec96>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/043dc3d0-4121-463f-85d9-b63071d20f6d>,
+                        <http://data.lblod.info/id/contact-punten/777cca85-07b9-45dc-9965-243684bf8a18>.
+
+      <http://data.lblod.info/id/contact-punten/043dc3d0-4121-463f-85d9-b63071d20f6d> a <http://schema.org/ContactPoint>;
+        mu:uuid "043dc3d0-4121-463f-85d9-b63071d20f6d";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/777cca85-07b9-45dc-9965-243684bf8a18> a <http://schema.org/ContactPoint>;
+        mu:uuid "777cca85-07b9-45dc-9965-243684bf8a18";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/442f7e0a-e9f1-425c-a7f9-b2e2847fec96> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "442f7e0a-e9f1-425c-a7f9-b2e2847fec96".
+
+      <http://data.lblod.info/id/bestuurseenheden/bb9a9db9c00189c27a851f0b772772675cba77e2463ab734477d00e4294db5df> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "bb9a9db9c00189c27a851f0b772772675cba77e2463ab734477d00e4294db5df";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ HEKLA: Hove, Edegem, Kontich, Lint en Aartselaar";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/86bc6a1c-fddb-4fcd-8e36-c1eb40a69fbc>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/22e3b7b7-2d30-4cc7-9ed8-4656dba4716a> .
+    
+
+      <http://data.lblod.info/id/identificatoren/cd1de862-eb7d-478f-b069-013861a56b1e> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "cd1de862-eb7d-478f-b069-013861a56b1e";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/90e22a1f-42f6-45da-8481-c1940456908e>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/90e22a1f-42f6-45da-8481-c1940456908e> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "90e22a1f-42f6-45da-8481-c1940456908e";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1198".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/a633593d-2a59-459b-8062-17e3f3b9119e> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "a633593d-2a59-459b-8062-17e3f3b9119e";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/6024ecf6-7ed2-44ce-8ec5-25ae02ac5aa2>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/79bdc07a-5a7c-4beb-931c-86b1704e104c>,
+                        <http://data.lblod.info/id/contact-punten/d033950b-f15a-48f1-8c78-d1553131e7e6>.
+
+      <http://data.lblod.info/id/contact-punten/79bdc07a-5a7c-4beb-931c-86b1704e104c> a <http://schema.org/ContactPoint>;
+        mu:uuid "79bdc07a-5a7c-4beb-931c-86b1704e104c";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/d033950b-f15a-48f1-8c78-d1553131e7e6> a <http://schema.org/ContactPoint>;
+        mu:uuid "d033950b-f15a-48f1-8c78-d1553131e7e6";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/6024ecf6-7ed2-44ce-8ec5-25ae02ac5aa2> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "6024ecf6-7ed2-44ce-8ec5-25ae02ac5aa2".
+
+      <http://data.lblod.info/id/bestuurseenheden/0610b306e95fae751dc07050565e987f31ba06420863bc44616b2e05452d8822> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "0610b306e95fae751dc07050565e987f31ba06420863bc44616b2e05452d8822";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ TARL: Ternat, Affligem, Roosdaal en Liedekerke";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/cd1de862-eb7d-478f-b069-013861a56b1e>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/a633593d-2a59-459b-8062-17e3f3b9119e> .
+    
+
+      <http://data.lblod.info/id/identificatoren/db2c2a82-4f95-4bd5-af27-4780054dcd64> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "db2c2a82-4f95-4bd5-af27-4780054dcd64";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/4ed06086-cdff-40dd-88ec-1efa6570862b>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/4ed06086-cdff-40dd-88ec-1efa6570862b> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "4ed06086-cdff-40dd-88ec-1efa6570862b";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1199".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/892a1afa-59c1-4147-a3cd-3d5094ae1150> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "892a1afa-59c1-4147-a3cd-3d5094ae1150";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/6be8a056-22be-4262-90d1-3c19f30be4f6>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/23b5bad1-aafe-4809-9a60-037f63df394c>,
+                        <http://data.lblod.info/id/contact-punten/30ebe412-c19e-4d62-9d0f-23a64dfc4f33>.
+
+      <http://data.lblod.info/id/contact-punten/23b5bad1-aafe-4809-9a60-037f63df394c> a <http://schema.org/ContactPoint>;
+        mu:uuid "23b5bad1-aafe-4809-9a60-037f63df394c";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/30ebe412-c19e-4d62-9d0f-23a64dfc4f33> a <http://schema.org/ContactPoint>;
+        mu:uuid "30ebe412-c19e-4d62-9d0f-23a64dfc4f33";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/6be8a056-22be-4262-90d1-3c19f30be4f6> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "6be8a056-22be-4262-90d1-3c19f30be4f6".
+
+      <http://data.lblod.info/id/bestuurseenheden/150440a8bb763d6f53d24ca1c6f1460cb5817c8a261fd90e74aadac3292c3efe> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "150440a8bb763d6f53d24ca1c6f1460cb5817c8a261fd90e74aadac3292c3efe";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Kanton Borgloon: Alken, Borgloon, Heers, Kortessem en Wellen";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/db2c2a82-4f95-4bd5-af27-4780054dcd64>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/892a1afa-59c1-4147-a3cd-3d5094ae1150> .
+    
+
+      <http://data.lblod.info/id/identificatoren/5b701ff8-b5b5-4c9e-83c9-2f61e45a7ae2> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "5b701ff8-b5b5-4c9e-83c9-2f61e45a7ae2";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/78d28fff-90f3-4763-bac4-68b148df2f10>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/78d28fff-90f3-4763-bac4-68b148df2f10> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "78d28fff-90f3-4763-bac4-68b148df2f10";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1200".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/f1e226e2-29fc-4da5-b468-19c66a77a5d8> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "f1e226e2-29fc-4da5-b468-19c66a77a5d8";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/2db3cb7c-f850-4884-b8f1-e92ef2a7632f>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/072e726a-13a3-4c87-9787-b893f686a055>,
+                        <http://data.lblod.info/id/contact-punten/ba22d4e3-9988-4581-80ec-6951178f7028>.
+
+      <http://data.lblod.info/id/contact-punten/072e726a-13a3-4c87-9787-b893f686a055> a <http://schema.org/ContactPoint>;
+        mu:uuid "072e726a-13a3-4c87-9787-b893f686a055";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/ba22d4e3-9988-4581-80ec-6951178f7028> a <http://schema.org/ContactPoint>;
+        mu:uuid "ba22d4e3-9988-4581-80ec-6951178f7028";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/2db3cb7c-f850-4884-b8f1-e92ef2a7632f> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "2db3cb7c-f850-4884-b8f1-e92ef2a7632f".
+
+      <http://data.lblod.info/id/bestuurseenheden/a62fddadcb0a8fb878c3edbdc71a4eb1e6c419b212d41a8bd589fb1a370eb112> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "a62fddadcb0a8fb878c3edbdc71a4eb1e6c419b212d41a8bd589fb1a370eb112";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Spoorkin: Alveringem, Lo-Reninge en Veurne";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/5b701ff8-b5b5-4c9e-83c9-2f61e45a7ae2>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/f1e226e2-29fc-4da5-b468-19c66a77a5d8> .
+    
+
+      <http://data.lblod.info/id/identificatoren/e0ac7fe2-1ae1-435f-ac40-747480b2452b> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "e0ac7fe2-1ae1-435f-ac40-747480b2452b";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/9488aab9-d190-4f9d-8c89-4bf2d13ae9ce>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/9488aab9-d190-4f9d-8c89-4bf2d13ae9ce> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "9488aab9-d190-4f9d-8c89-4bf2d13ae9ce";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1202".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/a10644d5-94bb-4f43-a728-bfcc1cad070f> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "a10644d5-94bb-4f43-a728-bfcc1cad070f";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/6241c904-a3f9-4839-b91e-34990f1ec5ee>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/2c38ca5c-57d0-4457-9406-38d585ec3af4>,
+                        <http://data.lblod.info/id/contact-punten/bdb4c336-a8b5-4a9b-a2d6-ac56db322362>.
+
+      <http://data.lblod.info/id/contact-punten/2c38ca5c-57d0-4457-9406-38d585ec3af4> a <http://schema.org/ContactPoint>;
+        mu:uuid "2c38ca5c-57d0-4457-9406-38d585ec3af4";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/bdb4c336-a8b5-4a9b-a2d6-ac56db322362> a <http://schema.org/ContactPoint>;
+        mu:uuid "bdb4c336-a8b5-4a9b-a2d6-ac56db322362";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/6241c904-a3f9-4839-b91e-34990f1ec5ee> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "6241c904-a3f9-4839-b91e-34990f1ec5ee".
+
+      <http://data.lblod.info/id/bestuurseenheden/097191c539cc02e6044671221f3ea0a8428c7fbc8dbdd5f38ee8f02ca51c6082> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "097191c539cc02e6044671221f3ea0a8428c7fbc8dbdd5f38ee8f02ca51c6082";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Antwerpen: Antwerpen";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/e0ac7fe2-1ae1-435f-ac40-747480b2452b>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/a10644d5-94bb-4f43-a728-bfcc1cad070f> .
+    
+
+      <http://data.lblod.info/id/identificatoren/c64378f3-19bf-42de-be9d-e5fb0da91e6e> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "c64378f3-19bf-42de-be9d-e5fb0da91e6e";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/04a837ef-e027-44dd-8f17-cac822768a4a>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/04a837ef-e027-44dd-8f17-cac822768a4a> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "04a837ef-e027-44dd-8f17-cac822768a4a";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1203".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/d522bc33-8bc2-4501-91a6-4bb9d4fc0ef2> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "d522bc33-8bc2-4501-91a6-4bb9d4fc0ef2";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/c1beec57-dddf-4c64-860e-e610e85c9c53>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/e487843d-f702-4433-a0e4-989d781641c7>,
+                        <http://data.lblod.info/id/contact-punten/3544cee5-b765-43e9-a6d9-095f7ae3a605>.
+
+      <http://data.lblod.info/id/contact-punten/e487843d-f702-4433-a0e4-989d781641c7> a <http://schema.org/ContactPoint>;
+        mu:uuid "e487843d-f702-4433-a0e4-989d781641c7";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/3544cee5-b765-43e9-a6d9-095f7ae3a605> a <http://schema.org/ContactPoint>;
+        mu:uuid "3544cee5-b765-43e9-a6d9-095f7ae3a605";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/c1beec57-dddf-4c64-860e-e610e85c9c53> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "c1beec57-dddf-4c64-860e-e610e85c9c53".
+
+      <http://data.lblod.info/id/bestuurseenheden/7b6bbae823b20191525038cd52089d22128163fb3c7f851ce56149938628d941> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "7b6bbae823b20191525038cd52089d22128163fb3c7f851ce56149938628d941";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ MIRA: Anzegem, Avelgem, Spiere-Helkijn, Waregem en Zwevegem";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/c64378f3-19bf-42de-be9d-e5fb0da91e6e>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/d522bc33-8bc2-4501-91a6-4bb9d4fc0ef2> .
+    
+
+      <http://data.lblod.info/id/identificatoren/eb56613a-e4c5-41ab-8959-b9e6e6aae76b> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "eb56613a-e4c5-41ab-8959-b9e6e6aae76b";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/457736a7-5fbd-4063-aa5f-16504f691d2c>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/457736a7-5fbd-4063-aa5f-16504f691d2c> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "457736a7-5fbd-4063-aa5f-16504f691d2c";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1204".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/3a7bf705-6a52-4c2f-8157-d2e880a9136e> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "3a7bf705-6a52-4c2f-8157-d2e880a9136e";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/2dad01f4-3441-476f-969c-93d7c79896d6>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/146a64ef-0382-40b5-b293-5a46289a17fd>,
+                        <http://data.lblod.info/id/contact-punten/c9e616b4-217c-4d28-a4a9-9c7a6fafa0b6>.
+
+      <http://data.lblod.info/id/contact-punten/146a64ef-0382-40b5-b293-5a46289a17fd> a <http://schema.org/ContactPoint>;
+        mu:uuid "146a64ef-0382-40b5-b293-5a46289a17fd";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/c9e616b4-217c-4d28-a4a9-9c7a6fafa0b6> a <http://schema.org/ContactPoint>;
+        mu:uuid "c9e616b4-217c-4d28-a4a9-9c7a6fafa0b6";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/2dad01f4-3441-476f-969c-93d7c79896d6> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "2dad01f4-3441-476f-969c-93d7c79896d6".
+
+      <http://data.lblod.info/id/bestuurseenheden/39e3e46f7cf031133152e763eaa26cab3df81f842f9912a25c69c445f0c428b8> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "39e3e46f7cf031133152e763eaa26cab3df81f842f9912a25c69c445f0c428b8";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Regio Tielt: Ardooie, Lichtervelde, Pittem, Ruiselede, Tielt en Wingene";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/eb56613a-e4c5-41ab-8959-b9e6e6aae76b>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/3a7bf705-6a52-4c2f-8157-d2e880a9136e> .
+    
+
+      <http://data.lblod.info/id/identificatoren/b691109d-216b-428d-88db-ec7c83c6bda5> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "b691109d-216b-428d-88db-ec7c83c6bda5";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/6bdcb445-d42d-4e53-b6c0-1993cd8b58f7>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/6bdcb445-d42d-4e53-b6c0-1993cd8b58f7> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "6bdcb445-d42d-4e53-b6c0-1993cd8b58f7";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1205".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/0c258797-abd8-448f-8f1a-68f130d67644> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "0c258797-abd8-448f-8f1a-68f130d67644";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/8b484468-87eb-4d6b-bbdb-9cc3718c05d2>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/7925ef4d-52f6-40f6-9245-cc0bddadb22e>,
+                        <http://data.lblod.info/id/contact-punten/ff390517-0ec4-441c-ab02-36675be73651>.
+
+      <http://data.lblod.info/id/contact-punten/7925ef4d-52f6-40f6-9245-cc0bddadb22e> a <http://schema.org/ContactPoint>;
+        mu:uuid "7925ef4d-52f6-40f6-9245-cc0bddadb22e";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/ff390517-0ec4-441c-ab02-36675be73651> a <http://schema.org/ContactPoint>;
+        mu:uuid "ff390517-0ec4-441c-ab02-36675be73651";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/8b484468-87eb-4d6b-bbdb-9cc3718c05d2> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "8b484468-87eb-4d6b-bbdb-9cc3718c05d2".
+
+      <http://data.lblod.info/id/bestuurseenheden/306340a51c1504e59f1c3b85c1ba1b62de8c70cb94d3998f27819761bcee5a98> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "306340a51c1504e59f1c3b85c1ba1b62de8c70cb94d3998f27819761bcee5a98";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Kempen Noord-Oost: Arendonk, Ravels en Retie";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/b691109d-216b-428d-88db-ec7c83c6bda5>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/0c258797-abd8-448f-8f1a-68f130d67644> .
+    
+
+      <http://data.lblod.info/id/identificatoren/f781d062-894a-42aa-86ed-cd829ed23a84> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "f781d062-894a-42aa-86ed-cd829ed23a84";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/60b07655-08a3-4207-91f5-1cfd6211add6>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/60b07655-08a3-4207-91f5-1cfd6211add6> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "60b07655-08a3-4207-91f5-1cfd6211add6";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1206".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/47df5d37-1194-48b0-89cd-1250c3ec800d> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "47df5d37-1194-48b0-89cd-1250c3ec800d";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/d03385c3-2e0c-4493-8d42-29d83baf7591>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/73a21303-3f24-4b52-8e8a-921d432203a9>,
+                        <http://data.lblod.info/id/contact-punten/b28fb4b7-d567-475d-ae59-f078ccf7e7af>.
+
+      <http://data.lblod.info/id/contact-punten/73a21303-3f24-4b52-8e8a-921d432203a9> a <http://schema.org/ContactPoint>;
+        mu:uuid "73a21303-3f24-4b52-8e8a-921d432203a9";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/b28fb4b7-d567-475d-ae59-f078ccf7e7af> a <http://schema.org/ContactPoint>;
+        mu:uuid "b28fb4b7-d567-475d-ae59-f078ccf7e7af";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/d03385c3-2e0c-4493-8d42-29d83baf7591> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "d03385c3-2e0c-4493-8d42-29d83baf7591".
+
+      <http://data.lblod.info/id/bestuurseenheden/90688b32e0808b6ebbb7b36030526750236527e8019414449065f57ea384ce71> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "90688b32e0808b6ebbb7b36030526750236527e8019414449065f57ea384ce71";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ AMOW: Asse, Merchtem, Opwijk en Wemmel";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/f781d062-894a-42aa-86ed-cd829ed23a84>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/47df5d37-1194-48b0-89cd-1250c3ec800d> .
+    
+
+      <http://data.lblod.info/id/identificatoren/42a2ab88-af4f-4f79-91a3-79d44c5b37b9> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "42a2ab88-af4f-4f79-91a3-79d44c5b37b9";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/664f6fcc-b15a-4e92-b950-1433e8184133>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/664f6fcc-b15a-4e92-b950-1433e8184133> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "664f6fcc-b15a-4e92-b950-1433e8184133";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1207".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/15681c87-bf24-452d-9a23-af4aa91488e6> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "15681c87-bf24-452d-9a23-af4aa91488e6";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/dfd50b57-662b-414b-b706-4c4ce6123b34>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/c36fa71f-77c6-4218-9023-1a6ac2afc7b0>,
+                        <http://data.lblod.info/id/contact-punten/903700ef-0607-4de2-b43f-737cc503546f>.
+
+      <http://data.lblod.info/id/contact-punten/c36fa71f-77c6-4218-9023-1a6ac2afc7b0> a <http://schema.org/ContactPoint>;
+        mu:uuid "c36fa71f-77c6-4218-9023-1a6ac2afc7b0";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/903700ef-0607-4de2-b43f-737cc503546f> a <http://schema.org/ContactPoint>;
+        mu:uuid "903700ef-0607-4de2-b43f-737cc503546f";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/dfd50b57-662b-414b-b706-4c4ce6123b34> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "dfd50b57-662b-414b-b706-4c4ce6123b34".
+
+      <http://data.lblod.info/id/bestuurseenheden/96d87c4956c98414938dd5fceeb05f65feebf21fbe5918e6d23bc2b58a7fc716> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "96d87c4956c98414938dd5fceeb05f65feebf21fbe5918e6d23bc2b58a7fc716";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Assenede/Evergem: Assenede en Evergem";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/42a2ab88-af4f-4f79-91a3-79d44c5b37b9>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/15681c87-bf24-452d-9a23-af4aa91488e6> .
+    
+
+      <http://data.lblod.info/id/identificatoren/b5ecdf3c-7f8e-42f0-9b72-4272ac2f3ccb> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "b5ecdf3c-7f8e-42f0-9b72-4272ac2f3ccb";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/1a74303c-25f4-4748-9fb2-1b87e67bdeb4>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/1a74303c-25f4-4748-9fb2-1b87e67bdeb4> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "1a74303c-25f4-4748-9fb2-1b87e67bdeb4";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1208".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/d4a2568b-f1de-4113-a2dc-34ab9227d29b> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "d4a2568b-f1de-4113-a2dc-34ab9227d29b";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/6f484ab6-ea6f-426e-89ae-ef751460a436>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/0822d7e6-a326-48fc-acc3-b82935211f59>,
+                        <http://data.lblod.info/id/contact-punten/db6434f6-e149-41da-b3a4-372a717cff35>.
+
+      <http://data.lblod.info/id/contact-punten/0822d7e6-a326-48fc-acc3-b82935211f59> a <http://schema.org/ContactPoint>;
+        mu:uuid "0822d7e6-a326-48fc-acc3-b82935211f59";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/db6434f6-e149-41da-b3a4-372a717cff35> a <http://schema.org/ContactPoint>;
+        mu:uuid "db6434f6-e149-41da-b3a4-372a717cff35";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/6f484ab6-ea6f-426e-89ae-ef751460a436> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "6f484ab6-ea6f-426e-89ae-ef751460a436".
+
+      <http://data.lblod.info/id/bestuurseenheden/a31131dd72b614c89184b331821c10a0f8feb109881a1b164749e9c8941c5e6b> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "a31131dd72b614c89184b331821c10a0f8feb109881a1b164749e9c8941c5e6b";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Regio Turnhout: Baarle-Hertog, Beerse, Kasterlee, Lille, Oud-Turnhout, Turnhout en Vosselaar";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/b5ecdf3c-7f8e-42f0-9b72-4272ac2f3ccb>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/d4a2568b-f1de-4113-a2dc-34ab9227d29b> .
+    
+
+      <http://data.lblod.info/id/identificatoren/a623bfc2-0cec-406b-9d11-7a0e2f2ee11a> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "a623bfc2-0cec-406b-9d11-7a0e2f2ee11a";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/a3f34e34-119e-437c-9a92-151e71264670>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/a3f34e34-119e-437c-9a92-151e71264670> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "a3f34e34-119e-437c-9a92-151e71264670";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1209".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/4daf23a2-a665-4ea9-80c2-01f555cdb3e5> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "4daf23a2-a665-4ea9-80c2-01f555cdb3e5";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/c83310a8-49c7-4625-ba97-6fa7df1d9000>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/91b18b8b-19fa-4b17-939f-47d60f8c8cc0>,
+                        <http://data.lblod.info/id/contact-punten/b9dad335-ef4e-480c-91a3-5e39b16cafe7>.
+
+      <http://data.lblod.info/id/contact-punten/91b18b8b-19fa-4b17-939f-47d60f8c8cc0> a <http://schema.org/ContactPoint>;
+        mu:uuid "91b18b8b-19fa-4b17-939f-47d60f8c8cc0";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/b9dad335-ef4e-480c-91a3-5e39b16cafe7> a <http://schema.org/ContactPoint>;
+        mu:uuid "b9dad335-ef4e-480c-91a3-5e39b16cafe7";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/c83310a8-49c7-4625-ba97-6fa7df1d9000> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "c83310a8-49c7-4625-ba97-6fa7df1d9000".
+
+      <http://data.lblod.info/id/bestuurseenheden/d847f2f345c5e58882e0e468c31de8868e71a73f4cbfa63823de17da3c7f1942> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "d847f2f345c5e58882e0e468c31de8868e71a73f4cbfa63823de17da3c7f1942";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Balen/Dessel/Mol: Balen, Dessel en Mol";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/a623bfc2-0cec-406b-9d11-7a0e2f2ee11a>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/4daf23a2-a665-4ea9-80c2-01f555cdb3e5> .
+    
+
+      <http://data.lblod.info/id/identificatoren/8e025747-08b6-4cac-8630-7e7a1625c200> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "8e025747-08b6-4cac-8630-7e7a1625c200";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/adfa09ce-a365-4a37-b0b5-335ded34045e>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/adfa09ce-a365-4a37-b0b5-335ded34045e> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "adfa09ce-a365-4a37-b0b5-335ded34045e";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1210".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/936d98fb-a4df-43ed-9c9a-e6bafa1134ac> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "936d98fb-a4df-43ed-9c9a-e6bafa1134ac";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/102d7c35-7df1-4358-b792-99724e11ab8c>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/ac8f55d7-f0fa-450a-8b4c-780308998b72>,
+                        <http://data.lblod.info/id/contact-punten/260fcbf5-91cf-4204-98fc-d2ddf994dc8d>.
+
+      <http://data.lblod.info/id/contact-punten/ac8f55d7-f0fa-450a-8b4c-780308998b72> a <http://schema.org/ContactPoint>;
+        mu:uuid "ac8f55d7-f0fa-450a-8b4c-780308998b72";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/260fcbf5-91cf-4204-98fc-d2ddf994dc8d> a <http://schema.org/ContactPoint>;
+        mu:uuid "260fcbf5-91cf-4204-98fc-d2ddf994dc8d";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/102d7c35-7df1-4358-b792-99724e11ab8c> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "102d7c35-7df1-4358-b792-99724e11ab8c".
+
+      <http://data.lblod.info/id/bestuurseenheden/2ca642d589b8012fe65bf54df3a87f740acac78624a902ad378dc4ee6c50a848> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "2ca642d589b8012fe65bf54df3a87f740acac78624a902ad378dc4ee6c50a848";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Het Houtsche: Beernem, Oostkamp en Zedelgem";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/8e025747-08b6-4cac-8630-7e7a1625c200>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/936d98fb-a4df-43ed-9c9a-e6bafa1134ac> .
+    
+
+      <http://data.lblod.info/id/identificatoren/a04aa597-40a2-46e2-b430-3964836b5c05> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "a04aa597-40a2-46e2-b430-3964836b5c05";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/b69fd0af-d86a-4ed0-87e8-43b26a1aba08>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/b69fd0af-d86a-4ed0-87e8-43b26a1aba08> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "b69fd0af-d86a-4ed0-87e8-43b26a1aba08";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1211".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/c3843f9f-e454-4850-96d3-f8035028a033> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "c3843f9f-e454-4850-96d3-f8035028a033";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/aed04d19-e5c4-4045-a7d4-555e2502edeb>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/d053a7d3-9981-46a6-9db4-09b8701a8c44>,
+                        <http://data.lblod.info/id/contact-punten/5bf97130-ee5c-4098-99d4-cfd174102ffe>.
+
+      <http://data.lblod.info/id/contact-punten/d053a7d3-9981-46a6-9db4-09b8701a8c44> a <http://schema.org/ContactPoint>;
+        mu:uuid "d053a7d3-9981-46a6-9db4-09b8701a8c44";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/5bf97130-ee5c-4098-99d4-cfd174102ffe> a <http://schema.org/ContactPoint>;
+        mu:uuid "5bf97130-ee5c-4098-99d4-cfd174102ffe";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/aed04d19-e5c4-4045-a7d4-555e2502edeb> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "aed04d19-e5c4-4045-a7d4-555e2502edeb".
+
+      <http://data.lblod.info/id/bestuurseenheden/cbb5b8b80d03be75744a41580e5658b3c236fa0a12822bbb334f893c524b5b18> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "cbb5b8b80d03be75744a41580e5658b3c236fa0a12822bbb334f893c524b5b18";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Beersel";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/a04aa597-40a2-46e2-b430-3964836b5c05>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/c3843f9f-e454-4850-96d3-f8035028a033> .
+    
+
+      <http://data.lblod.info/id/identificatoren/a194c848-c886-403b-b901-a10adf2d1178> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "a194c848-c886-403b-b901-a10adf2d1178";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/f2c72cc5-3097-475e-96df-550fd670a5af>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/f2c72cc5-3097-475e-96df-550fd670a5af> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "f2c72cc5-3097-475e-96df-550fd670a5af";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1212".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/7b095c48-de7f-4999-a891-5074413cf19d> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "7b095c48-de7f-4999-a891-5074413cf19d";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/fba5ec20-ea55-4e4b-9a0f-d83dfec318d4>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/811ad225-9138-43eb-8183-1c404cb49793>,
+                        <http://data.lblod.info/id/contact-punten/ef2ed025-58e1-428c-9459-b2eb37825864>.
+
+      <http://data.lblod.info/id/contact-punten/811ad225-9138-43eb-8183-1c404cb49793> a <http://schema.org/ContactPoint>;
+        mu:uuid "811ad225-9138-43eb-8183-1c404cb49793";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/ef2ed025-58e1-428c-9459-b2eb37825864> a <http://schema.org/ContactPoint>;
+        mu:uuid "ef2ed025-58e1-428c-9459-b2eb37825864";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/fba5ec20-ea55-4e4b-9a0f-d83dfec318d4> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "fba5ec20-ea55-4e4b-9a0f-d83dfec318d4".
+
+      <http://data.lblod.info/id/bestuurseenheden/81083789b63917e32ab90ef1a45adf893f370ee38da2e0542e5c035db4f60794> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "81083789b63917e32ab90ef1a45adf893f370ee38da2e0542e5c035db4f60794";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ BRT: Begijnendijk, Rotselaar en Tremelo";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/a194c848-c886-403b-b901-a10adf2d1178>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/7b095c48-de7f-4999-a891-5074413cf19d> .
+    
+
+      <http://data.lblod.info/id/identificatoren/bf8ee371-dd83-4e04-baa1-5e60f23165b4> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "bf8ee371-dd83-4e04-baa1-5e60f23165b4";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/123428cd-1ea8-48c1-8c98-9997e6236d8f>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/123428cd-1ea8-48c1-8c98-9997e6236d8f> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "123428cd-1ea8-48c1-8c98-9997e6236d8f";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1213".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/5816c7fb-670b-47e9-9349-56795fc2d64b> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "5816c7fb-670b-47e9-9349-56795fc2d64b";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/4916dbfd-a6e5-4802-9d26-fb3ff8697daa>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/af2dd648-ffb1-4bc9-81d5-4f328030dc0b>,
+                        <http://data.lblod.info/id/contact-punten/fa90ac52-5820-401f-bdd7-7317ff188cd8>.
+
+      <http://data.lblod.info/id/contact-punten/af2dd648-ffb1-4bc9-81d5-4f328030dc0b> a <http://schema.org/ContactPoint>;
+        mu:uuid "af2dd648-ffb1-4bc9-81d5-4f328030dc0b";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/fa90ac52-5820-401f-bdd7-7317ff188cd8> a <http://schema.org/ContactPoint>;
+        mu:uuid "fa90ac52-5820-401f-bdd7-7317ff188cd8";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/4916dbfd-a6e5-4802-9d26-fb3ff8697daa> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "4916dbfd-a6e5-4802-9d26-fb3ff8697daa".
+
+      <http://data.lblod.info/id/bestuurseenheden/39e0e2e69be463a4628f87bffe7dc6206aa6daa4a5516fb4ce11907f57d77079> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "39e0e2e69be463a4628f87bffe7dc6206aa6daa4a5516fb4ce11907f57d77079";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Hageland: Bekkevoort, Geetbets, Glabbeek, Kortenaken en Tielt-Winge";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/bf8ee371-dd83-4e04-baa1-5e60f23165b4>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/5816c7fb-670b-47e9-9349-56795fc2d64b> .
+    
+
+      <http://data.lblod.info/id/identificatoren/12b596a1-efc8-4b42-a928-481a25b15f10> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "12b596a1-efc8-4b42-a928-481a25b15f10";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/0392b921-bef7-49b4-8a7a-7b9540a2ffe7>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/0392b921-bef7-49b4-8a7a-7b9540a2ffe7> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "0392b921-bef7-49b4-8a7a-7b9540a2ffe7";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1214".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/e4510e38-10fd-469e-8308-d6a096fd8ce9> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "e4510e38-10fd-469e-8308-d6a096fd8ce9";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/efdf51bd-b9fb-46dc-9cf7-18e0feffa3df>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/7e61c482-11e4-4dea-a8ec-b91d82f2cb3b>,
+                        <http://data.lblod.info/id/contact-punten/dc4a3ca6-92f1-47ce-a7dd-684a9e8ca46e>.
+
+      <http://data.lblod.info/id/contact-punten/7e61c482-11e4-4dea-a8ec-b91d82f2cb3b> a <http://schema.org/ContactPoint>;
+        mu:uuid "7e61c482-11e4-4dea-a8ec-b91d82f2cb3b";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/dc4a3ca6-92f1-47ce-a7dd-684a9e8ca46e> a <http://schema.org/ContactPoint>;
+        mu:uuid "dc4a3ca6-92f1-47ce-a7dd-684a9e8ca46e";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/efdf51bd-b9fb-46dc-9cf7-18e0feffa3df> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "efdf51bd-b9fb-46dc-9cf7-18e0feffa3df".
+
+      <http://data.lblod.info/id/bestuurseenheden/08b6bdc2c34dacae28168cf967ef2e13384f032a147ddaea7f1145eff4f0d161> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "08b6bdc2c34dacae28168cf967ef2e13384f032a147ddaea7f1145eff4f0d161";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Beringen/Ham/Tessenderlo: Beringen, Ham en Tessenderlo";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/12b596a1-efc8-4b42-a928-481a25b15f10>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/e4510e38-10fd-469e-8308-d6a096fd8ce9> .
+    
+
+      <http://data.lblod.info/id/identificatoren/bd8cc863-5e4e-41ad-8c84-3154ccab5e9e> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "bd8cc863-5e4e-41ad-8c84-3154ccab5e9e";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/47dd3636-0759-48db-ad84-b081afa5b5a4>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/47dd3636-0759-48db-ad84-b081afa5b5a4> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "47dd3636-0759-48db-ad84-b081afa5b5a4";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1215".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/3b8a138f-2214-463d-a85c-4e4bf595b5f6> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "3b8a138f-2214-463d-a85c-4e4bf595b5f6";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/bb8371bb-8330-42f4-9a3c-05a1a2a3d9a9>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/a8c5ba89-6c5f-43e4-bb62-7a76aeed3d72>,
+                        <http://data.lblod.info/id/contact-punten/9b0a5d21-f48b-4ac4-a828-5f37e15493a4>.
+
+      <http://data.lblod.info/id/contact-punten/a8c5ba89-6c5f-43e4-bb62-7a76aeed3d72> a <http://schema.org/ContactPoint>;
+        mu:uuid "a8c5ba89-6c5f-43e4-bb62-7a76aeed3d72";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/9b0a5d21-f48b-4ac4-a828-5f37e15493a4> a <http://schema.org/ContactPoint>;
+        mu:uuid "9b0a5d21-f48b-4ac4-a828-5f37e15493a4";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/bb8371bb-8330-42f4-9a3c-05a1a2a3d9a9> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "bb8371bb-8330-42f4-9a3c-05a1a2a3d9a9".
+
+      <http://data.lblod.info/id/bestuurseenheden/f5094b8d7f26d69d04ba2c469a09e0c6dc08a78615c9483fd97d6d029e064121> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "f5094b8d7f26d69d04ba2c469a09e0c6dc08a78615c9483fd97d6d029e064121";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Berlaar/Nijlen: Berlaar en Nijlen";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/bd8cc863-5e4e-41ad-8c84-3154ccab5e9e>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/3b8a138f-2214-463d-a85c-4e4bf595b5f6> .
+    
+
+      <http://data.lblod.info/id/identificatoren/b465d6e4-a758-44c3-9c90-ee8c32324d0d> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "b465d6e4-a758-44c3-9c90-ee8c32324d0d";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/1c5f4bd8-c17c-4013-a98c-37e80e05cfac>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/1c5f4bd8-c17c-4013-a98c-37e80e05cfac> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "1c5f4bd8-c17c-4013-a98c-37e80e05cfac";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1216".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/88e588d1-b172-4c6a-9580-69698f93ee53> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "88e588d1-b172-4c6a-9580-69698f93ee53";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/5fabc278-32ad-48c1-9538-0a52baf6c80e>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/d468a138-7a08-408a-b31e-dd1fb361b695>,
+                        <http://data.lblod.info/id/contact-punten/6ed0e513-3707-4e6d-a720-86ded2cdb6eb>.
+
+      <http://data.lblod.info/id/contact-punten/d468a138-7a08-408a-b31e-dd1fb361b695> a <http://schema.org/ContactPoint>;
+        mu:uuid "d468a138-7a08-408a-b31e-dd1fb361b695";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/6ed0e513-3707-4e6d-a720-86ded2cdb6eb> a <http://schema.org/ContactPoint>;
+        mu:uuid "6ed0e513-3707-4e6d-a720-86ded2cdb6eb";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/5fabc278-32ad-48c1-9538-0a52baf6c80e> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "5fabc278-32ad-48c1-9538-0a52baf6c80e".
+
+      <http://data.lblod.info/id/bestuurseenheden/414f3538e482d3c1c21382ca22de18998ca1d3f5b517ced85946ecf90143149c> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "414f3538e482d3c1c21382ca22de18998ca1d3f5b517ced85946ecf90143149c";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Berlare/Zele: Berlare en Zele";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/b465d6e4-a758-44c3-9c90-ee8c32324d0d>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/88e588d1-b172-4c6a-9580-69698f93ee53> .
+    
+
+      <http://data.lblod.info/id/identificatoren/c7508c62-f099-42aa-a7fa-8781f7f2c9f0> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "c7508c62-f099-42aa-a7fa-8781f7f2c9f0";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/99384502-77b6-46e1-ae2a-b96f06d49a90>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/99384502-77b6-46e1-ae2a-b96f06d49a90> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "99384502-77b6-46e1-ae2a-b96f06d49a90";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1217".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/2ef06d05-48fb-49e7-abac-a8fcb7d94fb5> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "2ef06d05-48fb-49e7-abac-a8fcb7d94fb5";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/33593f15-d75a-4353-9096-cab218c3448e>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/09740d47-4aec-4d3f-936b-d363996e594a>,
+                        <http://data.lblod.info/id/contact-punten/337f7957-8895-4eaf-8d3c-75f1d1113a7e>.
+
+      <http://data.lblod.info/id/contact-punten/09740d47-4aec-4d3f-936b-d363996e594a> a <http://schema.org/ContactPoint>;
+        mu:uuid "09740d47-4aec-4d3f-936b-d363996e594a";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/337f7957-8895-4eaf-8d3c-75f1d1113a7e> a <http://schema.org/ContactPoint>;
+        mu:uuid "337f7957-8895-4eaf-8d3c-75f1d1113a7e";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/33593f15-d75a-4353-9096-cab218c3448e> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "33593f15-d75a-4353-9096-cab218c3448e".
+
+      <http://data.lblod.info/id/bestuurseenheden/3efcad40be18e793d070f78a44f2e63bc105778d6c8c4edc4bfeb5a87f06554c> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "3efcad40be18e793d070f78a44f2e63bc105778d6c8c4edc4bfeb5a87f06554c";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Bertem/Huldenberg/Oud-Heverlee";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/c7508c62-f099-42aa-a7fa-8781f7f2c9f0>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/2ef06d05-48fb-49e7-abac-a8fcb7d94fb5> .
+    
+
+      <http://data.lblod.info/id/identificatoren/6161103a-996e-4b47-9b5f-0517d354e19e> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "6161103a-996e-4b47-9b5f-0517d354e19e";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/bcc3dabc-d1f2-4850-97c0-cac1251dd99c>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/bcc3dabc-d1f2-4850-97c0-cac1251dd99c> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "bcc3dabc-d1f2-4850-97c0-cac1251dd99c";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1218".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/35023fde-0fce-42e9-886b-88b84a0f93de> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "35023fde-0fce-42e9-886b-88b84a0f93de";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/49f4dbfb-62e7-436f-8c5e-2fef6dab8fc9>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/fdcfa45e-a987-4389-b727-d78d86891cc7>,
+                        <http://data.lblod.info/id/contact-punten/cccb172f-7baa-4638-a232-8c343bbb7d02>.
+
+      <http://data.lblod.info/id/contact-punten/fdcfa45e-a987-4389-b727-d78d86891cc7> a <http://schema.org/ContactPoint>;
+        mu:uuid "fdcfa45e-a987-4389-b727-d78d86891cc7";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/cccb172f-7baa-4638-a232-8c343bbb7d02> a <http://schema.org/ContactPoint>;
+        mu:uuid "cccb172f-7baa-4638-a232-8c343bbb7d02";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/49f4dbfb-62e7-436f-8c5e-2fef6dab8fc9> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "49f4dbfb-62e7-436f-8c5e-2fef6dab8fc9".
+
+      <http://data.lblod.info/id/bestuurseenheden/7cb2089a8c6746d514711908abfd38414a2b01f6ad9a83f28be2e835888b3da7> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "7cb2089a8c6746d514711908abfd38414a2b01f6ad9a83f28be2e835888b3da7";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Pajottenland: Bever, Galmaarden, Gooik, Herne, Lennik en Pepingen";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/6161103a-996e-4b47-9b5f-0517d354e19e>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/35023fde-0fce-42e9-886b-88b84a0f93de> .
+    
+
+      <http://data.lblod.info/id/identificatoren/4056b660-7808-4db2-a718-638b065fce61> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "4056b660-7808-4db2-a718-638b065fce61";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/6edf281c-056b-4037-8384-60688f1c15d3>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/6edf281c-056b-4037-8384-60688f1c15d3> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "6edf281c-056b-4037-8384-60688f1c15d3";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1219".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/98414e63-b1ad-4c10-9a96-6a938e8e278c> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "98414e63-b1ad-4c10-9a96-6a938e8e278c";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/4c150c8a-7c84-4e3e-b0fb-6289d93b622b>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/f4ef1225-ad63-442e-9cca-e9c21a839c9a>,
+                        <http://data.lblod.info/id/contact-punten/2521d5ed-4139-41d3-a3e9-1df1a61f40fb>.
+
+      <http://data.lblod.info/id/contact-punten/f4ef1225-ad63-442e-9cca-e9c21a839c9a> a <http://schema.org/ContactPoint>;
+        mu:uuid "f4ef1225-ad63-442e-9cca-e9c21a839c9a";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/2521d5ed-4139-41d3-a3e9-1df1a61f40fb> a <http://schema.org/ContactPoint>;
+        mu:uuid "2521d5ed-4139-41d3-a3e9-1df1a61f40fb";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/4c150c8a-7c84-4e3e-b0fb-6289d93b622b> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "4c150c8a-7c84-4e3e-b0fb-6289d93b622b".
+
+      <http://data.lblod.info/id/bestuurseenheden/488938bd557800723290a816c51b471fff7f4918237a509f697973af6f509390> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "488938bd557800723290a816c51b471fff7f4918237a509f697973af6f509390";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Beveren";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/4056b660-7808-4db2-a718-638b065fce61>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/98414e63-b1ad-4c10-9a96-6a938e8e278c> .
+    
+
+      <http://data.lblod.info/id/identificatoren/d8754fdd-97a9-436e-8291-65abc5dfd53f> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "d8754fdd-97a9-436e-8291-65abc5dfd53f";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/8077534d-8a79-4a27-b057-ce0434de1da5>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/8077534d-8a79-4a27-b057-ce0434de1da5> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "8077534d-8a79-4a27-b057-ce0434de1da5";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1220".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/494e1d6b-a351-4b51-bb6a-45124f545479> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "494e1d6b-a351-4b51-bb6a-45124f545479";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/a6eb60aa-b836-41a0-8b6c-ded4ecd19c0f>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/a2a83449-4842-426a-b2ea-fe4589487c33>,
+                        <http://data.lblod.info/id/contact-punten/88d59f72-c194-4a8f-abdf-77dffaa10a3c>.
+
+      <http://data.lblod.info/id/contact-punten/a2a83449-4842-426a-b2ea-fe4589487c33> a <http://schema.org/ContactPoint>;
+        mu:uuid "a2a83449-4842-426a-b2ea-fe4589487c33";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/88d59f72-c194-4a8f-abdf-77dffaa10a3c> a <http://schema.org/ContactPoint>;
+        mu:uuid "88d59f72-c194-4a8f-abdf-77dffaa10a3c";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/a6eb60aa-b836-41a0-8b6c-ded4ecd19c0f> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "a6eb60aa-b836-41a0-8b6c-ded4ecd19c0f".
+
+      <http://data.lblod.info/id/bestuurseenheden/541c1603eb8c01968f95d1f262854134499e00d135cd7c9147d307ccbd1e20fd> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "541c1603eb8c01968f95d1f262854134499e00d135cd7c9147d307ccbd1e20fd";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Waasland-Noord: Beveren, Sint-Gillis-Waas en Stekene";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/d8754fdd-97a9-436e-8291-65abc5dfd53f>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/494e1d6b-a351-4b51-bb6a-45124f545479> .
+    
+
+      <http://data.lblod.info/id/identificatoren/2431e26e-88f7-40d0-818c-5248cefe29b1> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "2431e26e-88f7-40d0-818c-5248cefe29b1";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/a6872dbc-8f7c-4088-a970-062b91849c56>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/a6872dbc-8f7c-4088-a970-062b91849c56> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "a6872dbc-8f7c-4088-a970-062b91849c56";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1221".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/324726c1-1180-414f-abe1-ea340436a3be> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "324726c1-1180-414f-abe1-ea340436a3be";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/2e659199-ac70-4710-9b0e-4b8c27b9f6db>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/93bcf173-bf52-46e5-a733-52d259fb2ad3>,
+                        <http://data.lblod.info/id/contact-punten/d5f730fe-3381-4d07-a982-0ba6a3445ff9>.
+
+      <http://data.lblod.info/id/contact-punten/93bcf173-bf52-46e5-a733-52d259fb2ad3> a <http://schema.org/ContactPoint>;
+        mu:uuid "93bcf173-bf52-46e5-a733-52d259fb2ad3";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/d5f730fe-3381-4d07-a982-0ba6a3445ff9> a <http://schema.org/ContactPoint>;
+        mu:uuid "d5f730fe-3381-4d07-a982-0ba6a3445ff9";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/2e659199-ac70-4710-9b0e-4b8c27b9f6db> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "2e659199-ac70-4710-9b0e-4b8c27b9f6db".
+
+      <http://data.lblod.info/id/bestuurseenheden/da737a74e5094054c3bb3ef077839626a02eb79d148e15cfeee18e10c18ba55a> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "da737a74e5094054c3bb3ef077839626a02eb79d148e15cfeee18e10c18ba55a";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Bierbeek/Boutersem/Holsbeek/Lubbeek: Bierbeek, Boutersem, Holsbeek en Lubbeek";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/2431e26e-88f7-40d0-818c-5248cefe29b1>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/324726c1-1180-414f-abe1-ea340436a3be> .
+    
+
+      <http://data.lblod.info/id/identificatoren/6dbaffaf-a925-4103-b18b-6e8edbec080e> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "6dbaffaf-a925-4103-b18b-6e8edbec080e";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/2ef54599-c1e0-4418-a0d8-5dd2fabda35d>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/2ef54599-c1e0-4418-a0d8-5dd2fabda35d> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "2ef54599-c1e0-4418-a0d8-5dd2fabda35d";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1222".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/5c446bc1-fa99-42be-8e92-cd5fb558ba00> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "5c446bc1-fa99-42be-8e92-cd5fb558ba00";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/403346d5-00b6-47e9-a0e9-a83f8b52a93f>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/23c6dee5-c9b6-43e2-926b-6e5fbd3bf70a>,
+                        <http://data.lblod.info/id/contact-punten/c7371de2-9158-4a63-ad33-819c35399914>.
+
+      <http://data.lblod.info/id/contact-punten/23c6dee5-c9b6-43e2-926b-6e5fbd3bf70a> a <http://schema.org/ContactPoint>;
+        mu:uuid "23c6dee5-c9b6-43e2-926b-6e5fbd3bf70a";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/c7371de2-9158-4a63-ad33-819c35399914> a <http://schema.org/ContactPoint>;
+        mu:uuid "c7371de2-9158-4a63-ad33-819c35399914";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/403346d5-00b6-47e9-a0e9-a83f8b52a93f> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "403346d5-00b6-47e9-a0e9-a83f8b52a93f".
+
+      <http://data.lblod.info/id/bestuurseenheden/19ac0fa207989c27c3391e327aee16435475292296f010867945bf2987f95477> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "19ac0fa207989c27c3391e327aee16435475292296f010867945bf2987f95477";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Bilzen/Hoeselt/Riemst: Bilzen, Hoeselt en Riemst";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/6dbaffaf-a925-4103-b18b-6e8edbec080e>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/5c446bc1-fa99-42be-8e92-cd5fb558ba00> .
+    
+
+      <http://data.lblod.info/id/identificatoren/f1113bf7-cce9-4a7a-97c8-78cc88050699> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "f1113bf7-cce9-4a7a-97c8-78cc88050699";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/dac9e413-9163-4996-bf10-fb8200e9d9eb>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/dac9e413-9163-4996-bf10-fb8200e9d9eb> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "dac9e413-9163-4996-bf10-fb8200e9d9eb";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1223".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/9f8c9ed3-ea64-4174-aef8-7ae1a2d1970a> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "9f8c9ed3-ea64-4174-aef8-7ae1a2d1970a";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/27c57a3d-498a-48c5-a675-57fbccb2f176>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/f8f4d083-177f-4cc1-b720-b76ac0a210d6>,
+                        <http://data.lblod.info/id/contact-punten/4a0c050f-5f57-4c20-92d8-059ace90618a>.
+
+      <http://data.lblod.info/id/contact-punten/f8f4d083-177f-4cc1-b720-b76ac0a210d6> a <http://schema.org/ContactPoint>;
+        mu:uuid "f8f4d083-177f-4cc1-b720-b76ac0a210d6";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/4a0c050f-5f57-4c20-92d8-059ace90618a> a <http://schema.org/ContactPoint>;
+        mu:uuid "4a0c050f-5f57-4c20-92d8-059ace90618a";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/27c57a3d-498a-48c5-a675-57fbccb2f176> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "27c57a3d-498a-48c5-a675-57fbccb2f176".
+
+      <http://data.lblod.info/id/bestuurseenheden/05354d6fcc016d06f988a0e044fb160be7573550c11fe414b3c011961150a686> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "05354d6fcc016d06f988a0e044fb160be7573550c11fe414b3c011961150a686";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Blankenberge/Zuienkerke: Blankenberge en Zuienkerke";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/f1113bf7-cce9-4a7a-97c8-78cc88050699>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/9f8c9ed3-ea64-4174-aef8-7ae1a2d1970a> .
+    
+
+      <http://data.lblod.info/id/identificatoren/d1a088d1-8e32-4716-86f4-a9d0b8a72e56> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "d1a088d1-8e32-4716-86f4-a9d0b8a72e56";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/c61710d3-9149-4bd6-a8b2-c1e90bb3e7de>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/c61710d3-9149-4bd6-a8b2-c1e90bb3e7de> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "c61710d3-9149-4bd6-a8b2-c1e90bb3e7de";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1224".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/5134c0cc-6ec7-4499-aae0-318d77893428> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "5134c0cc-6ec7-4499-aae0-318d77893428";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/0224ea7d-6c0d-43b0-91f8-fc559726c627>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/0b232292-6278-4fd9-adb9-9847032fedf4>,
+                        <http://data.lblod.info/id/contact-punten/54563fb0-a391-460a-976e-84eab80342f1>.
+
+      <http://data.lblod.info/id/contact-punten/0b232292-6278-4fd9-adb9-9847032fedf4> a <http://schema.org/ContactPoint>;
+        mu:uuid "0b232292-6278-4fd9-adb9-9847032fedf4";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/54563fb0-a391-460a-976e-84eab80342f1> a <http://schema.org/ContactPoint>;
+        mu:uuid "54563fb0-a391-460a-976e-84eab80342f1";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/0224ea7d-6c0d-43b0-91f8-fc559726c627> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "0224ea7d-6c0d-43b0-91f8-fc559726c627".
+
+      <http://data.lblod.info/id/bestuurseenheden/9893dc25d4b91aef9e2ef6f712e0aac68cdf6f144dbed887c9500e6360df080d> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "9893dc25d4b91aef9e2ef6f712e0aac68cdf6f144dbed887c9500e6360df080d";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Bocholt/Bree/Kinrooi/Meeuwen-Gruitrode";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/d1a088d1-8e32-4716-86f4-a9d0b8a72e56>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/5134c0cc-6ec7-4499-aae0-318d77893428> .
+    
+
+      <http://data.lblod.info/id/identificatoren/c7e63c5e-3e81-41b9-a834-f1f581f768d0> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "c7e63c5e-3e81-41b9-a834-f1f581f768d0";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/33d686b2-5b7c-40ff-a155-81696c82b738>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/33d686b2-5b7c-40ff-a155-81696c82b738> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "33d686b2-5b7c-40ff-a155-81696c82b738";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1225".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/ff81e1d0-6d28-41ee-a43d-051ad7d40725> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "ff81e1d0-6d28-41ee-a43d-051ad7d40725";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/e60a606a-0fc8-4ba4-965e-7dbb605ad15a>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/b3c62a73-5ccd-4574-b6fd-1d77fa981d3e>,
+                        <http://data.lblod.info/id/contact-punten/2581171e-ea0d-4551-8673-b47378b09d89>.
+
+      <http://data.lblod.info/id/contact-punten/b3c62a73-5ccd-4574-b6fd-1d77fa981d3e> a <http://schema.org/ContactPoint>;
+        mu:uuid "b3c62a73-5ccd-4574-b6fd-1d77fa981d3e";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/2581171e-ea0d-4551-8673-b47378b09d89> a <http://schema.org/ContactPoint>;
+        mu:uuid "2581171e-ea0d-4551-8673-b47378b09d89";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/e60a606a-0fc8-4ba4-965e-7dbb605ad15a> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "e60a606a-0fc8-4ba4-965e-7dbb605ad15a".
+
+      <http://data.lblod.info/id/bestuurseenheden/80a9ab8eb46716ab23c597d13313ce24b17884ffcbdf00d216b877d57a52ade4> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "80a9ab8eb46716ab23c597d13313ce24b17884ffcbdf00d216b877d57a52ade4";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ MINOS: Boechout, Borsbeek, Mortsel, Wijnegem en Wommelgem";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/c7e63c5e-3e81-41b9-a834-f1f581f768d0>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/ff81e1d0-6d28-41ee-a43d-051ad7d40725> .
+    
+
+      <http://data.lblod.info/id/identificatoren/193cdfca-76b5-497a-9e45-6c860e74b0ae> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "193cdfca-76b5-497a-9e45-6c860e74b0ae";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/a49fe65a-a60c-4b20-b926-a228aa74f173>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/a49fe65a-a60c-4b20-b926-a228aa74f173> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "a49fe65a-a60c-4b20-b926-a228aa74f173";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1226".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/1cc6fab0-e35c-473b-98ad-d8529cdf7553> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "1cc6fab0-e35c-473b-98ad-d8529cdf7553";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/439754d3-061f-4811-9129-98e60e9adce2>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/9ca96024-8438-46a6-b786-713b0077016a>,
+                        <http://data.lblod.info/id/contact-punten/ba904958-caec-42ac-96b2-5cf78148dd13>.
+
+      <http://data.lblod.info/id/contact-punten/9ca96024-8438-46a6-b786-713b0077016a> a <http://schema.org/ContactPoint>;
+        mu:uuid "9ca96024-8438-46a6-b786-713b0077016a";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/ba904958-caec-42ac-96b2-5cf78148dd13> a <http://schema.org/ContactPoint>;
+        mu:uuid "ba904958-caec-42ac-96b2-5cf78148dd13";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/439754d3-061f-4811-9129-98e60e9adce2> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "439754d3-061f-4811-9129-98e60e9adce2".
+
+      <http://data.lblod.info/id/bestuurseenheden/f4838c2bb548a35f92a6ddcf725676b9f137f3fcb11e6737caa7cab1f1314e27> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "f4838c2bb548a35f92a6ddcf725676b9f137f3fcb11e6737caa7cab1f1314e27";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ BODUKAP: Bonheiden, Duffel, Sint-Katelijne-Waver en Putte";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/193cdfca-76b5-497a-9e45-6c860e74b0ae>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/1cc6fab0-e35c-473b-98ad-d8529cdf7553> .
+    
+
+      <http://data.lblod.info/id/identificatoren/239a8f70-126a-4c49-925c-791b5d7ef6b8> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "239a8f70-126a-4c49-925c-791b5d7ef6b8";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/e05ccfe3-fa03-4a99-9165-0faf4b4c0e4a>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/e05ccfe3-fa03-4a99-9165-0faf4b4c0e4a> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "e05ccfe3-fa03-4a99-9165-0faf4b4c0e4a";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1227".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/666b0440-22b3-4e25-9da7-5a1534dcdcc8> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "666b0440-22b3-4e25-9da7-5a1534dcdcc8";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/513a7fbe-89e5-4c39-a291-f853261e3eb6>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/948f4509-ebb9-43ed-a20d-3858628d78ed>,
+                        <http://data.lblod.info/id/contact-punten/7fb9cd4b-4873-4c5a-a8a9-5851f93b3a09>.
+
+      <http://data.lblod.info/id/contact-punten/948f4509-ebb9-43ed-a20d-3858628d78ed> a <http://schema.org/ContactPoint>;
+        mu:uuid "948f4509-ebb9-43ed-a20d-3858628d78ed";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/7fb9cd4b-4873-4c5a-a8a9-5851f93b3a09> a <http://schema.org/ContactPoint>;
+        mu:uuid "7fb9cd4b-4873-4c5a-a8a9-5851f93b3a09";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/513a7fbe-89e5-4c39-a291-f853261e3eb6> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "513a7fbe-89e5-4c39-a291-f853261e3eb6".
+
+      <http://data.lblod.info/id/bestuurseenheden/46616861cfaae13b550a36ae5c05187638df0873024f13043d3f40f24cabf4e6> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "46616861cfaae13b550a36ae5c05187638df0873024f13043d3f40f24cabf4e6";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Rupel: Boom, Hemiksem, Niel, Rumst en Schelle";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/239a8f70-126a-4c49-925c-791b5d7ef6b8>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/666b0440-22b3-4e25-9da7-5a1534dcdcc8> .
+    
+
+      <http://data.lblod.info/id/identificatoren/f2f94969-9439-4a96-a2be-513a8b6da1b4> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "f2f94969-9439-4a96-a2be-513a8b6da1b4";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/18352ea4-a4ea-420b-a94c-ae9f6b5e5c40>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/18352ea4-a4ea-420b-a94c-ae9f6b5e5c40> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "18352ea4-a4ea-420b-a94c-ae9f6b5e5c40";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1228".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/a9d1e000-501d-4d90-85ec-65b0ebea0167> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "a9d1e000-501d-4d90-85ec-65b0ebea0167";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/cf11fcab-45ab-4ac2-add2-e393cd0e28b6>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/fb0b62a7-b51d-40d5-953e-ab0bcf1dc67d>,
+                        <http://data.lblod.info/id/contact-punten/08858526-9209-42fa-9d9c-19b58a7eec85>.
+
+      <http://data.lblod.info/id/contact-punten/fb0b62a7-b51d-40d5-953e-ab0bcf1dc67d> a <http://schema.org/ContactPoint>;
+        mu:uuid "fb0b62a7-b51d-40d5-953e-ab0bcf1dc67d";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/08858526-9209-42fa-9d9c-19b58a7eec85> a <http://schema.org/ContactPoint>;
+        mu:uuid "08858526-9209-42fa-9d9c-19b58a7eec85";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/cf11fcab-45ab-4ac2-add2-e393cd0e28b6> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "cf11fcab-45ab-4ac2-add2-e393cd0e28b6".
+
+      <http://data.lblod.info/id/bestuurseenheden/d5d6693850ba1a749739c4574e7c75a98820629fdbbbbb143b7a4f7c279247ea> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "d5d6693850ba1a749739c4574e7c75a98820629fdbbbbb143b7a4f7c279247ea";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Boortmeerbeek/Haacht/Keerbergen: Boortmeerbeek, Haacht en Keerbergen";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/f2f94969-9439-4a96-a2be-513a8b6da1b4>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/a9d1e000-501d-4d90-85ec-65b0ebea0167> .
+    
+
+      <http://data.lblod.info/id/identificatoren/a975f6b0-81ce-4886-a344-467a5bafbbcc> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "a975f6b0-81ce-4886-a344-467a5bafbbcc";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/90f74036-c6a8-406d-bff6-acff436b7c55>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/90f74036-c6a8-406d-bff6-acff436b7c55> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "90f74036-c6a8-406d-bff6-acff436b7c55";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1229".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/4c563fc6-4306-4941-8cd0-79305cb087d1> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "4c563fc6-4306-4941-8cd0-79305cb087d1";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/5ed6b3ed-0ce5-46a2-b8ad-dc452525bb5e>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/25c401f5-c953-434e-9afb-5e745a2d6d18>,
+                        <http://data.lblod.info/id/contact-punten/615ad4e1-591f-4a03-b19e-b885b6f196ad>.
+
+      <http://data.lblod.info/id/contact-punten/25c401f5-c953-434e-9afb-5e745a2d6d18> a <http://schema.org/ContactPoint>;
+        mu:uuid "25c401f5-c953-434e-9afb-5e745a2d6d18";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/615ad4e1-591f-4a03-b19e-b885b6f196ad> a <http://schema.org/ContactPoint>;
+        mu:uuid "615ad4e1-591f-4a03-b19e-b885b6f196ad";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/5ed6b3ed-0ce5-46a2-b8ad-dc452525bb5e> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "5ed6b3ed-0ce5-46a2-b8ad-dc452525bb5e".
+
+      <http://data.lblod.info/id/bestuurseenheden/3b2c2151632d84c55dd93372a4e91a7493455a7f77a90fa2066fc618411d0ed6> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "3b2c2151632d84c55dd93372a4e91a7493455a7f77a90fa2066fc618411d0ed6";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Bornem/Puurs/Sint-Amands";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/a975f6b0-81ce-4886-a344-467a5bafbbcc>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/4c563fc6-4306-4941-8cd0-79305cb087d1> .
+    
+
+      <http://data.lblod.info/id/identificatoren/4c34491c-60d5-4055-96fd-9fc5324a60b0> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "4c34491c-60d5-4055-96fd-9fc5324a60b0";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/e160f95c-a798-487e-bc6d-4f64e2f930bc>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/e160f95c-a798-487e-bc6d-4f64e2f930bc> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "e160f95c-a798-487e-bc6d-4f64e2f930bc";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1230".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/f4d38455-50b0-4a7b-bb4d-c0e0a1b93f40> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "f4d38455-50b0-4a7b-bb4d-c0e0a1b93f40";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/078e797e-4eb9-4051-99ba-4d53c4b422b9>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/118b66ab-f1d0-42f0-95a6-922c56a95860>,
+                        <http://data.lblod.info/id/contact-punten/95e46afb-20b1-483a-9221-3eff4b3d3906>.
+
+      <http://data.lblod.info/id/contact-punten/118b66ab-f1d0-42f0-95a6-922c56a95860> a <http://schema.org/ContactPoint>;
+        mu:uuid "118b66ab-f1d0-42f0-95a6-922c56a95860";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/95e46afb-20b1-483a-9221-3eff4b3d3906> a <http://schema.org/ContactPoint>;
+        mu:uuid "95e46afb-20b1-483a-9221-3eff4b3d3906";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/078e797e-4eb9-4051-99ba-4d53c4b422b9> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "078e797e-4eb9-4051-99ba-4d53c4b422b9".
+
+      <http://data.lblod.info/id/bestuurseenheden/b7af3483cb5d0021c6f5864a433b211fce30246ef685621d104b1951915c21c4> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "b7af3483cb5d0021c6f5864a433b211fce30246ef685621d104b1951915c21c4";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Brakel: Brakel, Horebeke, Maarkedal en Zwalm";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/4c34491c-60d5-4055-96fd-9fc5324a60b0>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/f4d38455-50b0-4a7b-bb4d-c0e0a1b93f40> .
+    
+
+      <http://data.lblod.info/id/identificatoren/9b756c7d-6459-4683-bd5e-cd71d427960a> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "9b756c7d-6459-4683-bd5e-cd71d427960a";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/b1b136e0-6298-463f-ae4b-491a561d28c8>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/b1b136e0-6298-463f-ae4b-491a561d28c8> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "b1b136e0-6298-463f-ae4b-491a561d28c8";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1231".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/5c8ee90e-5195-4488-85ad-42cd74da0065> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "5c8ee90e-5195-4488-85ad-42cd74da0065";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/a53337e3-a86f-404f-b200-d51c842e0ab3>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/8151bdea-fbee-4397-bd3b-115756a99459>,
+                        <http://data.lblod.info/id/contact-punten/e84deb97-3009-4631-8900-9b1155102d0c>.
+
+      <http://data.lblod.info/id/contact-punten/8151bdea-fbee-4397-bd3b-115756a99459> a <http://schema.org/ContactPoint>;
+        mu:uuid "8151bdea-fbee-4397-bd3b-115756a99459";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/e84deb97-3009-4631-8900-9b1155102d0c> a <http://schema.org/ContactPoint>;
+        mu:uuid "e84deb97-3009-4631-8900-9b1155102d0c";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/a53337e3-a86f-404f-b200-d51c842e0ab3> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "a53337e3-a86f-404f-b200-d51c842e0ab3".
+
+      <http://data.lblod.info/id/bestuurseenheden/dce9ffab7edf87d670ce7ec399084fc2e12c6b5bb300b865e87c5237beae4ae0> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "dce9ffab7edf87d670ce7ec399084fc2e12c6b5bb300b865e87c5237beae4ae0";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Brasschaat: Brasschaat";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/9b756c7d-6459-4683-bd5e-cd71d427960a>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/5c8ee90e-5195-4488-85ad-42cd74da0065> .
+    
+
+      <http://data.lblod.info/id/identificatoren/b96fbe1c-f480-4e78-9540-d4cbc5d14256> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "b96fbe1c-f480-4e78-9540-d4cbc5d14256";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/42acca78-e9d5-4994-bc3c-de94db990ed8>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/42acca78-e9d5-4994-bc3c-de94db990ed8> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "42acca78-e9d5-4994-bc3c-de94db990ed8";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1232".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/5c4f0749-6f96-48da-ae6f-b3cb5148fbd0> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "5c4f0749-6f96-48da-ae6f-b3cb5148fbd0";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/3d689f81-867c-4dde-b7d4-3342261e15be>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/eb12fdaf-71fd-4500-a00f-0431a7658fab>,
+                        <http://data.lblod.info/id/contact-punten/8815023c-a339-4f63-b036-c5ec1a949a28>.
+
+      <http://data.lblod.info/id/contact-punten/eb12fdaf-71fd-4500-a00f-0431a7658fab> a <http://schema.org/ContactPoint>;
+        mu:uuid "eb12fdaf-71fd-4500-a00f-0431a7658fab";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/8815023c-a339-4f63-b036-c5ec1a949a28> a <http://schema.org/ContactPoint>;
+        mu:uuid "8815023c-a339-4f63-b036-c5ec1a949a28";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/3d689f81-867c-4dde-b7d4-3342261e15be> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "3d689f81-867c-4dde-b7d4-3342261e15be".
+
+      <http://data.lblod.info/id/bestuurseenheden/5dab8a7b0656aaf0db13044fcafc0088f9f0b7776c294a6e9abfdbf7420effae> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "5dab8a7b0656aaf0db13044fcafc0088f9f0b7776c294a6e9abfdbf7420effae";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Voorkempen: Brecht, Malle, Schilde en Zoersel";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/b96fbe1c-f480-4e78-9540-d4cbc5d14256>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/5c4f0749-6f96-48da-ae6f-b3cb5148fbd0> .
+    
+
+      <http://data.lblod.info/id/identificatoren/d6a07be0-04a1-418b-bf7b-7a39dce8f674> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "d6a07be0-04a1-418b-bf7b-7a39dce8f674";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/5e607e8c-b6d5-47be-9fc3-45ce38ce1535>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/5e607e8c-b6d5-47be-9fc3-45ce38ce1535> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "5e607e8c-b6d5-47be-9fc3-45ce38ce1535";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1233".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/51d61a3b-0181-49a1-a204-c3cee7996e5d> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "51d61a3b-0181-49a1-a204-c3cee7996e5d";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/b1973c86-d082-4a86-b355-c51406b1da31>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/9f1e6de4-76d8-4b3d-86a9-a64fd75bc38d>,
+                        <http://data.lblod.info/id/contact-punten/cb03ba7a-c0f1-4015-abdb-a60e7889d9f9>.
+
+      <http://data.lblod.info/id/contact-punten/9f1e6de4-76d8-4b3d-86a9-a64fd75bc38d> a <http://schema.org/ContactPoint>;
+        mu:uuid "9f1e6de4-76d8-4b3d-86a9-a64fd75bc38d";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/cb03ba7a-c0f1-4015-abdb-a60e7889d9f9> a <http://schema.org/ContactPoint>;
+        mu:uuid "cb03ba7a-c0f1-4015-abdb-a60e7889d9f9";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/b1973c86-d082-4a86-b355-c51406b1da31> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "b1973c86-d082-4a86-b355-c51406b1da31".
+
+      <http://data.lblod.info/id/bestuurseenheden/c7d15b793e42f0024e56ae7a89d02f8d6f491ec42cd2ece4c856ee24b154559d> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "c7d15b793e42f0024e56ae7a89d02f8d6f491ec42cd2ece4c856ee24b154559d";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Bredene/De Haan: Bredene en De Haan";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/d6a07be0-04a1-418b-bf7b-7a39dce8f674>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/51d61a3b-0181-49a1-a204-c3cee7996e5d> .
+    
+
+      <http://data.lblod.info/id/identificatoren/2345ca43-ecbd-4fc5-acdc-5196ca900bd5> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "2345ca43-ecbd-4fc5-acdc-5196ca900bd5";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/2b18e526-dd0b-4edc-837f-ca034b39f93a>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/2b18e526-dd0b-4edc-837f-ca034b39f93a> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "2b18e526-dd0b-4edc-837f-ca034b39f93a";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1234".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/f4bc7213-a4dc-4459-a710-b3d45228ee96> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "f4bc7213-a4dc-4459-a710-b3d45228ee96";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/53d5442c-bfa4-48e9-9918-7a7a5e765ed1>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/0ffc52b6-d553-47ed-9766-364701202685>,
+                        <http://data.lblod.info/id/contact-punten/1884ea38-022c-469f-8071-0d0568f320f8>.
+
+      <http://data.lblod.info/id/contact-punten/0ffc52b6-d553-47ed-9766-364701202685> a <http://schema.org/ContactPoint>;
+        mu:uuid "0ffc52b6-d553-47ed-9766-364701202685";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/1884ea38-022c-469f-8071-0d0568f320f8> a <http://schema.org/ContactPoint>;
+        mu:uuid "1884ea38-022c-469f-8071-0d0568f320f8";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/53d5442c-bfa4-48e9-9918-7a7a5e765ed1> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "53d5442c-bfa4-48e9-9918-7a7a5e765ed1".
+
+      <http://data.lblod.info/id/bestuurseenheden/eed6ef4fd7723fca33613bb9c9570825be3f8e50c32ce9456ded3d54bc624370> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "eed6ef4fd7723fca33613bb9c9570825be3f8e50c32ce9456ded3d54bc624370";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Brugge: Brugge";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/2345ca43-ecbd-4fc5-acdc-5196ca900bd5>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/f4bc7213-a4dc-4459-a710-b3d45228ee96> .
+    
+
+      <http://data.lblod.info/id/identificatoren/00573318-e13a-476e-a323-eb6dc30ebbf7> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "00573318-e13a-476e-a323-eb6dc30ebbf7";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/aad29980-bd3c-4e66-9615-5d4dcdc4ecc7>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/aad29980-bd3c-4e66-9615-5d4dcdc4ecc7> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "aad29980-bd3c-4e66-9615-5d4dcdc4ecc7";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1236".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/9d4e3319-85f2-4322-b3a6-53189cb02b2b> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "9d4e3319-85f2-4322-b3a6-53189cb02b2b";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/95ed4881-1437-47f5-8262-2494e3996200>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/656e6949-4934-4b9b-a47d-9905da206721>,
+                        <http://data.lblod.info/id/contact-punten/4237ce09-8993-426f-9770-df9b55915ecc>.
+
+      <http://data.lblod.info/id/contact-punten/656e6949-4934-4b9b-a47d-9905da206721> a <http://schema.org/ContactPoint>;
+        mu:uuid "656e6949-4934-4b9b-a47d-9905da206721";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/4237ce09-8993-426f-9770-df9b55915ecc> a <http://schema.org/ContactPoint>;
+        mu:uuid "4237ce09-8993-426f-9770-df9b55915ecc";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/95ed4881-1437-47f5-8262-2494e3996200> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "95ed4881-1437-47f5-8262-2494e3996200".
+
+      <http://data.lblod.info/id/bestuurseenheden/7e526f7f2d12f55a06620b512401826b6855ed478ff0693e04fba59cabba3c4d> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "7e526f7f2d12f55a06620b512401826b6855ed478ff0693e04fba59cabba3c4d";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Buggenhout/Lebbeke: Buggenhout en Lebbeke";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/00573318-e13a-476e-a323-eb6dc30ebbf7>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/9d4e3319-85f2-4322-b3a6-53189cb02b2b> .
+    
+
+      <http://data.lblod.info/id/identificatoren/ab096187-c15e-4a4d-a5e6-2e6f02e52caf> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "ab096187-c15e-4a4d-a5e6-2e6f02e52caf";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/546a904c-d2fa-4712-b94f-7cdf556154bf>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/546a904c-d2fa-4712-b94f-7cdf556154bf> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "546a904c-d2fa-4712-b94f-7cdf556154bf";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1237".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/1eb5b616-66ec-42d5-af83-5adcaeb0c013> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "1eb5b616-66ec-42d5-af83-5adcaeb0c013";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/1bcfb83d-d791-4a4c-a195-852eb84f1127>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/fa2c7c4f-deae-4f91-a867-d8a702f4dc9f>,
+                        <http://data.lblod.info/id/contact-punten/c629ce9e-74fe-4ae1-8c70-c95f7dc1ab76>.
+
+      <http://data.lblod.info/id/contact-punten/fa2c7c4f-deae-4f91-a867-d8a702f4dc9f> a <http://schema.org/ContactPoint>;
+        mu:uuid "fa2c7c4f-deae-4f91-a867-d8a702f4dc9f";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/c629ce9e-74fe-4ae1-8c70-c95f7dc1ab76> a <http://schema.org/ContactPoint>;
+        mu:uuid "c629ce9e-74fe-4ae1-8c70-c95f7dc1ab76";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/1bcfb83d-d791-4a4c-a195-852eb84f1127> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "1bcfb83d-d791-4a4c-a195-852eb84f1127".
+
+      <http://data.lblod.info/id/bestuurseenheden/165a9a64a6b84a278806b11c3f760f48198990168f591cf7a7462beb0f2cb16b> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "165a9a64a6b84a278806b11c3f760f48198990168f591cf7a7462beb0f2cb16b";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Damme/Knokke-Heist: Damme en Knokke-Heist";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/ab096187-c15e-4a4d-a5e6-2e6f02e52caf>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/1eb5b616-66ec-42d5-af83-5adcaeb0c013> .
+    
+
+      <http://data.lblod.info/id/identificatoren/045943ab-bd00-4dff-bce4-9c62d36bfc01> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "045943ab-bd00-4dff-bce4-9c62d36bfc01";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/06e822ec-767f-40c6-afad-e10026f1fb53>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/06e822ec-767f-40c6-afad-e10026f1fb53> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "06e822ec-767f-40c6-afad-e10026f1fb53";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1238".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/e5fa1bbf-45ee-46de-ae16-32080e874abd> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "e5fa1bbf-45ee-46de-ae16-32080e874abd";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/ea0b857c-3b07-4af1-b7eb-5c0888b45317>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/abcc6d43-4ec3-497d-a63c-27b8af775d30>,
+                        <http://data.lblod.info/id/contact-punten/19257230-08ac-483b-a872-043eea4545c0>.
+
+      <http://data.lblod.info/id/contact-punten/abcc6d43-4ec3-497d-a63c-27b8af775d30> a <http://schema.org/ContactPoint>;
+        mu:uuid "abcc6d43-4ec3-497d-a63c-27b8af775d30";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/19257230-08ac-483b-a872-043eea4545c0> a <http://schema.org/ContactPoint>;
+        mu:uuid "19257230-08ac-483b-a872-043eea4545c0";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/ea0b857c-3b07-4af1-b7eb-5c0888b45317> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "ea0b857c-3b07-4af1-b7eb-5c0888b45317".
+
+      <http://data.lblod.info/id/bestuurseenheden/68ad1301fbb5f209b4ef0fe2b11e77c7bea6011f5e28f8f6875597a7b08f0f1e> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "68ad1301fbb5f209b4ef0fe2b11e77c7bea6011f5e28f8f6875597a7b08f0f1e";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Westkust: De Panne, Koksijde en Nieuwpoort";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/045943ab-bd00-4dff-bce4-9c62d36bfc01>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/e5fa1bbf-45ee-46de-ae16-32080e874abd> .
+    
+
+      <http://data.lblod.info/id/identificatoren/49808520-f11a-467f-99c3-cbb2439218b5> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "49808520-f11a-467f-99c3-cbb2439218b5";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/d48c48db-8664-437d-8008-e8a03271c667>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/d48c48db-8664-437d-8008-e8a03271c667> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "d48c48db-8664-437d-8008-e8a03271c667";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1239".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/945175dc-1f8a-4aca-8843-6ea9925aea4d> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "945175dc-1f8a-4aca-8843-6ea9925aea4d";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/fb29edd3-4d51-4d3d-935a-2b7e42f4a6f7>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/38ce99a5-c307-48c1-be52-d48672a1683e>,
+                        <http://data.lblod.info/id/contact-punten/e860a25a-f3b4-4ae8-b79e-6b99160688b3>.
+
+      <http://data.lblod.info/id/contact-punten/38ce99a5-c307-48c1-be52-d48672a1683e> a <http://schema.org/ContactPoint>;
+        mu:uuid "38ce99a5-c307-48c1-be52-d48672a1683e";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/e860a25a-f3b4-4ae8-b79e-6b99160688b3> a <http://schema.org/ContactPoint>;
+        mu:uuid "e860a25a-f3b4-4ae8-b79e-6b99160688b3";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/fb29edd3-4d51-4d3d-935a-2b7e42f4a6f7> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "fb29edd3-4d51-4d3d-935a-2b7e42f4a6f7".
+
+      <http://data.lblod.info/id/bestuurseenheden/c16d166294750ae2c48acae9855a49cd3280a3597c0d8f3257021c68fdede345> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "c16d166294750ae2c48acae9855a49cd3280a3597c0d8f3257021c68fdede345";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Schelde-Leie: De Pinte, Gavere, Nazareth en Sint-Martens-Latem";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/49808520-f11a-467f-99c3-cbb2439218b5>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/945175dc-1f8a-4aca-8843-6ea9925aea4d> .
+    
+
+      <http://data.lblod.info/id/identificatoren/4a4cb3aa-b395-4255-830b-105db5634ce1> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "4a4cb3aa-b395-4255-830b-105db5634ce1";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/35c3f1f2-f8dd-4c4e-8156-b61e6769bf81>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/35c3f1f2-f8dd-4c4e-8156-b61e6769bf81> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "35c3f1f2-f8dd-4c4e-8156-b61e6769bf81";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1240".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/3dd1dfbb-bf21-469b-984a-c0d100dd612d> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "3dd1dfbb-bf21-469b-984a-c0d100dd612d";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/b9c40a08-a358-4487-b4f0-e9a2ce671cb1>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/4fb81dd9-b13d-423e-af29-c4ffdfa05190>,
+                        <http://data.lblod.info/id/contact-punten/1dff4037-3328-4c67-8fbd-1d390597b0a2>.
+
+      <http://data.lblod.info/id/contact-punten/4fb81dd9-b13d-423e-af29-c4ffdfa05190> a <http://schema.org/ContactPoint>;
+        mu:uuid "4fb81dd9-b13d-423e-af29-c4ffdfa05190";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/1dff4037-3328-4c67-8fbd-1d390597b0a2> a <http://schema.org/ContactPoint>;
+        mu:uuid "1dff4037-3328-4c67-8fbd-1d390597b0a2";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/b9c40a08-a358-4487-b4f0-e9a2ce671cb1> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "b9c40a08-a358-4487-b4f0-e9a2ce671cb1".
+
+      <http://data.lblod.info/id/bestuurseenheden/479036ca47b011e16fefafbe4d3512a44c564804dc26d331ce4dcbe0fa3366d2> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "479036ca47b011e16fefafbe4d3512a44c564804dc26d331ce4dcbe0fa3366d2";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Gavers: Deerlijk en Harelbeke";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/4a4cb3aa-b395-4255-830b-105db5634ce1>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/3dd1dfbb-bf21-469b-984a-c0d100dd612d> .
+    
+
+      <http://data.lblod.info/id/identificatoren/5ca22452-4c6a-4a59-be2f-d59f49c0dc2b> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "5ca22452-4c6a-4a59-be2f-d59f49c0dc2b";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/b83a836f-d0c0-40c6-9b72-21eeeff3b04e>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/b83a836f-d0c0-40c6-9b72-21eeeff3b04e> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "b83a836f-d0c0-40c6-9b72-21eeeff3b04e";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1241".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/07edc897-59cd-4051-a960-16df6036b83f> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "07edc897-59cd-4051-a960-16df6036b83f";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/74af20b2-de21-447d-93de-3cd084f3bbb1>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/16be76b3-4abe-4b63-a777-a368b7d6808a>,
+                        <http://data.lblod.info/id/contact-punten/f21debcc-65ea-4486-aba0-a05b2ae6b26d>.
+
+      <http://data.lblod.info/id/contact-punten/16be76b3-4abe-4b63-a777-a368b7d6808a> a <http://schema.org/ContactPoint>;
+        mu:uuid "16be76b3-4abe-4b63-a777-a368b7d6808a";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/f21debcc-65ea-4486-aba0-a05b2ae6b26d> a <http://schema.org/ContactPoint>;
+        mu:uuid "f21debcc-65ea-4486-aba0-a05b2ae6b26d";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/74af20b2-de21-447d-93de-3cd084f3bbb1> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "74af20b2-de21-447d-93de-3cd084f3bbb1".
+
+      <http://data.lblod.info/id/bestuurseenheden/19c1183ad20b9b4023da2eb7d1ab3eb5dda64558e050c8198abf9714463362ff> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "19c1183ad20b9b4023da2eb7d1ab3eb5dda64558e050c8198abf9714463362ff";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Deinze/Zulte";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/5ca22452-4c6a-4a59-be2f-d59f49c0dc2b>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/07edc897-59cd-4051-a960-16df6036b83f> .
+    
+
+      <http://data.lblod.info/id/identificatoren/15fa1a42-97c2-476b-a2a6-2b596574af95> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "15fa1a42-97c2-476b-a2a6-2b596574af95";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/214fe291-6c57-4fe6-820a-2cc1624a8d8b>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/214fe291-6c57-4fe6-820a-2cc1624a8d8b> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "214fe291-6c57-4fe6-820a-2cc1624a8d8b";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1242".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/c764b8cb-a0f8-45da-92ed-bbbfa5a97da2> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "c764b8cb-a0f8-45da-92ed-bbbfa5a97da2";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/00014b53-4ce4-46af-a18c-3501a4b58839>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/f9b47a97-33ba-4f5a-8b56-47261774155e>,
+                        <http://data.lblod.info/id/contact-punten/ae9a7683-759c-4d3b-8617-394e009cdc36>.
+
+      <http://data.lblod.info/id/contact-punten/f9b47a97-33ba-4f5a-8b56-47261774155e> a <http://schema.org/ContactPoint>;
+        mu:uuid "f9b47a97-33ba-4f5a-8b56-47261774155e";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/ae9a7683-759c-4d3b-8617-394e009cdc36> a <http://schema.org/ContactPoint>;
+        mu:uuid "ae9a7683-759c-4d3b-8617-394e009cdc36";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/00014b53-4ce4-46af-a18c-3501a4b58839> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "00014b53-4ce4-46af-a18c-3501a4b58839".
+
+      <http://data.lblod.info/id/bestuurseenheden/c5726151c11e3ec6dd94a158ead5e9bd9e4a7307ab76e4f64da20fc526d481aa> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "c5726151c11e3ec6dd94a158ead5e9bd9e4a7307ab76e4f64da20fc526d481aa";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Denderleeuw/Haaltert: Denderleeuw en Haaltert";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/15fa1a42-97c2-476b-a2a6-2b596574af95>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/c764b8cb-a0f8-45da-92ed-bbbfa5a97da2> .
+    
+
+      <http://data.lblod.info/id/identificatoren/f26b64af-39a6-44da-b5c2-774e042485ac> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "f26b64af-39a6-44da-b5c2-774e042485ac";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/eb9909e4-f798-4f87-a952-39609e4469f6>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/eb9909e4-f798-4f87-a952-39609e4469f6> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "eb9909e4-f798-4f87-a952-39609e4469f6";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1243".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/a70d9d48-0dec-4062-aa59-ffec8edf25f2> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "a70d9d48-0dec-4062-aa59-ffec8edf25f2";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/ba9851aa-ea87-4325-aaa5-f72726c0e1bc>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/b55b5e54-9217-4e36-a1a0-025d7c3c78be>,
+                        <http://data.lblod.info/id/contact-punten/7ecf7e93-84f3-4e18-94c4-bf51191e0a91>.
+
+      <http://data.lblod.info/id/contact-punten/b55b5e54-9217-4e36-a1a0-025d7c3c78be> a <http://schema.org/ContactPoint>;
+        mu:uuid "b55b5e54-9217-4e36-a1a0-025d7c3c78be";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/7ecf7e93-84f3-4e18-94c4-bf51191e0a91> a <http://schema.org/ContactPoint>;
+        mu:uuid "7ecf7e93-84f3-4e18-94c4-bf51191e0a91";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/ba9851aa-ea87-4325-aaa5-f72726c0e1bc> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "ba9851aa-ea87-4325-aaa5-f72726c0e1bc".
+
+      <http://data.lblod.info/id/bestuurseenheden/67b25dc29ad301f607aed564241d318de74be7dc1ec15202a67111d7a86becf9> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "67b25dc29ad301f607aed564241d318de74be7dc1ec15202a67111d7a86becf9";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Dendermonde: Dendermonde";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/f26b64af-39a6-44da-b5c2-774e042485ac>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/a70d9d48-0dec-4062-aa59-ffec8edf25f2> .
+    
+
+      <http://data.lblod.info/id/identificatoren/a0218465-68d4-4349-afca-ee452fa8199b> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "a0218465-68d4-4349-afca-ee452fa8199b";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/1ee1980c-dbb0-449d-b47c-d37eca3eed79>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/1ee1980c-dbb0-449d-b47c-d37eca3eed79> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "1ee1980c-dbb0-449d-b47c-d37eca3eed79";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1244".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/de0bc9c2-5ba4-49a2-a4e6-71955ee8402b> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "de0bc9c2-5ba4-49a2-a4e6-71955ee8402b";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/1d031dd7-b26a-40e5-b9b6-b8362ef5ebb3>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/a1470ed4-8e0c-4e80-b7d4-af5f38fc1286>,
+                        <http://data.lblod.info/id/contact-punten/ad8a707e-300d-404b-9d99-130b02df8bda>.
+
+      <http://data.lblod.info/id/contact-punten/a1470ed4-8e0c-4e80-b7d4-af5f38fc1286> a <http://schema.org/ContactPoint>;
+        mu:uuid "a1470ed4-8e0c-4e80-b7d4-af5f38fc1286";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/ad8a707e-300d-404b-9d99-130b02df8bda> a <http://schema.org/ContactPoint>;
+        mu:uuid "ad8a707e-300d-404b-9d99-130b02df8bda";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/1d031dd7-b26a-40e5-b9b6-b8362ef5ebb3> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "1d031dd7-b26a-40e5-b9b6-b8362ef5ebb3".
+
+      <http://data.lblod.info/id/bestuurseenheden/fa52110c7c3e70feab724980e2d991a97712a1deeeb25b168ef6de7b16de41ae> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "fa52110c7c3e70feab724980e2d991a97712a1deeeb25b168ef6de7b16de41ae";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ MIDOW: Meulebeke, Ingelmunster, Dentergem, Oostrozebeke en Wielsbeke";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/a0218465-68d4-4349-afca-ee452fa8199b>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/de0bc9c2-5ba4-49a2-a4e6-71955ee8402b> .
+    
+
+      <http://data.lblod.info/id/identificatoren/8f6d6f3f-d258-4058-bbf8-86d6a478d0c4> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "8f6d6f3f-d258-4058-bbf8-86d6a478d0c4";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/c69e20b1-ea47-4aa0-ba36-cd12efbe5af6>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/c69e20b1-ea47-4aa0-ba36-cd12efbe5af6> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "c69e20b1-ea47-4aa0-ba36-cd12efbe5af6";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1245".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/a0419a32-d3c1-439e-836b-8bacb299a591> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "a0419a32-d3c1-439e-836b-8bacb299a591";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/b4f0af2b-330f-4ae1-99cc-e9c0f4da8c46>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/56311896-7b7a-4ee7-bcc2-34d1b0b3c664>,
+                        <http://data.lblod.info/id/contact-punten/59bad3c0-b874-4345-adef-5bb050162326>.
+
+      <http://data.lblod.info/id/contact-punten/56311896-7b7a-4ee7-bcc2-34d1b0b3c664> a <http://schema.org/ContactPoint>;
+        mu:uuid "56311896-7b7a-4ee7-bcc2-34d1b0b3c664";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/59bad3c0-b874-4345-adef-5bb050162326> a <http://schema.org/ContactPoint>;
+        mu:uuid "59bad3c0-b874-4345-adef-5bb050162326";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/b4f0af2b-330f-4ae1-99cc-e9c0f4da8c46> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "b4f0af2b-330f-4ae1-99cc-e9c0f4da8c46".
+
+      <http://data.lblod.info/id/bestuurseenheden/9e2072f69e9c1ecd1af7f65a234f141ef6cfe36eb63b2758d54d1414618188ff> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "9e2072f69e9c1ecd1af7f65a234f141ef6cfe36eb63b2758d54d1414618188ff";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Diepenbeek/Hasselt/Zonhoven";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/8f6d6f3f-d258-4058-bbf8-86d6a478d0c4>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/a0419a32-d3c1-439e-836b-8bacb299a591> .
+    
+
+      <http://data.lblod.info/id/identificatoren/337bfbfe-6ee8-4dbd-93e2-61104ac46c18> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "337bfbfe-6ee8-4dbd-93e2-61104ac46c18";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/d0ae1a28-590f-4697-8384-4e77053c634b>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/d0ae1a28-590f-4697-8384-4e77053c634b> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "d0ae1a28-590f-4697-8384-4e77053c634b";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1246".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/2399aeac-a4e6-4a22-a9bd-b89b5d2d2eb8> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "2399aeac-a4e6-4a22-a9bd-b89b5d2d2eb8";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/03d64743-d288-4e87-90d5-b2fd8ff003ad>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/79d70539-7240-4421-8bc1-7423fd1215d1>,
+                        <http://data.lblod.info/id/contact-punten/7fbf8d33-84c4-4c8f-8d3a-cfcb62f4d7b9>.
+
+      <http://data.lblod.info/id/contact-punten/79d70539-7240-4421-8bc1-7423fd1215d1> a <http://schema.org/ContactPoint>;
+        mu:uuid "79d70539-7240-4421-8bc1-7423fd1215d1";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/7fbf8d33-84c4-4c8f-8d3a-cfcb62f4d7b9> a <http://schema.org/ContactPoint>;
+        mu:uuid "7fbf8d33-84c4-4c8f-8d3a-cfcb62f4d7b9";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/03d64743-d288-4e87-90d5-b2fd8ff003ad> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "03d64743-d288-4e87-90d5-b2fd8ff003ad".
+
+      <http://data.lblod.info/id/bestuurseenheden/41e3bb71cb1fe2763a64ce47ee758fbeb532fbd4348281f34a86a5f88dd71980> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "41e3bb71cb1fe2763a64ce47ee758fbeb532fbd4348281f34a86a5f88dd71980";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Demerdal DSZ: Diest en Scherpenheuvel-Zichem";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/337bfbfe-6ee8-4dbd-93e2-61104ac46c18>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/2399aeac-a4e6-4a22-a9bd-b89b5d2d2eb8> .
+    
+
+      <http://data.lblod.info/id/identificatoren/91c0af8b-7063-4f4f-9ab9-8fe3d5ba6048> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "91c0af8b-7063-4f4f-9ab9-8fe3d5ba6048";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/ed09cf49-b2b2-4d9a-88a2-a0c59fba588c>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/ed09cf49-b2b2-4d9a-88a2-a0c59fba588c> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "ed09cf49-b2b2-4d9a-88a2-a0c59fba588c";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1247".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/d2ea3d0c-9ce2-4f91-beb0-e4213dadb230> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "d2ea3d0c-9ce2-4f91-beb0-e4213dadb230";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/b2bc49d4-cab2-47d7-9b5f-fdaca8c5d02a>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/53a1f7ef-9653-4002-b1e8-ffdbdffe3b59>,
+                        <http://data.lblod.info/id/contact-punten/ef9b1cfb-5f6e-4f92-9b63-8cf07fdff858>.
+
+      <http://data.lblod.info/id/contact-punten/53a1f7ef-9653-4002-b1e8-ffdbdffe3b59> a <http://schema.org/ContactPoint>;
+        mu:uuid "53a1f7ef-9653-4002-b1e8-ffdbdffe3b59";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/ef9b1cfb-5f6e-4f92-9b63-8cf07fdff858> a <http://schema.org/ContactPoint>;
+        mu:uuid "ef9b1cfb-5f6e-4f92-9b63-8cf07fdff858";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/b2bc49d4-cab2-47d7-9b5f-fdaca8c5d02a> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "b2bc49d4-cab2-47d7-9b5f-fdaca8c5d02a".
+
+      <http://data.lblod.info/id/bestuurseenheden/95871bddebd4ad93db54cb1b40d41af29f7ce08f0b59698b0540be129a9a3433> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "95871bddebd4ad93db54cb1b40d41af29f7ce08f0b59698b0540be129a9a3433";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Polder: Diksmuide, Houthulst, Koekelare en Kortemark";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/91c0af8b-7063-4f4f-9ab9-8fe3d5ba6048>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/d2ea3d0c-9ce2-4f91-beb0-e4213dadb230> .
+    
+
+      <http://data.lblod.info/id/identificatoren/4a6aa9bd-4468-4331-bbba-3a9aa06c114e> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "4a6aa9bd-4468-4331-bbba-3a9aa06c114e";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/47517fde-55f1-4141-b192-bb3729e40da2>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/47517fde-55f1-4141-b192-bb3729e40da2> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "47517fde-55f1-4141-b192-bb3729e40da2";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1248".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/71995ac4-7a27-4237-8644-95b329bb6680> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "71995ac4-7a27-4237-8644-95b329bb6680";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/512f8d8d-0c12-4f2a-a637-4e634d7aa11c>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/1fdf4924-eb29-4d5c-ac4e-a9b8c0efe138>,
+                        <http://data.lblod.info/id/contact-punten/078fa61d-aa93-4656-836b-979ebabe3c82>.
+
+      <http://data.lblod.info/id/contact-punten/1fdf4924-eb29-4d5c-ac4e-a9b8c0efe138> a <http://schema.org/ContactPoint>;
+        mu:uuid "1fdf4924-eb29-4d5c-ac4e-a9b8c0efe138";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/078fa61d-aa93-4656-836b-979ebabe3c82> a <http://schema.org/ContactPoint>;
+        mu:uuid "078fa61d-aa93-4656-836b-979ebabe3c82";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/512f8d8d-0c12-4f2a-a637-4e634d7aa11c> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "512f8d8d-0c12-4f2a-a637-4e634d7aa11c".
+
+      <http://data.lblod.info/id/bestuurseenheden/e65a70ecf702fb23f1447e234eab584fe788e9618fb7d52cd1d562718207b499> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "e65a70ecf702fb23f1447e234eab584fe788e9618fb7d52cd1d562718207b499";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Dilbeek: Dilbeek";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/4a6aa9bd-4468-4331-bbba-3a9aa06c114e>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/71995ac4-7a27-4237-8644-95b329bb6680> .
+    
+
+      <http://data.lblod.info/id/identificatoren/0cd9d1cf-8948-4e3f-99d7-3098f6fed881> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "0cd9d1cf-8948-4e3f-99d7-3098f6fed881";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/86436cef-bf47-4e1b-998e-8593aee43b61>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/86436cef-bf47-4e1b-998e-8593aee43b61> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "86436cef-bf47-4e1b-998e-8593aee43b61";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1249".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/b8f62d1d-fd10-4dab-9578-28ecd8a28f0b> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "b8f62d1d-fd10-4dab-9578-28ecd8a28f0b";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/ae4db581-32c4-44f4-ac80-6b165311550f>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/998ddb97-49d9-4ce8-9ead-3eec1c6e8ea4>,
+                        <http://data.lblod.info/id/contact-punten/87b82af7-d841-4b30-af1f-7a1e36d9fd80>.
+
+      <http://data.lblod.info/id/contact-punten/998ddb97-49d9-4ce8-9ead-3eec1c6e8ea4> a <http://schema.org/ContactPoint>;
+        mu:uuid "998ddb97-49d9-4ce8-9ead-3eec1c6e8ea4";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/87b82af7-d841-4b30-af1f-7a1e36d9fd80> a <http://schema.org/ContactPoint>;
+        mu:uuid "87b82af7-d841-4b30-af1f-7a1e36d9fd80";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/ae4db581-32c4-44f4-ac80-6b165311550f> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "ae4db581-32c4-44f4-ac80-6b165311550f".
+
+      <http://data.lblod.info/id/bestuurseenheden/97028faf77fd95eb5016a13c19f3a3a8ccf97c6c937398ba96976e52d171dbd8> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "97028faf77fd95eb5016a13c19f3a3a8ccf97c6c937398ba96976e52d171dbd8";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Maasland: Dilsen-Stokkem en Maaseik";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/0cd9d1cf-8948-4e3f-99d7-3098f6fed881>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/b8f62d1d-fd10-4dab-9578-28ecd8a28f0b> .
+    
+
+      <http://data.lblod.info/id/identificatoren/dbbcf804-5a49-4c9b-9980-8fe7734c0f5f> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "dbbcf804-5a49-4c9b-9980-8fe7734c0f5f";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/73f45f8f-7aab-4973-8ab9-a2e974d00ae8>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/73f45f8f-7aab-4973-8ab9-a2e974d00ae8> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "73f45f8f-7aab-4973-8ab9-a2e974d00ae8";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1250".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/4b9a9328-8868-4e3d-ae92-89c585c40406> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "4b9a9328-8868-4e3d-ae92-89c585c40406";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/a7f54c67-c629-4af4-8243-8c29b4f8d1d8>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/3211ce0a-d885-4de2-8239-e2c58e3fa7b0>,
+                        <http://data.lblod.info/id/contact-punten/6f764f57-5d58-4a76-8b11-38388f9b1e53>.
+
+      <http://data.lblod.info/id/contact-punten/3211ce0a-d885-4de2-8239-e2c58e3fa7b0> a <http://schema.org/ContactPoint>;
+        mu:uuid "3211ce0a-d885-4de2-8239-e2c58e3fa7b0";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/6f764f57-5d58-4a76-8b11-38388f9b1e53> a <http://schema.org/ContactPoint>;
+        mu:uuid "6f764f57-5d58-4a76-8b11-38388f9b1e53";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/a7f54c67-c629-4af4-8243-8c29b4f8d1d8> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "a7f54c67-c629-4af4-8243-8c29b4f8d1d8".
+
+      <http://data.lblod.info/id/bestuurseenheden/a691d36ff95b67005d30d5fb89594dab69ec7fdbf975ffdcd36ef9bb39efb06d> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "a691d36ff95b67005d30d5fb89594dab69ec7fdbf975ffdcd36ef9bb39efb06d";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Rode: Drogenbos, Linkebeek en Sint-Genesius-Rode";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/dbbcf804-5a49-4c9b-9980-8fe7734c0f5f>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/4b9a9328-8868-4e3d-ae92-89c585c40406> .
+    
+
+      <http://data.lblod.info/id/identificatoren/f333d9c5-44f0-4e75-bf10-9b2ee28f275c> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "f333d9c5-44f0-4e75-bf10-9b2ee28f275c";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/f1da5fd0-26cb-4930-994f-52832b88c4a4>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/f1da5fd0-26cb-4930-994f-52832b88c4a4> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "f1da5fd0-26cb-4930-994f-52832b88c4a4";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1251".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/8e165e0c-1d45-4f97-9fd6-132c9d50be18> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "8e165e0c-1d45-4f97-9fd6-132c9d50be18";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/1f2bdc8b-02e3-416e-ae45-681248397526>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/55226d9f-436e-4397-ae88-eb00725d163a>,
+                        <http://data.lblod.info/id/contact-punten/0f3f065b-e38b-4ced-9119-a57d9b284551>.
+
+      <http://data.lblod.info/id/contact-punten/55226d9f-436e-4397-ae88-eb00725d163a> a <http://schema.org/ContactPoint>;
+        mu:uuid "55226d9f-436e-4397-ae88-eb00725d163a";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/0f3f065b-e38b-4ced-9119-a57d9b284551> a <http://schema.org/ContactPoint>;
+        mu:uuid "0f3f065b-e38b-4ced-9119-a57d9b284551";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/1f2bdc8b-02e3-416e-ae45-681248397526> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "1f2bdc8b-02e3-416e-ae45-681248397526".
+
+      <http://data.lblod.info/id/bestuurseenheden/d8d1b52a9170168ad481f2495652e1b9753aea23385f79710abd86549f1373fa> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "d8d1b52a9170168ad481f2495652e1b9753aea23385f79710abd86549f1373fa";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Meetjesland-Centrum: Eeklo, Kaprijke en Sint-Laureins";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/f333d9c5-44f0-4e75-bf10-9b2ee28f275c>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/8e165e0c-1d45-4f97-9fd6-132c9d50be18> .
+    
+
+      <http://data.lblod.info/id/identificatoren/dbb6944c-a4f8-41f3-bab4-c9003d0410bc> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "dbb6944c-a4f8-41f3-bab4-c9003d0410bc";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/58ef0bb9-ff89-4696-a03b-4c60a64e8e4a>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/58ef0bb9-ff89-4696-a03b-4c60a64e8e4a> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "58ef0bb9-ff89-4696-a03b-4c60a64e8e4a";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1252".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/769c40f9-6457-4b33-a823-da587e4f03b1> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "769c40f9-6457-4b33-a823-da587e4f03b1";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/bcdbefad-c4b9-4846-95bd-a2a900c8d4ac>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/2d046058-d036-41b1-be7e-6724f27f199a>,
+                        <http://data.lblod.info/id/contact-punten/1f917667-f849-481c-a5d2-6a3501fde18a>.
+
+      <http://data.lblod.info/id/contact-punten/2d046058-d036-41b1-be7e-6724f27f199a> a <http://schema.org/ContactPoint>;
+        mu:uuid "2d046058-d036-41b1-be7e-6724f27f199a";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/1f917667-f849-481c-a5d2-6a3501fde18a> a <http://schema.org/ContactPoint>;
+        mu:uuid "1f917667-f849-481c-a5d2-6a3501fde18a";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/bcdbefad-c4b9-4846-95bd-a2a900c8d4ac> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "bcdbefad-c4b9-4846-95bd-a2a900c8d4ac".
+
+      <http://data.lblod.info/id/bestuurseenheden/622fa725ba8455b01817c8e48974edeab56607018fce5c1cb3694306d3e7005c> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "622fa725ba8455b01817c8e48974edeab56607018fce5c1cb3694306d3e7005c";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Erpe-Mere/Lede: Erpe-Mere en Lede";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/dbb6944c-a4f8-41f3-bab4-c9003d0410bc>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/769c40f9-6457-4b33-a823-da587e4f03b1> .
+    
+
+      <http://data.lblod.info/id/identificatoren/3668fe27-2e9b-42eb-9711-d146d5bb944b> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "3668fe27-2e9b-42eb-9711-d146d5bb944b";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/07b2a0df-643e-43a8-8d4a-86c791cb5252>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/07b2a0df-643e-43a8-8d4a-86c791cb5252> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "07b2a0df-643e-43a8-8d4a-86c791cb5252";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1253".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/d349f252-63f2-4419-ae6e-43201ff10ca2> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "d349f252-63f2-4419-ae6e-43201ff10ca2";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/ac4bf932-ddeb-45c7-846f-a82bfbabcb28>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/53e7bd3b-29ed-4fa9-8a01-2c59798f61e5>,
+                        <http://data.lblod.info/id/contact-punten/542b35cc-d65f-4248-98f2-4551742f9269>.
+
+      <http://data.lblod.info/id/contact-punten/53e7bd3b-29ed-4fa9-8a01-2c59798f61e5> a <http://schema.org/ContactPoint>;
+        mu:uuid "53e7bd3b-29ed-4fa9-8a01-2c59798f61e5";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/542b35cc-d65f-4248-98f2-4551742f9269> a <http://schema.org/ContactPoint>;
+        mu:uuid "542b35cc-d65f-4248-98f2-4551742f9269";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/ac4bf932-ddeb-45c7-846f-a82bfbabcb28> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "ac4bf932-ddeb-45c7-846f-a82bfbabcb28".
+
+      <http://data.lblod.info/id/bestuurseenheden/4ffd00c0ba7ceab20db24832a4b9963112ed66914dcca05f3e5dc8b8b9d4479d> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "4ffd00c0ba7ceab20db24832a4b9963112ed66914dcca05f3e5dc8b8b9d4479d";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Grens: Essen, Kalmthout en Wuustwezel";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/3668fe27-2e9b-42eb-9711-d146d5bb944b>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/d349f252-63f2-4419-ae6e-43201ff10ca2> .
+    
+
+      <http://data.lblod.info/id/identificatoren/54dd7dbc-db43-4a8f-bffe-39eb59772e3b> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "54dd7dbc-db43-4a8f-bffe-39eb59772e3b";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/274b9f33-f9fa-49b9-ab1b-babc87a6ea7e>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/274b9f33-f9fa-49b9-ab1b-babc87a6ea7e> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "274b9f33-f9fa-49b9-ab1b-babc87a6ea7e";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1257".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/c209e90e-4b9b-4a58-bb49-fc75f7e8d187> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "c209e90e-4b9b-4a58-bb49-fc75f7e8d187";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/0232d20d-7954-4be0-a334-784f583291d0>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/b94fbb06-e9d1-4483-89ed-7fdab99b12ec>,
+                        <http://data.lblod.info/id/contact-punten/af4d96fb-5aac-4919-8249-cbf2fb6e601e>.
+
+      <http://data.lblod.info/id/contact-punten/b94fbb06-e9d1-4483-89ed-7fdab99b12ec> a <http://schema.org/ContactPoint>;
+        mu:uuid "b94fbb06-e9d1-4483-89ed-7fdab99b12ec";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/af4d96fb-5aac-4919-8249-cbf2fb6e601e> a <http://schema.org/ContactPoint>;
+        mu:uuid "af4d96fb-5aac-4919-8249-cbf2fb6e601e";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/0232d20d-7954-4be0-a334-784f583291d0> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "0232d20d-7954-4be0-a334-784f583291d0".
+
+      <http://data.lblod.info/id/bestuurseenheden/7271a57b8249b4dd3175f50ea96c66ff536eff057c6bc0acfe40281e2a91ddc2> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "7271a57b8249b4dd3175f50ea96c66ff536eff057c6bc0acfe40281e2a91ddc2";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Geel-Laakdal-Meerhout: Geel, Laakdal en Meerhout";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/54dd7dbc-db43-4a8f-bffe-39eb59772e3b>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/c209e90e-4b9b-4a58-bb49-fc75f7e8d187> .
+    
+
+      <http://data.lblod.info/id/identificatoren/fb80b349-f20d-41c8-923e-274db27ed56e> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "fb80b349-f20d-41c8-923e-274db27ed56e";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/29488c5e-594a-4c4f-a8ea-4e15b6b75571>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/29488c5e-594a-4c4f-a8ea-4e15b6b75571> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "29488c5e-594a-4c4f-a8ea-4e15b6b75571";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1258".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/cbaf9c03-c3b2-4dcb-b021-da0360617208> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "cbaf9c03-c3b2-4dcb-b021-da0360617208";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/35e200af-ca1b-44d1-818a-d9a563bbfa84>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/ef30ae19-5038-475c-9a77-f54557fd1f8c>,
+                        <http://data.lblod.info/id/contact-punten/bfa58f3f-7f27-4c90-925f-a5cfb94fde41>.
+
+      <http://data.lblod.info/id/contact-punten/ef30ae19-5038-475c-9a77-f54557fd1f8c> a <http://schema.org/ContactPoint>;
+        mu:uuid "ef30ae19-5038-475c-9a77-f54557fd1f8c";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/bfa58f3f-7f27-4c90-925f-a5cfb94fde41> a <http://schema.org/ContactPoint>;
+        mu:uuid "bfa58f3f-7f27-4c90-925f-a5cfb94fde41";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/35e200af-ca1b-44d1-818a-d9a563bbfa84> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "35e200af-ca1b-44d1-818a-d9a563bbfa84".
+
+      <http://data.lblod.info/id/bestuurseenheden/d39a7017044dcf082194095e3b3ec72de112bd47528e32125c697be1aa3c10cd> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "d39a7017044dcf082194095e3b3ec72de112bd47528e32125c697be1aa3c10cd";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Genk/As/Opglabeek/Zutendaal";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/fb80b349-f20d-41c8-923e-274db27ed56e>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/cbaf9c03-c3b2-4dcb-b021-da0360617208> .
+    
+
+      <http://data.lblod.info/id/identificatoren/aec93828-7e6c-4ef8-b674-11f3ec3d6150> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "aec93828-7e6c-4ef8-b674-11f3ec3d6150";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/3188e56e-4610-4475-84fd-38d6cf18630a>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/3188e56e-4610-4475-84fd-38d6cf18630a> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "3188e56e-4610-4475-84fd-38d6cf18630a";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1259".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/7664d376-38d2-4069-860d-f96d597e67ee> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "7664d376-38d2-4069-860d-f96d597e67ee";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/676858ff-4991-4151-8a86-70793ef10747>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/94a88a7b-201d-4beb-9f17-3b461056970a>,
+                        <http://data.lblod.info/id/contact-punten/b0f8f496-b9c7-4714-8cfe-d71ecbace01b>.
+
+      <http://data.lblod.info/id/contact-punten/94a88a7b-201d-4beb-9f17-3b461056970a> a <http://schema.org/ContactPoint>;
+        mu:uuid "94a88a7b-201d-4beb-9f17-3b461056970a";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/b0f8f496-b9c7-4714-8cfe-d71ecbace01b> a <http://schema.org/ContactPoint>;
+        mu:uuid "b0f8f496-b9c7-4714-8cfe-d71ecbace01b";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/676858ff-4991-4151-8a86-70793ef10747> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "676858ff-4991-4151-8a86-70793ef10747".
+
+      <http://data.lblod.info/id/bestuurseenheden/5187962dfd40789953d4fbde3634751ee90b48b17147c585ccf4f2ac1ee72fd3> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "5187962dfd40789953d4fbde3634751ee90b48b17147c585ccf4f2ac1ee72fd3";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Gent: Gent";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/aec93828-7e6c-4ef8-b674-11f3ec3d6150>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/7664d376-38d2-4069-860d-f96d597e67ee> .
+    
+
+      <http://data.lblod.info/id/identificatoren/a07b7bd3-83ea-496f-9a3d-fbc0065de824> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "a07b7bd3-83ea-496f-9a3d-fbc0065de824";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/6ecae14a-667c-4f25-86bb-1dc5f1f47a75>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/6ecae14a-667c-4f25-86bb-1dc5f1f47a75> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "6ecae14a-667c-4f25-86bb-1dc5f1f47a75";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1260".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/ab863c18-4779-4c06-ac3a-e11b1f7dab3c> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "ab863c18-4779-4c06-ac3a-e11b1f7dab3c";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/d4669842-edf9-492b-9578-1f36df350eeb>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/dead70b1-2dcd-436d-a629-e22272bf0106>,
+                        <http://data.lblod.info/id/contact-punten/2e6699af-0fea-4a9f-b9c2-485fc8ebbab7>.
+
+      <http://data.lblod.info/id/contact-punten/dead70b1-2dcd-436d-a629-e22272bf0106> a <http://schema.org/ContactPoint>;
+        mu:uuid "dead70b1-2dcd-436d-a629-e22272bf0106";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/2e6699af-0fea-4a9f-b9c2-485fc8ebbab7> a <http://schema.org/ContactPoint>;
+        mu:uuid "2e6699af-0fea-4a9f-b9c2-485fc8ebbab7";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/d4669842-edf9-492b-9578-1f36df350eeb> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "d4669842-edf9-492b-9578-1f36df350eeb".
+
+      <http://data.lblod.info/id/bestuurseenheden/25572d6c63bc386d742bbb6ac0d8ddc739dc0599e156c6eac68aca492390840e> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "25572d6c63bc386d742bbb6ac0d8ddc739dc0599e156c6eac68aca492390840e";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Geraardsbergen/Lierde: Geraardsbergen en Lierde";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/a07b7bd3-83ea-496f-9a3d-fbc0065de824>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/ab863c18-4779-4c06-ac3a-e11b1f7dab3c> .
+    
+
+      <http://data.lblod.info/id/identificatoren/f2d46bde-2bde-4f53-92af-743270e1ebe5> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "f2d46bde-2bde-4f53-92af-743270e1ebe5";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/454397bf-af58-4c58-8511-9723ab0fd24c>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/454397bf-af58-4c58-8511-9723ab0fd24c> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "454397bf-af58-4c58-8511-9723ab0fd24c";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1261".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/bb12b359-caa0-4d25-a1a0-3d6ace5d8f16> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "bb12b359-caa0-4d25-a1a0-3d6ace5d8f16";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/31725383-3245-4e2b-8a73-238b446c06df>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/4ce55848-c1ec-4807-be46-361dad6fc542>,
+                        <http://data.lblod.info/id/contact-punten/2cce9721-1051-4cce-831f-95e0f1625b04>.
+
+      <http://data.lblod.info/id/contact-punten/4ce55848-c1ec-4807-be46-361dad6fc542> a <http://schema.org/ContactPoint>;
+        mu:uuid "4ce55848-c1ec-4807-be46-361dad6fc542";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/2cce9721-1051-4cce-831f-95e0f1625b04> a <http://schema.org/ContactPoint>;
+        mu:uuid "2cce9721-1051-4cce-831f-95e0f1625b04";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/31725383-3245-4e2b-8a73-238b446c06df> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "31725383-3245-4e2b-8a73-238b446c06df".
+
+      <http://data.lblod.info/id/bestuurseenheden/11feae29e6178a2b58ac73bb639360d58248e3e438f2201f219b95b58c6b4ef4> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "11feae29e6178a2b58ac73bb639360d58248e3e438f2201f219b95b58c6b4ef4";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Sint-Truiden/Gingelom/Nieuwerkerken: Sint-Truiden, Gingelom en Nieuwerkerken";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/f2d46bde-2bde-4f53-92af-743270e1ebe5>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/bb12b359-caa0-4d25-a1a0-3d6ace5d8f16> .
+    
+
+      <http://data.lblod.info/id/identificatoren/447d920e-f613-465b-a3db-06a43cff1e43> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "447d920e-f613-465b-a3db-06a43cff1e43";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/03973d62-ac9e-4407-a65b-8d1aec7f4d2a>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/03973d62-ac9e-4407-a65b-8d1aec7f4d2a> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "03973d62-ac9e-4407-a65b-8d1aec7f4d2a";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1262".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/53d98668-db2c-4471-8372-9859a77a5748> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "53d98668-db2c-4471-8372-9859a77a5748";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/e0d7ddc2-ce59-4f2c-a660-500e208bf78a>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/054cdf74-352f-4b52-80b3-72e5b82bb5d3>,
+                        <http://data.lblod.info/id/contact-punten/bf79f711-8983-4b7f-8344-a3b9be5e76e2>.
+
+      <http://data.lblod.info/id/contact-punten/054cdf74-352f-4b52-80b3-72e5b82bb5d3> a <http://schema.org/ContactPoint>;
+        mu:uuid "054cdf74-352f-4b52-80b3-72e5b82bb5d3";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/bf79f711-8983-4b7f-8344-a3b9be5e76e2> a <http://schema.org/ContactPoint>;
+        mu:uuid "bf79f711-8983-4b7f-8344-a3b9be5e76e2";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/e0d7ddc2-ce59-4f2c-a660-500e208bf78a> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "e0d7ddc2-ce59-4f2c-a660-500e208bf78a".
+
+      <http://data.lblod.info/id/bestuurseenheden/a32dc005ecbc001abd3338cdacb111895d3053b313654136ef1903035c10a53c> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "a32dc005ecbc001abd3338cdacb111895d3053b313654136ef1903035c10a53c";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Kouter: Gistel, Ichtegem, Jabbeke, Oudenburg en Torhout";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/447d920e-f613-465b-a3db-06a43cff1e43>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/53d98668-db2c-4471-8372-9859a77a5748> .
+    
+
+      <http://data.lblod.info/id/identificatoren/f476462f-fedc-4f6d-be05-b6e09a8b60ee> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "f476462f-fedc-4f6d-be05-b6e09a8b60ee";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/e6dbd6be-a822-4265-a88b-213097ed6379>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/e6dbd6be-a822-4265-a88b-213097ed6379> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "e6dbd6be-a822-4265-a88b-213097ed6379";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1263".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/41c0e8ed-a476-4477-8895-3f33ddfb1e55> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "41c0e8ed-a476-4477-8895-3f33ddfb1e55";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/eb0771db-f084-44ee-8158-8947fa83b739>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/61e86c2a-b638-460b-a363-5be61c6f917d>,
+                        <http://data.lblod.info/id/contact-punten/68fd6842-86f1-406d-ae6a-a1ff543c0ae6>.
+
+      <http://data.lblod.info/id/contact-punten/61e86c2a-b638-460b-a363-5be61c6f917d> a <http://schema.org/ContactPoint>;
+        mu:uuid "61e86c2a-b638-460b-a363-5be61c6f917d";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/68fd6842-86f1-406d-ae6a-a1ff543c0ae6> a <http://schema.org/ContactPoint>;
+        mu:uuid "68fd6842-86f1-406d-ae6a-a1ff543c0ae6";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/eb0771db-f084-44ee-8158-8947fa83b739> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "eb0771db-f084-44ee-8158-8947fa83b739".
+
+      <http://data.lblod.info/id/bestuurseenheden/5018524f9ceca4f9e21764f9e8e4e63d1ad6890c338c090d0dd074faccf1bfb2> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "5018524f9ceca4f9e21764f9e8e4e63d1ad6890c338c090d0dd074faccf1bfb2";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Grimbergen: Grimbergen";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/f476462f-fedc-4f6d-be05-b6e09a8b60ee>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/41c0e8ed-a476-4477-8895-3f33ddfb1e55> .
+    
+
+      <http://data.lblod.info/id/identificatoren/0638cc29-f839-458f-8584-e6a90a363fe1> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "0638cc29-f839-458f-8584-e6a90a363fe1";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/2165e5ce-ad35-4c79-b0b2-c8491add292d>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/2165e5ce-ad35-4c79-b0b2-c8491add292d> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "2165e5ce-ad35-4c79-b0b2-c8491add292d";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1264".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/8aca2c3c-5a0f-4228-a150-d3a5b7955780> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "8aca2c3c-5a0f-4228-a150-d3a5b7955780";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/835f696b-567d-4c45-8d6b-45ba13bdcc24>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/3315ce4f-3384-4cf2-874d-4584b80c73b3>,
+                        <http://data.lblod.info/id/contact-punten/6e1c155e-505d-4608-9d69-5e29042636ba>.
+
+      <http://data.lblod.info/id/contact-punten/3315ce4f-3384-4cf2-874d-4584b80c73b3> a <http://schema.org/ContactPoint>;
+        mu:uuid "3315ce4f-3384-4cf2-874d-4584b80c73b3";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/6e1c155e-505d-4608-9d69-5e29042636ba> a <http://schema.org/ContactPoint>;
+        mu:uuid "6e1c155e-505d-4608-9d69-5e29042636ba";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/835f696b-567d-4c45-8d6b-45ba13bdcc24> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "835f696b-567d-4c45-8d6b-45ba13bdcc24".
+
+      <http://data.lblod.info/id/bestuurseenheden/abca98258a8436dd7f74c633f0b60c7e50b407a1bb27777c102a1963f8843f8b> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "abca98258a8436dd7f74c633f0b60c7e50b407a1bb27777c102a1963f8843f8b";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Halen/Herk-De-Stad/Lummen";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/0638cc29-f839-458f-8584-e6a90a363fe1>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/8aca2c3c-5a0f-4228-a150-d3a5b7955780> .
+    
+
+      <http://data.lblod.info/id/identificatoren/3d0bf267-7855-41b2-b293-4efc9c6d0be2> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "3d0bf267-7855-41b2-b293-4efc9c6d0be2";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/16b8ea35-e8e2-41f7-b96c-3f1efe225b26>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/16b8ea35-e8e2-41f7-b96c-3f1efe225b26> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "16b8ea35-e8e2-41f7-b96c-3f1efe225b26";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1265".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/54ca502f-c84c-42eb-bd8d-14e03b3b7169> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "54ca502f-c84c-42eb-bd8d-14e03b3b7169";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/57d0dfd7-b232-4e37-b7b7-6634841d5955>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/ffaf2fa8-5e02-42f6-bc22-0e43fd19f2c8>,
+                        <http://data.lblod.info/id/contact-punten/14a79c6f-769b-4046-b3cc-0772923de784>.
+
+      <http://data.lblod.info/id/contact-punten/ffaf2fa8-5e02-42f6-bc22-0e43fd19f2c8> a <http://schema.org/ContactPoint>;
+        mu:uuid "ffaf2fa8-5e02-42f6-bc22-0e43fd19f2c8";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/14a79c6f-769b-4046-b3cc-0772923de784> a <http://schema.org/ContactPoint>;
+        mu:uuid "14a79c6f-769b-4046-b3cc-0772923de784";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/57d0dfd7-b232-4e37-b7b7-6634841d5955> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "57d0dfd7-b232-4e37-b7b7-6634841d5955".
+
+      <http://data.lblod.info/id/bestuurseenheden/458df2d318d52e34278e4ce1886b9458351d3a4b06fe28c68a7558b0cdd528c3> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "458df2d318d52e34278e4ce1886b9458351d3a4b06fe28c68a7558b0cdd528c3";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Halle";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/3d0bf267-7855-41b2-b293-4efc9c6d0be2>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/54ca502f-c84c-42eb-bd8d-14e03b3b7169> .
+    
+
+      <http://data.lblod.info/id/identificatoren/2254dc58-b85b-452d-9050-aa4099594c18> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "2254dc58-b85b-452d-9050-aa4099594c18";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/c04c449f-7ab8-49b9-ba9e-bf3ea8cbb3ac>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/c04c449f-7ab8-49b9-ba9e-bf3ea8cbb3ac> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "c04c449f-7ab8-49b9-ba9e-bf3ea8cbb3ac";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1266".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/ce437fda-abab-4a50-9bf3-29aadc8f03c7> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "ce437fda-abab-4a50-9bf3-29aadc8f03c7";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/cb386176-1ee5-45c5-bf7f-be492bcc749c>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/60e5a666-d357-481a-aa27-ef0703758110>,
+                        <http://data.lblod.info/id/contact-punten/4fed0ca8-cda7-47c6-b9d7-5f5d90fdf564>.
+
+      <http://data.lblod.info/id/contact-punten/60e5a666-d357-481a-aa27-ef0703758110> a <http://schema.org/ContactPoint>;
+        mu:uuid "60e5a666-d357-481a-aa27-ef0703758110";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/4fed0ca8-cda7-47c6-b9d7-5f5d90fdf564> a <http://schema.org/ContactPoint>;
+        mu:uuid "4fed0ca8-cda7-47c6-b9d7-5f5d90fdf564";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/cb386176-1ee5-45c5-bf7f-be492bcc749c> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "cb386176-1ee5-45c5-bf7f-be492bcc749c".
+
+      <http://data.lblod.info/id/bestuurseenheden/31bceaaaa3f4019e85edfe0e509340aa30554d0f3bb343616841c20641788b6e> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "31bceaaaa3f4019e85edfe0e509340aa30554d0f3bb343616841c20641788b6e";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Hamme/Waasmunster: Hamme en Waasmunster";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/2254dc58-b85b-452d-9050-aa4099594c18>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/ce437fda-abab-4a50-9bf3-29aadc8f03c7> .
+    
+
+      <http://data.lblod.info/id/identificatoren/f6124be5-2d06-4682-bdf2-b0f2fc40bffd> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "f6124be5-2d06-4682-bdf2-b0f2fc40bffd";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/5982d348-7a52-4268-a472-7a00adeb2221>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/5982d348-7a52-4268-a472-7a00adeb2221> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "5982d348-7a52-4268-a472-7a00adeb2221";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1267".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/8c4431f5-8326-4ca2-bfe4-5ac8f23dbc17> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "8c4431f5-8326-4ca2-bfe4-5ac8f23dbc17";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/cb2d91ff-9d0b-4a93-b528-01c1fc4b8617>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/ab8f1e72-b63f-4885-b950-9de6a5713428>,
+                        <http://data.lblod.info/id/contact-punten/760e8063-3051-4a75-93b0-4172fb859fb8>.
+
+      <http://data.lblod.info/id/contact-punten/ab8f1e72-b63f-4885-b950-9de6a5713428> a <http://schema.org/ContactPoint>;
+        mu:uuid "ab8f1e72-b63f-4885-b950-9de6a5713428";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/760e8063-3051-4a75-93b0-4172fb859fb8> a <http://schema.org/ContactPoint>;
+        mu:uuid "760e8063-3051-4a75-93b0-4172fb859fb8";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/cb2d91ff-9d0b-4a93-b528-01c1fc4b8617> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "cb2d91ff-9d0b-4a93-b528-01c1fc4b8617".
+
+      <http://data.lblod.info/id/bestuurseenheden/77801115dec7f63400134c21d897a41bddb775eb438d81b354ad18fb6d7ab956> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "77801115dec7f63400134c21d897a41bddb775eb438d81b354ad18fb6d7ab956";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ HANO: Hamont-Achel en Pelt";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/f6124be5-2d06-4682-bdf2-b0f2fc40bffd>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/8c4431f5-8326-4ca2-bfe4-5ac8f23dbc17> .
+    
+
+      <http://data.lblod.info/id/identificatoren/677e19e5-7b3e-4f09-9e09-787f2488360b> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "677e19e5-7b3e-4f09-9e09-787f2488360b";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/6748a7d4-9e34-4cc8-937f-8dcf000d48bf>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/6748a7d4-9e34-4cc8-937f-8dcf000d48bf> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "6748a7d4-9e34-4cc8-937f-8dcf000d48bf";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1268".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/0f98d1d7-ed1d-4eb1-af61-59218fe35f64> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "0f98d1d7-ed1d-4eb1-af61-59218fe35f64";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/9ee6aa02-edba-472d-ba65-8b759485eba3>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/5cf4349c-24b0-467a-9027-79924c96c141>,
+                        <http://data.lblod.info/id/contact-punten/225fbd4b-f7ee-4548-8a47-558e5bfcb119>.
+
+      <http://data.lblod.info/id/contact-punten/5cf4349c-24b0-467a-9027-79924c96c141> a <http://schema.org/ContactPoint>;
+        mu:uuid "5cf4349c-24b0-467a-9027-79924c96c141";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/225fbd4b-f7ee-4548-8a47-558e5bfcb119> a <http://schema.org/ContactPoint>;
+        mu:uuid "225fbd4b-f7ee-4548-8a47-558e5bfcb119";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/9ee6aa02-edba-472d-ba65-8b759485eba3> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "9ee6aa02-edba-472d-ba65-8b759485eba3".
+
+      <http://data.lblod.info/id/bestuurseenheden/ff7d80dc-ec00-43ac-ac7e-d51694df37ff> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "ff7d80dc-ec00-43ac-ac7e-d51694df37ff";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Limburg Regio Hoofdstad: Hasselt, Zonhoven, Diepenbeek, Halen, Herk-de-Stad en Lummen";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/677e19e5-7b3e-4f09-9e09-787f2488360b>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/0f98d1d7-ed1d-4eb1-af61-59218fe35f64> .
+    
+
+      <http://data.lblod.info/id/identificatoren/ff86aace-bf93-4393-8664-da74f56ac014> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "ff86aace-bf93-4393-8664-da74f56ac014";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/12354aa2-32ff-4fce-a5c4-5722c99fc77d>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/12354aa2-32ff-4fce-a5c4-5722c99fc77d> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "12354aa2-32ff-4fce-a5c4-5722c99fc77d";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1269".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/dd776645-9ac7-49a5-b445-79b4e9403d2b> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "dd776645-9ac7-49a5-b445-79b4e9403d2b";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/bcf659fc-59ed-4ab6-be78-27892ab9f01a>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/e4a877c9-b6fa-4655-bebe-2b5d26253738>,
+                        <http://data.lblod.info/id/contact-punten/68e735bc-451c-4335-9b95-65961ba51644>.
+
+      <http://data.lblod.info/id/contact-punten/e4a877c9-b6fa-4655-bebe-2b5d26253738> a <http://schema.org/ContactPoint>;
+        mu:uuid "e4a877c9-b6fa-4655-bebe-2b5d26253738";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/68e735bc-451c-4335-9b95-65961ba51644> a <http://schema.org/ContactPoint>;
+        mu:uuid "68e735bc-451c-4335-9b95-65961ba51644";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/bcf659fc-59ed-4ab6-be78-27892ab9f01a> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "bcf659fc-59ed-4ab6-be78-27892ab9f01a".
+
+      <http://data.lblod.info/id/bestuurseenheden/ee07affaf869f10517967da1ba7e79151646a1f3621b3cbca591cec2b8c549b7> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "ee07affaf869f10517967da1ba7e79151646a1f3621b3cbca591cec2b8c549b7";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Kempenland: Hechtel-Eksel, Leopoldsburg en Peer";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/ff86aace-bf93-4393-8664-da74f56ac014>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/dd776645-9ac7-49a5-b445-79b4e9403d2b> .
+    
+
+      <http://data.lblod.info/id/identificatoren/7a629271-e777-4901-a1d4-d8d841b55abc> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "7a629271-e777-4901-a1d4-d8d841b55abc";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/3479b932-0495-414c-b6d3-dd553bc4cb98>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/3479b932-0495-414c-b6d3-dd553bc4cb98> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "3479b932-0495-414c-b6d3-dd553bc4cb98";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1270".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/f64bd1f4-88ec-4563-8ca8-e8227f2d3527> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "f64bd1f4-88ec-4563-8ca8-e8227f2d3527";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/d63ede1e-acc6-4f05-9cb7-65e9658a96a9>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/75238512-e7a0-4202-925f-5709de77cad3>,
+                        <http://data.lblod.info/id/contact-punten/703b71d2-614b-461a-b924-642f03911245>.
+
+      <http://data.lblod.info/id/contact-punten/75238512-e7a0-4202-925f-5709de77cad3> a <http://schema.org/ContactPoint>;
+        mu:uuid "75238512-e7a0-4202-925f-5709de77cad3";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/703b71d2-614b-461a-b924-642f03911245> a <http://schema.org/ContactPoint>;
+        mu:uuid "703b71d2-614b-461a-b924-642f03911245";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/d63ede1e-acc6-4f05-9cb7-65e9658a96a9> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "d63ede1e-acc6-4f05-9cb7-65e9658a96a9".
+
+      <http://data.lblod.info/id/bestuurseenheden/52bda330e11552b586106748bf652e5dd41163670d5c4226b2c02bfa2f579946> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "52bda330e11552b586106748bf652e5dd41163670d5c4226b2c02bfa2f579946";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Heist: Heist-op-den-Berg";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/7a629271-e777-4901-a1d4-d8d841b55abc>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/f64bd1f4-88ec-4563-8ca8-e8227f2d3527> .
+    
+
+      <http://data.lblod.info/id/identificatoren/21ccc759-a893-4d84-8f01-2b19aa3e179e> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "21ccc759-a893-4d84-8f01-2b19aa3e179e";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/e7c9a1cc-06ad-4d97-af0e-53f8979932e3>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/e7c9a1cc-06ad-4d97-af0e-53f8979932e3> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "e7c9a1cc-06ad-4d97-af0e-53f8979932e3";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1271".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/d6059e1e-5eff-4044-8b94-14a539fe3806> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "d6059e1e-5eff-4044-8b94-14a539fe3806";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/2b2b67ba-75df-4d69-86a0-89c84307f71d>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/eca7c1d1-e91e-4e30-8156-185730fbecbd>,
+                        <http://data.lblod.info/id/contact-punten/54e77578-5714-4866-961f-5e36c13c2bb4>.
+
+      <http://data.lblod.info/id/contact-punten/eca7c1d1-e91e-4e30-8156-185730fbecbd> a <http://schema.org/ContactPoint>;
+        mu:uuid "eca7c1d1-e91e-4e30-8156-185730fbecbd";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/54e77578-5714-4866-961f-5e36c13c2bb4> a <http://schema.org/ContactPoint>;
+        mu:uuid "54e77578-5714-4866-961f-5e36c13c2bb4";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/2b2b67ba-75df-4d69-86a0-89c84307f71d> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "2b2b67ba-75df-4d69-86a0-89c84307f71d".
+
+      <http://data.lblod.info/id/bestuurseenheden/b6fb86dcca01c89d6787801c958d6b8551f3755ec6f1c35bb97c0cf37b9ddc2c> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "b6fb86dcca01c89d6787801c958d6b8551f3755ec6f1c35bb97c0cf37b9ddc2c";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ HerKo: Herent en Kortenberg";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/21ccc759-a893-4d84-8f01-2b19aa3e179e>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/d6059e1e-5eff-4044-8b94-14a539fe3806> .
+    
+
+      <http://data.lblod.info/id/identificatoren/89f39300-984c-4273-9c07-5604cbfc4de9> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "89f39300-984c-4273-9c07-5604cbfc4de9";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/8cbf4790-0d97-40ef-8461-ad85e4f80b6e>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/8cbf4790-0d97-40ef-8461-ad85e4f80b6e> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "8cbf4790-0d97-40ef-8461-ad85e4f80b6e";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1272".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/671593e5-6b7b-4d57-b575-6cc7aa68748f> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "671593e5-6b7b-4d57-b575-6cc7aa68748f";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/82f1da49-04fc-40b6-9a5d-7b8d27a821ec>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/9f45b10e-6da4-4062-a403-1d7d539b86df>,
+                        <http://data.lblod.info/id/contact-punten/30620924-61b0-4942-80fa-9ffb6e41fff3>.
+
+      <http://data.lblod.info/id/contact-punten/9f45b10e-6da4-4062-a403-1d7d539b86df> a <http://schema.org/ContactPoint>;
+        mu:uuid "9f45b10e-6da4-4062-a403-1d7d539b86df";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/30620924-61b0-4942-80fa-9ffb6e41fff3> a <http://schema.org/ContactPoint>;
+        mu:uuid "30620924-61b0-4942-80fa-9ffb6e41fff3";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/82f1da49-04fc-40b6-9a5d-7b8d27a821ec> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "82f1da49-04fc-40b6-9a5d-7b8d27a821ec".
+
+      <http://data.lblod.info/id/bestuurseenheden/dbfedd56289924d8a7cc26a5aada392281547e053a10c0678238fc08a219fb6e> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "dbfedd56289924d8a7cc26a5aada392281547e053a10c0678238fc08a219fb6e";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Zuiderkempen: Herselt, Hulshout en Westerlo";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/89f39300-984c-4273-9c07-5604cbfc4de9>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/671593e5-6b7b-4d57-b575-6cc7aa68748f> .
+    
+
+      <http://data.lblod.info/id/identificatoren/a2506f10-5c3c-4f99-a487-4ca768923c78> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "a2506f10-5c3c-4f99-a487-4ca768923c78";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/98d95f55-3c4f-4588-9e48-07158a1bc9d5>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/98d95f55-3c4f-4588-9e48-07158a1bc9d5> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "98d95f55-3c4f-4588-9e48-07158a1bc9d5";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1273".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/b892a55f-3ca7-484c-a673-d4e9b9ed1b0a> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "b892a55f-3ca7-484c-a673-d4e9b9ed1b0a";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/8c49566a-4c84-4fa3-aa96-d49a3af1ceb0>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/0dd3e220-d0b1-4a2f-9732-563ed88b3ad7>,
+                        <http://data.lblod.info/id/contact-punten/01669cc1-df57-4555-9993-945d3d124f76>.
+
+      <http://data.lblod.info/id/contact-punten/0dd3e220-d0b1-4a2f-9732-563ed88b3ad7> a <http://schema.org/ContactPoint>;
+        mu:uuid "0dd3e220-d0b1-4a2f-9732-563ed88b3ad7";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/01669cc1-df57-4555-9993-945d3d124f76> a <http://schema.org/ContactPoint>;
+        mu:uuid "01669cc1-df57-4555-9993-945d3d124f76";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/8c49566a-4c84-4fa3-aa96-d49a3af1ceb0> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "8c49566a-4c84-4fa3-aa96-d49a3af1ceb0".
+
+      <http://data.lblod.info/id/bestuurseenheden/41d31a2eb697af977aadf64c73e0bcffb094e0f20e4017fe3b49c507079c0976> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "41d31a2eb697af977aadf64c73e0bcffb094e0f20e4017fe3b49c507079c0976";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Tongeren/Herstappe: Tongeren en Herstappe";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/a2506f10-5c3c-4f99-a487-4ca768923c78>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/b892a55f-3ca7-484c-a673-d4e9b9ed1b0a> .
+    
+
+      <http://data.lblod.info/id/identificatoren/5a37be7c-242a-4716-8e4b-4f95171a111e> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "5a37be7c-242a-4716-8e4b-4f95171a111e";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/ab082e5b-6bd5-46d4-af64-c986c456d316>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/ab082e5b-6bd5-46d4-af64-c986c456d316> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "ab082e5b-6bd5-46d4-af64-c986c456d316";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1274".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/8f7d61c1-66e5-4e69-ab17-3b3afcc67cb3> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "8f7d61c1-66e5-4e69-ab17-3b3afcc67cb3";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/94390645-2d4f-49f2-ade2-8bda93574447>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/e5c192d0-7517-42d0-a9d4-7d311aedb2b4>,
+                        <http://data.lblod.info/id/contact-punten/5c2991e5-989f-42ac-855b-b39838d5f4f6>.
+
+      <http://data.lblod.info/id/contact-punten/e5c192d0-7517-42d0-a9d4-7d311aedb2b4> a <http://schema.org/ContactPoint>;
+        mu:uuid "e5c192d0-7517-42d0-a9d4-7d311aedb2b4";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/5c2991e5-989f-42ac-855b-b39838d5f4f6> a <http://schema.org/ContactPoint>;
+        mu:uuid "5c2991e5-989f-42ac-855b-b39838d5f4f6";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/94390645-2d4f-49f2-ade2-8bda93574447> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "94390645-2d4f-49f2-ade2-8bda93574447".
+
+      <http://data.lblod.info/id/bestuurseenheden/08b125860dd7716256dd35ba2e38a009206555f29adc44642c655450a471ebef> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "08b125860dd7716256dd35ba2e38a009206555f29adc44642c655450a471ebef";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Zottegem/Herzele/Sint-Lievens-Houtem: Zottegem, Herzele en Sint-Lievens-Houtem";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/5a37be7c-242a-4716-8e4b-4f95171a111e>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/8f7d61c1-66e5-4e69-ab17-3b3afcc67cb3> .
+    
+
+      <http://data.lblod.info/id/identificatoren/ee7c0ff6-bf35-4dd1-a82d-e31c7a6fab4c> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "ee7c0ff6-bf35-4dd1-a82d-e31c7a6fab4c";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/69da2dbe-f53e-45d7-a3f0-4dd3bb7f95f1>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/69da2dbe-f53e-45d7-a3f0-4dd3bb7f95f1> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "69da2dbe-f53e-45d7-a3f0-4dd3bb7f95f1";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1275".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/d3d5677f-774d-42fc-981f-1f49f43c8b9d> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "d3d5677f-774d-42fc-981f-1f49f43c8b9d";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/c5b85ef0-8bf4-4cca-91d7-a1cd37ee0bad>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/fd1d7980-808c-4252-83b8-8996518b88b8>,
+                        <http://data.lblod.info/id/contact-punten/4950a59b-efb1-45db-bffe-6b203296998a>.
+
+      <http://data.lblod.info/id/contact-punten/fd1d7980-808c-4252-83b8-8996518b88b8> a <http://schema.org/ContactPoint>;
+        mu:uuid "fd1d7980-808c-4252-83b8-8996518b88b8";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/4950a59b-efb1-45db-bffe-6b203296998a> a <http://schema.org/ContactPoint>;
+        mu:uuid "4950a59b-efb1-45db-bffe-6b203296998a";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/c5b85ef0-8bf4-4cca-91d7-a1cd37ee0bad> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "c5b85ef0-8bf4-4cca-91d7-a1cd37ee0bad".
+
+      <http://data.lblod.info/id/bestuurseenheden/8a72024e99b1e083aca28a026122ad2bc517372bc18e95210fb54f080136e3f8> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "8a72024e99b1e083aca28a026122ad2bc517372bc18e95210fb54f080136e3f8";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Heusden-Zolder: Heusden-Zolder";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/ee7c0ff6-bf35-4dd1-a82d-e31c7a6fab4c>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/d3d5677f-774d-42fc-981f-1f49f43c8b9d> .
+    
+
+      <http://data.lblod.info/id/identificatoren/9cb693a2-714e-4fe7-a4cd-bad545d1e59d> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "9cb693a2-714e-4fe7-a4cd-bad545d1e59d";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/696eb2a9-b446-4e21-afbe-44eb5280e13d>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/696eb2a9-b446-4e21-afbe-44eb5280e13d> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "696eb2a9-b446-4e21-afbe-44eb5280e13d";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1276".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/45c4ba8a-e865-4e04-8ff7-5660f3ca89e2> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "45c4ba8a-e865-4e04-8ff7-5660f3ca89e2";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/2cbf417e-cadb-4b8c-a02a-3aaf2ce2fb9f>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/ba50929e-7bcf-4f90-bdcc-b65e386424bf>,
+                        <http://data.lblod.info/id/contact-punten/89344173-22ac-41c3-bd20-3264851deca8>.
+
+      <http://data.lblod.info/id/contact-punten/ba50929e-7bcf-4f90-bdcc-b65e386424bf> a <http://schema.org/ContactPoint>;
+        mu:uuid "ba50929e-7bcf-4f90-bdcc-b65e386424bf";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/89344173-22ac-41c3-bd20-3264851deca8> a <http://schema.org/ContactPoint>;
+        mu:uuid "89344173-22ac-41c3-bd20-3264851deca8";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/2cbf417e-cadb-4b8c-a02a-3aaf2ce2fb9f> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "2cbf417e-cadb-4b8c-a02a-3aaf2ce2fb9f".
+
+      <http://data.lblod.info/id/bestuurseenheden/195d911f1417b20a4b715b1a54e8ae6e92b9a23cde908f2fb03a0081910d8fce> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "195d911f1417b20a4b715b1a54e8ae6e92b9a23cde908f2fb03a0081910d8fce";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ ARRO Ieper: Heuvelland, Langemark-Poelkapelle, Mesen, Moorslede, Poperinge, Staden, Vleteren, Wervik, Ieper en Zonnebeke";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/9cb693a2-714e-4fe7-a4cd-bad545d1e59d>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/45c4ba8a-e865-4e04-8ff7-5660f3ca89e2> .
+    
+
+      <http://data.lblod.info/id/identificatoren/194d63fd-cd67-434c-92df-c0dc34313505> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "194d63fd-cd67-434c-92df-c0dc34313505";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/66e6d698-6de6-4b12-9850-c98d9ba7700f>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/66e6d698-6de6-4b12-9850-c98d9ba7700f> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "66e6d698-6de6-4b12-9850-c98d9ba7700f";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1277".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/5a6ad335-b74d-4611-9ab5-69060e0261ab> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "5a6ad335-b74d-4611-9ab5-69060e0261ab";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/a07ecf0f-eb88-49e0-9850-e0404694f945>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/44ffb5a2-b51e-4c5b-841d-63c8e4d772a9>,
+                        <http://data.lblod.info/id/contact-punten/3928f476-94fe-4ad2-872b-9de35d6a59d7>.
+
+      <http://data.lblod.info/id/contact-punten/44ffb5a2-b51e-4c5b-841d-63c8e4d772a9> a <http://schema.org/ContactPoint>;
+        mu:uuid "44ffb5a2-b51e-4c5b-841d-63c8e4d772a9";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/3928f476-94fe-4ad2-872b-9de35d6a59d7> a <http://schema.org/ContactPoint>;
+        mu:uuid "3928f476-94fe-4ad2-872b-9de35d6a59d7";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/a07ecf0f-eb88-49e0-9850-e0404694f945> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "a07ecf0f-eb88-49e0-9850-e0404694f945".
+
+      <http://data.lblod.info/id/bestuurseenheden/a65afe7380499a2c24c2d039f2a97493f2f99bc03836de9bb99c2c267676388f> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "a65afe7380499a2c24c2d039f2a97493f2f99bc03836de9bb99c2c267676388f";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Hoegaarden/Tienen";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/194d63fd-cd67-434c-92df-c0dc34313505>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/5a6ad335-b74d-4611-9ab5-69060e0261ab> .
+    
+
+      <http://data.lblod.info/id/identificatoren/732faa35-8e92-4d61-afb8-127922616a36> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "732faa35-8e92-4d61-afb8-127922616a36";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/1277e645-0a28-4e8e-90af-4b908c7a20c1>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/1277e645-0a28-4e8e-90af-4b908c7a20c1> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "1277e645-0a28-4e8e-90af-4b908c7a20c1";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1278".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/d363caa3-e655-407a-ade8-82191f534ce3> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "d363caa3-e655-407a-ade8-82191f534ce3";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/2abb87bf-6a97-4d18-8b6a-9b32762da66c>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/2cacc278-5086-4635-8a3e-2f4b5cd71bf6>,
+                        <http://data.lblod.info/id/contact-punten/84c1c137-adef-44ac-a79b-92154be807f8>.
+
+      <http://data.lblod.info/id/contact-punten/2cacc278-5086-4635-8a3e-2f4b5cd71bf6> a <http://schema.org/ContactPoint>;
+        mu:uuid "2cacc278-5086-4635-8a3e-2f4b5cd71bf6";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/84c1c137-adef-44ac-a79b-92154be807f8> a <http://schema.org/ContactPoint>;
+        mu:uuid "84c1c137-adef-44ac-a79b-92154be807f8";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/2abb87bf-6a97-4d18-8b6a-9b32762da66c> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "2abb87bf-6a97-4d18-8b6a-9b32762da66c".
+
+      <http://data.lblod.info/id/bestuurseenheden/b5aee7f43fc9c5d0df74e2cbb9214c03c425cf026b1fd77dd1e3b08e5fc7f875> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "b5aee7f43fc9c5d0df74e2cbb9214c03c425cf026b1fd77dd1e3b08e5fc7f875";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Druivenstreek: Overijse en Hoeilaart";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/732faa35-8e92-4d61-afb8-127922616a36>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/d363caa3-e655-407a-ade8-82191f534ce3> .
+    
+
+      <http://data.lblod.info/id/identificatoren/1c14a563-8fc3-4c54-91c1-5d0943a4ec54> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "1c14a563-8fc3-4c54-91c1-5d0943a4ec54";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/8e0320b4-4aab-42f4-818c-0aa18a82365d>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/8e0320b4-4aab-42f4-818c-0aa18a82365d> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "8e0320b4-4aab-42f4-818c-0aa18a82365d";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1279".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/f55b9e9e-6407-454e-9609-849f23c6d305> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "f55b9e9e-6407-454e-9609-849f23c6d305";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/45b50694-c3bb-4905-abc2-0dd752c68981>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/04e14032-f031-4bfb-aa94-b55413366770>,
+                        <http://data.lblod.info/id/contact-punten/b9d3d0c6-0ac8-4b63-90c5-0bf22ee910db>.
+
+      <http://data.lblod.info/id/contact-punten/04e14032-f031-4bfb-aa94-b55413366770> a <http://schema.org/ContactPoint>;
+        mu:uuid "04e14032-f031-4bfb-aa94-b55413366770";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/b9d3d0c6-0ac8-4b63-90c5-0bf22ee910db> a <http://schema.org/ContactPoint>;
+        mu:uuid "b9d3d0c6-0ac8-4b63-90c5-0bf22ee910db";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/45b50694-c3bb-4905-abc2-0dd752c68981> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "45b50694-c3bb-4905-abc2-0dd752c68981".
+
+      <http://data.lblod.info/id/bestuurseenheden/5ba4a42bd459dda75ce452a253ddc09547174265456ad1e3f9389a3ff139a1f9> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "5ba4a42bd459dda75ce452a253ddc09547174265456ad1e3f9389a3ff139a1f9";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ RIHO: Roeselare, Izegem en Hooglede";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/1c14a563-8fc3-4c54-91c1-5d0943a4ec54>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/f55b9e9e-6407-454e-9609-849f23c6d305> .
+    
+
+      <http://data.lblod.info/id/identificatoren/52f6e0d8-6a6d-44a7-8e27-d4226037d41b> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "52f6e0d8-6a6d-44a7-8e27-d4226037d41b";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/61ee1c4b-deb3-450e-9ef3-0f5adb5c7228>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/61ee1c4b-deb3-450e-9ef3-0f5adb5c7228> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "61ee1c4b-deb3-450e-9ef3-0f5adb5c7228";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1280".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/0da5a6fb-a2b0-40a6-b9a3-255643f3c9d9> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "0da5a6fb-a2b0-40a6-b9a3-255643f3c9d9";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/50a69c59-e4fe-45e7-bbe6-c35f1b0f464c>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/88c0bc3a-e6c8-471e-99a8-7600fa48995a>,
+                        <http://data.lblod.info/id/contact-punten/f5f9de1a-aba8-45f4-8eea-b0e4ec9b440d>.
+
+      <http://data.lblod.info/id/contact-punten/88c0bc3a-e6c8-471e-99a8-7600fa48995a> a <http://schema.org/ContactPoint>;
+        mu:uuid "88c0bc3a-e6c8-471e-99a8-7600fa48995a";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/f5f9de1a-aba8-45f4-8eea-b0e4ec9b440d> a <http://schema.org/ContactPoint>;
+        mu:uuid "f5f9de1a-aba8-45f4-8eea-b0e4ec9b440d";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/50a69c59-e4fe-45e7-bbe6-c35f1b0f464c> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "50a69c59-e4fe-45e7-bbe6-c35f1b0f464c".
+
+      <http://data.lblod.info/id/bestuurseenheden/b2fdc615ffb131e53a200e14c74ac92d4ed6dac176e3e6ea2c79d227835077c9> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "b2fdc615ffb131e53a200e14c74ac92d4ed6dac176e3e6ea2c79d227835077c9";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Noorderkempen: Hoogstraten, Merksplas en Rijkevorsel";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/52f6e0d8-6a6d-44a7-8e27-d4226037d41b>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/0da5a6fb-a2b0-40a6-b9a3-255643f3c9d9> .
+    
+
+      <http://data.lblod.info/id/identificatoren/e691cccc-bd4d-4ce1-bec0-08c983dff055> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "e691cccc-bd4d-4ce1-bec0-08c983dff055";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/786b9334-4850-4019-8aed-d397cf1316ea>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/786b9334-4850-4019-8aed-d397cf1316ea> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "786b9334-4850-4019-8aed-d397cf1316ea";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1281".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/a19ded7b-cba9-4b60-a7cb-d5ffafe1a7e5> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "a19ded7b-cba9-4b60-a7cb-d5ffafe1a7e5";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/d03ffb8e-5bc8-4c0e-9cc2-308ab8c3d3eb>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/c7b80842-ed7b-4231-b4c0-697fe68a5857>,
+                        <http://data.lblod.info/id/contact-punten/a5594bd9-daf6-4b32-a0a3-4f1ca8776e5b>.
+
+      <http://data.lblod.info/id/contact-punten/c7b80842-ed7b-4231-b4c0-697fe68a5857> a <http://schema.org/ContactPoint>;
+        mu:uuid "c7b80842-ed7b-4231-b4c0-697fe68a5857";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/a5594bd9-daf6-4b32-a0a3-4f1ca8776e5b> a <http://schema.org/ContactPoint>;
+        mu:uuid "a5594bd9-daf6-4b32-a0a3-4f1ca8776e5b";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/d03ffb8e-5bc8-4c0e-9cc2-308ab8c3d3eb> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "d03ffb8e-5bc8-4c0e-9cc2-308ab8c3d3eb".
+
+      <http://data.lblod.info/id/bestuurseenheden/08293a0d743c13f37e99deddf000e75ba13f70ca6a5ac65cde49ad23d600ab3c> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "08293a0d743c13f37e99deddf000e75ba13f70ca6a5ac65cde49ad23d600ab3c";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Houthalen-Helchteren";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/e691cccc-bd4d-4ce1-bec0-08c983dff055>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/a19ded7b-cba9-4b60-a7cb-d5ffafe1a7e5> .
+    
+
+      <http://data.lblod.info/id/identificatoren/2d382542-4328-4608-b415-7c9d4b0b406b> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "2d382542-4328-4608-b415-7c9d4b0b406b";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/1d8bcff7-7aa5-4e25-9d1e-0e22838c347c>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/1d8bcff7-7aa5-4e25-9d1e-0e22838c347c> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "1d8bcff7-7aa5-4e25-9d1e-0e22838c347c";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1282".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/cbd09587-30fd-44a5-912e-2a8bc2bc35fb> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "cbd09587-30fd-44a5-912e-2a8bc2bc35fb";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/91347c74-ea6c-4c1b-9ab1-ed3c11a50d5c>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/4f042380-a0f2-412a-8b83-fc24821f0018>,
+                        <http://data.lblod.info/id/contact-punten/69798c7c-b4a1-4b44-8a81-844e54922bff>.
+
+      <http://data.lblod.info/id/contact-punten/4f042380-a0f2-412a-8b83-fc24821f0018> a <http://schema.org/ContactPoint>;
+        mu:uuid "4f042380-a0f2-412a-8b83-fc24821f0018";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/69798c7c-b4a1-4b44-8a81-844e54922bff> a <http://schema.org/ContactPoint>;
+        mu:uuid "69798c7c-b4a1-4b44-8a81-844e54922bff";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/91347c74-ea6c-4c1b-9ab1-ed3c11a50d5c> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "91347c74-ea6c-4c1b-9ab1-ed3c11a50d5c".
+
+      <http://data.lblod.info/id/bestuurseenheden/7ddda00fc45a0994092bc26f30d97352b7586676438d5557b3f5cc336daab063> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "7ddda00fc45a0994092bc26f30d97352b7586676438d5557b3f5cc336daab063";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ KASTZE: Kampenhout, Steenokkerzeel en Zemst";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/2d382542-4328-4608-b415-7c9d4b0b406b>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/cbd09587-30fd-44a5-912e-2a8bc2bc35fb> .
+    
+
+      <http://data.lblod.info/id/identificatoren/84344d79-c182-42ee-9d67-aa48a195cd8a> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "84344d79-c182-42ee-9d67-aa48a195cd8a";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/6f5a9802-b5ac-492a-b4ff-a36915f9d2dd>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/6f5a9802-b5ac-492a-b4ff-a36915f9d2dd> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "6f5a9802-b5ac-492a-b4ff-a36915f9d2dd";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1283".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/0193844e-fb5d-4ccb-be87-d177cfce488f> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "0193844e-fb5d-4ccb-be87-d177cfce488f";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/a41b5f47-839f-440f-aab5-08377e80c4ea>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/53ae543a-e30a-4211-a479-e65a0e42892d>,
+                        <http://data.lblod.info/id/contact-punten/f50c4d76-313d-4913-a937-3e95f5b1a62c>.
+
+      <http://data.lblod.info/id/contact-punten/53ae543a-e30a-4211-a479-e65a0e42892d> a <http://schema.org/ContactPoint>;
+        mu:uuid "53ae543a-e30a-4211-a479-e65a0e42892d";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/f50c4d76-313d-4913-a937-3e95f5b1a62c> a <http://schema.org/ContactPoint>;
+        mu:uuid "f50c4d76-313d-4913-a937-3e95f5b1a62c";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/a41b5f47-839f-440f-aab5-08377e80c4ea> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "a41b5f47-839f-440f-aab5-08377e80c4ea".
+
+      <http://data.lblod.info/id/bestuurseenheden/0594a740b99274c7347f3492ae4d05f9b05d057a1cbad30683634296e189cc38> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "0594a740b99274c7347f3492ae4d05f9b05d057a1cbad30683634296e189cc38";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Noord: Kapellen en Stabroek";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/84344d79-c182-42ee-9d67-aa48a195cd8a>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/0193844e-fb5d-4ccb-be87-d177cfce488f> .
+    
+
+      <http://data.lblod.info/id/identificatoren/19827a31-aab8-4408-a036-74168c3d2d8f> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "19827a31-aab8-4408-a036-74168c3d2d8f";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/28d00cb8-bf80-491e-985b-32586ca4c647>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/28d00cb8-bf80-491e-985b-32586ca4c647> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "28d00cb8-bf80-491e-985b-32586ca4c647";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1284".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/7e521998-e345-4c95-80e2-0847ea766be0> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "7e521998-e345-4c95-80e2-0847ea766be0";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/19ad1c41-1c97-4bf8-9b6b-d74732339273>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/c7c20a7c-2bbb-4584-8127-b995fd8a5b4e>,
+                        <http://data.lblod.info/id/contact-punten/0eb92c33-6084-4638-9840-188115ae02a9>.
+
+      <http://data.lblod.info/id/contact-punten/c7c20a7c-2bbb-4584-8127-b995fd8a5b4e> a <http://schema.org/ContactPoint>;
+        mu:uuid "c7c20a7c-2bbb-4584-8127-b995fd8a5b4e";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/0eb92c33-6084-4638-9840-188115ae02a9> a <http://schema.org/ContactPoint>;
+        mu:uuid "0eb92c33-6084-4638-9840-188115ae02a9";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/19ad1c41-1c97-4bf8-9b6b-d74732339273> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "19ad1c41-1c97-4bf8-9b6b-d74732339273".
+
+      <http://data.lblod.info/id/bestuurseenheden/c7778ecc532ee037ab821de348f7c6d98ed5b2401abce2e7da64687290c08962> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "c7778ecc532ee037ab821de348f7c6d98ed5b2401abce2e7da64687290c08962";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ K-L-M: Kapelle-op-den-Bos, Londerzeel en Meise";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/19827a31-aab8-4408-a036-74168c3d2d8f>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/7e521998-e345-4c95-80e2-0847ea766be0> .
+    
+
+      <http://data.lblod.info/id/identificatoren/2dddf410-509b-4cf6-8bbc-adada736a42d> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "2dddf410-509b-4cf6-8bbc-adada736a42d";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/b1cc3062-8de4-4cb5-8fe5-c4ccd62407bf>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/b1cc3062-8de4-4cb5-8fe5-c4ccd62407bf> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "b1cc3062-8de4-4cb5-8fe5-c4ccd62407bf";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1285".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/84515f32-7c39-4342-8be5-198f84f21a61> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "84515f32-7c39-4342-8be5-198f84f21a61";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/c54e76fd-47f3-4b53-acb4-b16c48559fd3>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/ae64a019-cc72-4d9f-8f17-8822c22b7859>,
+                        <http://data.lblod.info/id/contact-punten/a162d1ab-faa4-404e-b235-373583f2f2f7>.
+
+      <http://data.lblod.info/id/contact-punten/ae64a019-cc72-4d9f-8f17-8822c22b7859> a <http://schema.org/ContactPoint>;
+        mu:uuid "ae64a019-cc72-4d9f-8f17-8822c22b7859";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/a162d1ab-faa4-404e-b235-373583f2f2f7> a <http://schema.org/ContactPoint>;
+        mu:uuid "a162d1ab-faa4-404e-b235-373583f2f2f7";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/c54e76fd-47f3-4b53-acb4-b16c48559fd3> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "c54e76fd-47f3-4b53-acb4-b16c48559fd3".
+
+      <http://data.lblod.info/id/bestuurseenheden/4deae42b2b25bff407f5abc7cbb6d62eb02afaf2892086341c324fdf2c0e6e92> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "4deae42b2b25bff407f5abc7cbb6d62eb02afaf2892086341c324fdf2c0e6e92";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Vlaamse Ardennen: Kluisbergen, Kruisem, Oudenaarde en Wortegem-Petegem";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/2dddf410-509b-4cf6-8bbc-adada736a42d>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/84515f32-7c39-4342-8be5-198f84f21a61> .
+    
+
+      <http://data.lblod.info/id/identificatoren/1ebb52fd-074d-4b00-a77d-9146c0e6fe79> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "1ebb52fd-074d-4b00-a77d-9146c0e6fe79";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/98563e8f-2d82-46a2-9bf1-bb5c38b5045c>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/98563e8f-2d82-46a2-9bf1-bb5c38b5045c> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "98563e8f-2d82-46a2-9bf1-bb5c38b5045c";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1286".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/a1ff80d6-0050-4eeb-a438-714f0104dd0c> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "a1ff80d6-0050-4eeb-a438-714f0104dd0c";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/dd012caf-74f5-4f7e-838f-fae84d8690b4>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/95ca3fce-1264-4d0f-8776-9b3940a060dd>,
+                        <http://data.lblod.info/id/contact-punten/96c0ae40-3b15-48d0-8308-348f7fa23215>.
+
+      <http://data.lblod.info/id/contact-punten/95ca3fce-1264-4d0f-8776-9b3940a060dd> a <http://schema.org/ContactPoint>;
+        mu:uuid "95ca3fce-1264-4d0f-8776-9b3940a060dd";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/96c0ae40-3b15-48d0-8308-348f7fa23215> a <http://schema.org/ContactPoint>;
+        mu:uuid "96c0ae40-3b15-48d0-8308-348f7fa23215";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/dd012caf-74f5-4f7e-838f-fae84d8690b4> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "dd012caf-74f5-4f7e-838f-fae84d8690b4".
+
+      <http://data.lblod.info/id/bestuurseenheden/477e468496131b7d35f145b0361bca5c2cad577fd9ec27d385d703942dc944d0> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "477e468496131b7d35f145b0361bca5c2cad577fd9ec27d385d703942dc944d0";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ VLAS: Kortrijk, Kuurne en Lendelede";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/1ebb52fd-074d-4b00-a77d-9146c0e6fe79>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/a1ff80d6-0050-4eeb-a438-714f0104dd0c> .
+    
+
+      <http://data.lblod.info/id/identificatoren/0e243181-d224-47cb-b7b2-8709908cc0bc> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "0e243181-d224-47cb-b7b2-8709908cc0bc";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/df78ed8a-f19f-4467-96c1-84f69dbc4077>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/df78ed8a-f19f-4467-96c1-84f69dbc4077> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "df78ed8a-f19f-4467-96c1-84f69dbc4077";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1287".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/22a5b7f4-64b4-440c-9b6a-860a07f25df9> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "22a5b7f4-64b4-440c-9b6a-860a07f25df9";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/be5de18b-c15c-4971-8053-71bb4aa8461b>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/f24e8423-3728-447b-bfa0-54bb3e8b35c1>,
+                        <http://data.lblod.info/id/contact-punten/5303eb15-8541-480e-8521-f2a0f9809da5>.
+
+      <http://data.lblod.info/id/contact-punten/f24e8423-3728-447b-bfa0-54bb3e8b35c1> a <http://schema.org/ContactPoint>;
+        mu:uuid "f24e8423-3728-447b-bfa0-54bb3e8b35c1";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/5303eb15-8541-480e-8521-f2a0f9809da5> a <http://schema.org/ContactPoint>;
+        mu:uuid "5303eb15-8541-480e-8521-f2a0f9809da5";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/be5de18b-c15c-4971-8053-71bb4aa8461b> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "be5de18b-c15c-4971-8053-71bb4aa8461b".
+
+      <http://data.lblod.info/id/bestuurseenheden/beff71011cde3ac0ee0d94b592462be141cc9f0deb5c6ea996ea191bf79ae2fe> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "beff71011cde3ac0ee0d94b592462be141cc9f0deb5c6ea996ea191bf79ae2fe";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ WOKRA: Wezembeek-Oppem en Kraainem";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/0e243181-d224-47cb-b7b2-8709908cc0bc>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/22a5b7f4-64b4-440c-9b6a-860a07f25df9> .
+    
+
+      <http://data.lblod.info/id/identificatoren/f155e116-daca-40d8-97b0-09cbf94f7d53> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "f155e116-daca-40d8-97b0-09cbf94f7d53";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/8306ebfc-2a65-477e-8414-2ab56bdbe0c2>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/8306ebfc-2a65-477e-8414-2ab56bdbe0c2> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "8306ebfc-2a65-477e-8414-2ab56bdbe0c2";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1288".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/c204cc1b-47bf-4b6b-9fcb-9567faaf2f1d> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "c204cc1b-47bf-4b6b-9fcb-9567faaf2f1d";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/34a575ac-3706-4910-88c6-9781b6b58e39>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/50c727f7-ecee-4b7b-9fa2-770b2c7c6bae>,
+                        <http://data.lblod.info/id/contact-punten/a08533ed-cd37-4e7d-96db-8ba902f8a56e>.
+
+      <http://data.lblod.info/id/contact-punten/50c727f7-ecee-4b7b-9fa2-770b2c7c6bae> a <http://schema.org/ContactPoint>;
+        mu:uuid "50c727f7-ecee-4b7b-9fa2-770b2c7c6bae";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/a08533ed-cd37-4e7d-96db-8ba902f8a56e> a <http://schema.org/ContactPoint>;
+        mu:uuid "a08533ed-cd37-4e7d-96db-8ba902f8a56e";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/34a575ac-3706-4910-88c6-9781b6b58e39> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "34a575ac-3706-4910-88c6-9781b6b58e39".
+
+      <http://data.lblod.info/id/bestuurseenheden/7dd1250996188607bb1e28df1ebea0b943e8db59c08ea01e3c57672531c43ec6> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "7dd1250996188607bb1e28df1ebea0b943e8db59c08ea01e3c57672531c43ec6";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Kruibeke/Temse: Kruibeke en Temse";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/f155e116-daca-40d8-97b0-09cbf94f7d53>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/c204cc1b-47bf-4b6b-9fcb-9567faaf2f1d> .
+    
+
+      <http://data.lblod.info/id/identificatoren/67cdf273-5dee-4063-aa6b-ce6aaf2170b2> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "67cdf273-5dee-4063-aa6b-ce6aaf2170b2";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/ce16fc8a-2ff2-43f6-9e6a-bff3d0c4d444>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/ce16fc8a-2ff2-43f6-9e6a-bff3d0c4d444> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "ce16fc8a-2ff2-43f6-9e6a-bff3d0c4d444";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1289".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/908d9f5a-ecec-4f6f-8a9c-fcf6505cc4b1> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "908d9f5a-ecec-4f6f-8a9c-fcf6505cc4b1";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/8a028aad-162e-496e-a09f-5209b1f12bca>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/d1e5cf19-e591-45e4-8666-af4069c6cd72>,
+                        <http://data.lblod.info/id/contact-punten/972e9e86-11f0-4605-8812-eddd6e897f71>.
+
+      <http://data.lblod.info/id/contact-punten/d1e5cf19-e591-45e4-8666-af4069c6cd72> a <http://schema.org/ContactPoint>;
+        mu:uuid "d1e5cf19-e591-45e4-8666-af4069c6cd72";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/972e9e86-11f0-4605-8812-eddd6e897f71> a <http://schema.org/ContactPoint>;
+        mu:uuid "972e9e86-11f0-4605-8812-eddd6e897f71";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/8a028aad-162e-496e-a09f-5209b1f12bca> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "8a028aad-162e-496e-a09f-5209b1f12bca".
+
+      <http://data.lblod.info/id/bestuurseenheden/c747c462297c0fd1d31076b8f5b20e23aa3309ccb0f5b0b072097aa7612950e9> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "c747c462297c0fd1d31076b8f5b20e23aa3309ccb0f5b0b072097aa7612950e9";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Wetteren/Laarne/Wichelen: Wetteren, Laarne en Wichelen";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/67cdf273-5dee-4063-aa6b-ce6aaf2170b2>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/908d9f5a-ecec-4f6f-8a9c-fcf6505cc4b1> .
+    
+
+      <http://data.lblod.info/id/identificatoren/af0f5e4a-8cbe-4a86-aecf-f373e13c160f> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "af0f5e4a-8cbe-4a86-aecf-f373e13c160f";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/0e246196-c97e-4279-9de6-9c4136859999>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/0e246196-c97e-4279-9de6-9c4136859999> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "0e246196-c97e-4279-9de6-9c4136859999";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1290".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/a4e22e98-c03b-41e8-98c9-6445040e8011> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "a4e22e98-c03b-41e8-98c9-6445040e8011";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/025b87df-3695-497f-9ca5-9f14e540643d>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/b342d009-b96f-45e0-be54-f6661df2de9d>,
+                        <http://data.lblod.info/id/contact-punten/bcc479b2-0eee-4325-b398-5503c3384201>.
+
+      <http://data.lblod.info/id/contact-punten/b342d009-b96f-45e0-be54-f6661df2de9d> a <http://schema.org/ContactPoint>;
+        mu:uuid "b342d009-b96f-45e0-be54-f6661df2de9d";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/bcc479b2-0eee-4325-b398-5503c3384201> a <http://schema.org/ContactPoint>;
+        mu:uuid "bcc479b2-0eee-4325-b398-5503c3384201";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/025b87df-3695-497f-9ca5-9f14e540643d> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "025b87df-3695-497f-9ca5-9f14e540643d".
+
+      <http://data.lblod.info/id/bestuurseenheden/9b1af8b3306f7f2966d2326a7a301c149d2a62db4803335aaffae9ff45fe068d> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "9b1af8b3306f7f2966d2326a7a301c149d2a62db4803335aaffae9ff45fe068d";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Lanaken";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/af0f5e4a-8cbe-4a86-aecf-f373e13c160f>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/a4e22e98-c03b-41e8-98c9-6445040e8011> .
+    
+
+      <http://data.lblod.info/id/identificatoren/439e648d-2eeb-4d36-83b1-d06323a79ea2> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "439e648d-2eeb-4d36-83b1-d06323a79ea2";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/e097ea19-0e14-4e9a-a3d6-51742ef91d11>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/e097ea19-0e14-4e9a-a3d6-51742ef91d11> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "e097ea19-0e14-4e9a-a3d6-51742ef91d11";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1291".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/f0eb8906-53e7-4493-8e15-57b49d515807> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "f0eb8906-53e7-4493-8e15-57b49d515807";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/1814239a-e88f-484a-850a-8d892fe724a5>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/1d21ec72-d955-4ca2-97da-d2e8a0f81ef4>,
+                        <http://data.lblod.info/id/contact-punten/f11ca092-6b82-48cc-92b3-e1f8a7e1907e>.
+
+      <http://data.lblod.info/id/contact-punten/1d21ec72-d955-4ca2-97da-d2e8a0f81ef4> a <http://schema.org/ContactPoint>;
+        mu:uuid "1d21ec72-d955-4ca2-97da-d2e8a0f81ef4";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/f11ca092-6b82-48cc-92b3-e1f8a7e1907e> a <http://schema.org/ContactPoint>;
+        mu:uuid "f11ca092-6b82-48cc-92b3-e1f8a7e1907e";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/1814239a-e88f-484a-850a-8d892fe724a5> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "1814239a-e88f-484a-850a-8d892fe724a5".
+
+      <http://data.lblod.info/id/bestuurseenheden/1db0e6fb09e60db1e8534b20c69abb03584870612717a454937717be9b7fd019> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "1db0e6fb09e60db1e8534b20c69abb03584870612717a454937717be9b7fd019";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ LaMa: Lanaken en Maasmechelen";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/439e648d-2eeb-4d36-83b1-d06323a79ea2>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/f0eb8906-53e7-4493-8e15-57b49d515807> .
+    
+
+      <http://data.lblod.info/id/identificatoren/e2f250bb-a65a-4ece-a142-be2d434b0d21> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "e2f250bb-a65a-4ece-a142-be2d434b0d21";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/935278ad-1b98-42d4-b946-80081485dba0>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/935278ad-1b98-42d4-b946-80081485dba0> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "935278ad-1b98-42d4-b946-80081485dba0";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1292".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/3e45dbc8-e06a-41fd-a70f-7c9416ad0bd2> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "3e45dbc8-e06a-41fd-a70f-7c9416ad0bd2";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/f01a243c-d70b-4e64-a186-6ded99ee7c13>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/84ddb12d-c97e-4c03-b08e-354bee6ede8d>,
+                        <http://data.lblod.info/id/contact-punten/8a16e9ff-9c7d-442c-b8b9-db1b7d8ceb23>.
+
+      <http://data.lblod.info/id/contact-punten/84ddb12d-c97e-4c03-b08e-354bee6ede8d> a <http://schema.org/ContactPoint>;
+        mu:uuid "84ddb12d-c97e-4c03-b08e-354bee6ede8d";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/8a16e9ff-9c7d-442c-b8b9-db1b7d8ceb23> a <http://schema.org/ContactPoint>;
+        mu:uuid "8a16e9ff-9c7d-442c-b8b9-db1b7d8ceb23";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/f01a243c-d70b-4e64-a186-6ded99ee7c13> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "f01a243c-d70b-4e64-a186-6ded99ee7c13".
+
+      <http://data.lblod.info/id/bestuurseenheden/520ae455030cb427fa5dead38ba62d2975fcf2d0f695d365cf9e84b5b5b5b73e> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "520ae455030cb427fa5dead38ba62d2975fcf2d0f695d365cf9e84b5b5b5b73e";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Landen/Linter/Zoutleeuw";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/e2f250bb-a65a-4ece-a142-be2d434b0d21>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/3e45dbc8-e06a-41fd-a70f-7c9416ad0bd2> .
+    
+
+      <http://data.lblod.info/id/identificatoren/05472be6-1b7f-45b0-8a55-07bcb00bcce2> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "05472be6-1b7f-45b0-8a55-07bcb00bcce2";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/ec9f4745-7956-44ac-82dc-b0ed574e6fa8>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/ec9f4745-7956-44ac-82dc-b0ed574e6fa8> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "ec9f4745-7956-44ac-82dc-b0ed574e6fa8";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1293".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/d4acb193-549b-4565-84ec-a140f486d3be> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "d4acb193-549b-4565-84ec-a140f486d3be";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/4bc26a9d-33e0-4d20-85da-5ac68bf08e98>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/50af1508-4ee1-4a13-aa41-e8cdd6fbb46c>,
+                        <http://data.lblod.info/id/contact-punten/96a93a89-befa-49b1-bf6e-e62d6388a66d>.
+
+      <http://data.lblod.info/id/contact-punten/50af1508-4ee1-4a13-aa41-e8cdd6fbb46c> a <http://schema.org/ContactPoint>;
+        mu:uuid "50af1508-4ee1-4a13-aa41-e8cdd6fbb46c";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/96a93a89-befa-49b1-bf6e-e62d6388a66d> a <http://schema.org/ContactPoint>;
+        mu:uuid "96a93a89-befa-49b1-bf6e-e62d6388a66d";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/4bc26a9d-33e0-4d20-85da-5ac68bf08e98> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "4bc26a9d-33e0-4d20-85da-5ac68bf08e98".
+
+      <http://data.lblod.info/id/bestuurseenheden/e39d8bf95a03ade08ef25a79ebc050abfc81a69731f1de66fe6d031d27135aac> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "e39d8bf95a03ade08ef25a79ebc050abfc81a69731f1de66fe6d031d27135aac";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Grensleie: Ledegem, Menen en Wevelgem";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/05472be6-1b7f-45b0-8a55-07bcb00bcce2>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/d4acb193-549b-4565-84ec-a140f486d3be> .
+    
+
+      <http://data.lblod.info/id/identificatoren/a7d7e587-7175-441c-b446-20f1f5ee7117> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "a7d7e587-7175-441c-b446-20f1f5ee7117";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/06d29896-951f-4cba-b7f4-bb7d8c621c2b>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/06d29896-951f-4cba-b7f4-bb7d8c621c2b> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "06d29896-951f-4cba-b7f4-bb7d8c621c2b";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1294".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/6d4ae5d8-f9f5-460a-aa22-433ddc70953a> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "6d4ae5d8-f9f5-460a-aa22-433ddc70953a";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/95775176-610e-4430-bdf8-6a4bc17d3d04>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/01c3da20-92c5-4f97-820d-fae62c40ec2a>,
+                        <http://data.lblod.info/id/contact-punten/3fc3800b-b92f-4c2c-b7f0-e216c70890ae>.
+
+      <http://data.lblod.info/id/contact-punten/01c3da20-92c5-4f97-820d-fae62c40ec2a> a <http://schema.org/ContactPoint>;
+        mu:uuid "01c3da20-92c5-4f97-820d-fae62c40ec2a";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/3fc3800b-b92f-4c2c-b7f0-e216c70890ae> a <http://schema.org/ContactPoint>;
+        mu:uuid "3fc3800b-b92f-4c2c-b7f0-e216c70890ae";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/95775176-610e-4430-bdf8-6a4bc17d3d04> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "95775176-610e-4430-bdf8-6a4bc17d3d04".
+
+      <http://data.lblod.info/id/bestuurseenheden/35454115a5e3a31059e0c4fd55906df42c75885b0233c1f17eb4bcef6e696908> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "35454115a5e3a31059e0c4fd55906df42c75885b0233c1f17eb4bcef6e696908";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Leuven: Leuven";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/a7d7e587-7175-441c-b446-20f1f5ee7117>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/6d4ae5d8-f9f5-460a-aa22-433ddc70953a> .
+    
+
+      <http://data.lblod.info/id/identificatoren/8dc66ad8-80da-457b-9c7e-f38d9411bd5a> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "8dc66ad8-80da-457b-9c7e-f38d9411bd5a";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/e27ee40d-23bf-4e9d-b108-83f7f5847446>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/e27ee40d-23bf-4e9d-b108-83f7f5847446> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "e27ee40d-23bf-4e9d-b108-83f7f5847446";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1295".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/fc4e2bf5-e6a0-4ccf-a984-40a8e73f358a> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "fc4e2bf5-e6a0-4ccf-a984-40a8e73f358a";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/82587b56-0219-41d2-adc3-2e32fd31e68f>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/3befc703-0baa-44d2-86d8-e982d5d57723>,
+                        <http://data.lblod.info/id/contact-punten/8cca5e68-6ea1-40e3-82b5-abe4323e26d1>.
+
+      <http://data.lblod.info/id/contact-punten/3befc703-0baa-44d2-86d8-e982d5d57723> a <http://schema.org/ContactPoint>;
+        mu:uuid "3befc703-0baa-44d2-86d8-e982d5d57723";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/8cca5e68-6ea1-40e3-82b5-abe4323e26d1> a <http://schema.org/ContactPoint>;
+        mu:uuid "8cca5e68-6ea1-40e3-82b5-abe4323e26d1";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/82587b56-0219-41d2-adc3-2e32fd31e68f> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "82587b56-0219-41d2-adc3-2e32fd31e68f".
+
+      <http://data.lblod.info/id/bestuurseenheden/b77b75f239b9a14e40750981aa88976e46df7ddf83c3554103409a4a2291fea3> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "b77b75f239b9a14e40750981aa88976e46df7ddf83c3554103409a4a2291fea3";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Lier: Lier";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/8dc66ad8-80da-457b-9c7e-f38d9411bd5a>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/fc4e2bf5-e6a0-4ccf-a984-40a8e73f358a> .
+    
+
+      <http://data.lblod.info/id/identificatoren/4195d03f-0f01-404c-b5e7-9d5894c64654> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "4195d03f-0f01-404c-b5e7-9d5894c64654";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/af716cdb-c925-484f-a733-e21aa46728ad>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/af716cdb-c925-484f-a733-e21aa46728ad> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "af716cdb-c925-484f-a733-e21aa46728ad";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1296".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/d06a0ee6-34bc-4e1d-9023-47f894f59d40> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "d06a0ee6-34bc-4e1d-9023-47f894f59d40";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/d8b8f20b-f876-43ae-ab5d-294df22f982d>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/9a507a22-87ae-4ca9-a944-fcd7c0b281ad>,
+                        <http://data.lblod.info/id/contact-punten/31af8ef9-1132-4eb0-909d-f4f8558558f0>.
+
+      <http://data.lblod.info/id/contact-punten/9a507a22-87ae-4ca9-a944-fcd7c0b281ad> a <http://schema.org/ContactPoint>;
+        mu:uuid "9a507a22-87ae-4ca9-a944-fcd7c0b281ad";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/31af8ef9-1132-4eb0-909d-f4f8558558f0> a <http://schema.org/ContactPoint>;
+        mu:uuid "31af8ef9-1132-4eb0-909d-f4f8558558f0";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/d8b8f20b-f876-43ae-ab5d-294df22f982d> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "d8b8f20b-f876-43ae-ab5d-294df22f982d".
+
+      <http://data.lblod.info/id/bestuurseenheden/9cb5a65d9190da4bb96d0f59882cbcfb34248d354e6bd27101fccba186f4c7b7> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "9cb5a65d9190da4bb96d0f59882cbcfb34248d354e6bd27101fccba186f4c7b7";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Regio Puyenbroeck: Lochristi, Moerbeke, Wachtebeke en Zelzate";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/4195d03f-0f01-404c-b5e7-9d5894c64654>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/d06a0ee6-34bc-4e1d-9023-47f894f59d40> .
+    
+
+      <http://data.lblod.info/id/identificatoren/f5720e6f-4060-4638-97b4-4fcbc715f391> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "f5720e6f-4060-4638-97b4-4fcbc715f391";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/92117457-3b0c-4c02-8a96-006df6d89144>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/92117457-3b0c-4c02-8a96-006df6d89144> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "92117457-3b0c-4c02-8a96-006df6d89144";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1297".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/bfa58778-40d3-4d3b-8136-5d24cb4287bd> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "bfa58778-40d3-4d3b-8136-5d24cb4287bd";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/d965119c-951d-4109-9613-f9ee1476690c>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/55ce6e6f-8bf7-4b33-9948-82dc208130a6>,
+                        <http://data.lblod.info/id/contact-punten/13b0236f-53df-4786-82f6-058fccdfff4f>.
+
+      <http://data.lblod.info/id/contact-punten/55ce6e6f-8bf7-4b33-9948-82dc208130a6> a <http://schema.org/ContactPoint>;
+        mu:uuid "55ce6e6f-8bf7-4b33-9948-82dc208130a6";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/13b0236f-53df-4786-82f6-058fccdfff4f> a <http://schema.org/ContactPoint>;
+        mu:uuid "13b0236f-53df-4786-82f6-058fccdfff4f";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/d965119c-951d-4109-9613-f9ee1476690c> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "d965119c-951d-4109-9613-f9ee1476690c".
+
+      <http://data.lblod.info/id/bestuurseenheden/d8cb6ca314f27d657f4043f27110632e63a9520070728922d3c958f51d70c281> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "d8cb6ca314f27d657f4043f27110632e63a9520070728922d3c958f51d70c281";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Lokeren: Lokeren";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/f5720e6f-4060-4638-97b4-4fcbc715f391>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/bfa58778-40d3-4d3b-8136-5d24cb4287bd> .
+    
+
+      <http://data.lblod.info/id/identificatoren/99c0dbba-f207-444a-8970-2b05fd58d776> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "99c0dbba-f207-444a-8970-2b05fd58d776";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/d9dbd845-5522-4f30-a42c-a9258b5532ae>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/d9dbd845-5522-4f30-a42c-a9258b5532ae> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "d9dbd845-5522-4f30-a42c-a9258b5532ae";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1298".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/dc93c4aa-da5b-4fc2-ab7c-1cabd196053f> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "dc93c4aa-da5b-4fc2-ab7c-1cabd196053f";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/87b673e9-b495-4000-aae8-ec84aa9fde93>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/c9af162e-9ffb-4d44-bf68-781f4522fa1d>,
+                        <http://data.lblod.info/id/contact-punten/48e3a464-32f9-4b35-98b9-4677b15f9052>.
+
+      <http://data.lblod.info/id/contact-punten/c9af162e-9ffb-4d44-bf68-781f4522fa1d> a <http://schema.org/ContactPoint>;
+        mu:uuid "c9af162e-9ffb-4d44-bf68-781f4522fa1d";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/48e3a464-32f9-4b35-98b9-4677b15f9052> a <http://schema.org/ContactPoint>;
+        mu:uuid "48e3a464-32f9-4b35-98b9-4677b15f9052";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/87b673e9-b495-4000-aae8-ec84aa9fde93> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "87b673e9-b495-4000-aae8-ec84aa9fde93".
+
+      <http://data.lblod.info/id/bestuurseenheden/0b1af0370213e4b8ea5c3d5a2ccadcfce1149d092da47a3e447fe383050f9506> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "0b1af0370213e4b8ea5c3d5a2ccadcfce1149d092da47a3e447fe383050f9506";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Lommel: Lommel";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/99c0dbba-f207-444a-8970-2b05fd58d776>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/dc93c4aa-da5b-4fc2-ab7c-1cabd196053f> .
+    
+
+      <http://data.lblod.info/id/identificatoren/e1be497d-8212-47e9-87ff-d4ffe5689a6b> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "e1be497d-8212-47e9-87ff-d4ffe5689a6b";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/fa074572-c4ce-4f12-bb07-983d1534fd85>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/fa074572-c4ce-4f12-bb07-983d1534fd85> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "fa074572-c4ce-4f12-bb07-983d1534fd85";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1299".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/8f0d2f4b-691a-4c22-894c-6d16c7e4661c> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "8f0d2f4b-691a-4c22-894c-6d16c7e4661c";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/2d95136b-1409-4a18-bc9c-19f13382afcc>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/386070d6-8673-44cf-9007-4efbd14edaa7>,
+                        <http://data.lblod.info/id/contact-punten/e9ab94c9-5f6a-4dc2-a491-48d0d5204fde>.
+
+      <http://data.lblod.info/id/contact-punten/386070d6-8673-44cf-9007-4efbd14edaa7> a <http://schema.org/ContactPoint>;
+        mu:uuid "386070d6-8673-44cf-9007-4efbd14edaa7";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/e9ab94c9-5f6a-4dc2-a491-48d0d5204fde> a <http://schema.org/ContactPoint>;
+        mu:uuid "e9ab94c9-5f6a-4dc2-a491-48d0d5204fde";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/2d95136b-1409-4a18-bc9c-19f13382afcc> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "2d95136b-1409-4a18-bc9c-19f13382afcc".
+
+      <http://data.lblod.info/id/bestuurseenheden/2ba0f1e28168459a963a81784a8404e94268f70b49f99342d50ff421ab8a06c6> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "2ba0f1e28168459a963a81784a8404e94268f70b49f99342d50ff421ab8a06c6";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Lovendegem/Nevele/Waarschoot/Zomergem";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/e1be497d-8212-47e9-87ff-d4ffe5689a6b>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/8f0d2f4b-691a-4c22-894c-6d16c7e4661c> .
+    
+
+      <http://data.lblod.info/id/identificatoren/ff4085d6-a20b-442b-a8d9-50d647a07a8e> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "ff4085d6-a20b-442b-a8d9-50d647a07a8e";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/78160b6f-5586-486f-a3b0-5fede8edb799>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/78160b6f-5586-486f-a3b0-5fede8edb799> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "78160b6f-5586-486f-a3b0-5fede8edb799";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1300".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/c08fd938-08ff-40f8-8118-36b287ee9625> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "c08fd938-08ff-40f8-8118-36b287ee9625";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/d1bd4af6-d3e2-4649-9d33-16c3af377187>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/2dafa331-68a7-440f-a39b-7b3a271c0174>,
+                        <http://data.lblod.info/id/contact-punten/46f2f6b0-0c27-45c3-ab73-8ddcb4c2f5b7>.
+
+      <http://data.lblod.info/id/contact-punten/2dafa331-68a7-440f-a39b-7b3a271c0174> a <http://schema.org/ContactPoint>;
+        mu:uuid "2dafa331-68a7-440f-a39b-7b3a271c0174";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/46f2f6b0-0c27-45c3-ab73-8ddcb4c2f5b7> a <http://schema.org/ContactPoint>;
+        mu:uuid "46f2f6b0-0c27-45c3-ab73-8ddcb4c2f5b7";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/d1bd4af6-d3e2-4649-9d33-16c3af377187> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "d1bd4af6-d3e2-4649-9d33-16c3af377187".
+
+      <http://data.lblod.info/id/bestuurseenheden/d71ddb7a663a892d7a8cb511d30bf5ae3ba49fda39dd65e39dae9c789bb901fe> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "d71ddb7a663a892d7a8cb511d30bf5ae3ba49fda39dd65e39dae9c789bb901fe";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Maasmechelen";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/ff4085d6-a20b-442b-a8d9-50d647a07a8e>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/c08fd938-08ff-40f8-8118-36b287ee9625> .
+    
+
+      <http://data.lblod.info/id/identificatoren/7abb9446-daf7-4181-b70a-6ed893da0660> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "7abb9446-daf7-4181-b70a-6ed893da0660";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/767e546e-f201-4d55-9043-587c24d5165a>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/767e546e-f201-4d55-9043-587c24d5165a> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "767e546e-f201-4d55-9043-587c24d5165a";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1301".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/3d02ea6b-5ab3-4934-a0ce-d1f2b7b0fd0d> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "3d02ea6b-5ab3-4934-a0ce-d1f2b7b0fd0d";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/ad1abf7b-ef03-4692-9515-0f433de1f07e>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/d4478781-c473-43c5-84f2-f16425331081>,
+                        <http://data.lblod.info/id/contact-punten/cb6042b0-7b88-4a83-994a-270884e64f6a>.
+
+      <http://data.lblod.info/id/contact-punten/d4478781-c473-43c5-84f2-f16425331081> a <http://schema.org/ContactPoint>;
+        mu:uuid "d4478781-c473-43c5-84f2-f16425331081";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/cb6042b0-7b88-4a83-994a-270884e64f6a> a <http://schema.org/ContactPoint>;
+        mu:uuid "cb6042b0-7b88-4a83-994a-270884e64f6a";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/ad1abf7b-ef03-4692-9515-0f433de1f07e> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "ad1abf7b-ef03-4692-9515-0f433de1f07e".
+
+      <http://data.lblod.info/id/bestuurseenheden/d6fe7204ffe4c6c227156eb34caddcd860f911cc98728f9593d9cd7d28d3161d> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "d6fe7204ffe4c6c227156eb34caddcd860f911cc98728f9593d9cd7d28d3161d";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Vilvoorde/Machelen: Vilvoorde en Machelen";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/7abb9446-daf7-4181-b70a-6ed893da0660>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/3d02ea6b-5ab3-4934-a0ce-d1f2b7b0fd0d> .
+    
+
+      <http://data.lblod.info/id/identificatoren/b213042b-9d5d-4b4c-83fc-ef44c20ebdd5> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "b213042b-9d5d-4b4c-83fc-ef44c20ebdd5";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/a8efb7b7-9a68-4bd6-8f9f-b1c8aa7919a8>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/a8efb7b7-9a68-4bd6-8f9f-b1c8aa7919a8> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "a8efb7b7-9a68-4bd6-8f9f-b1c8aa7919a8";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1302".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/21c182ce-d17e-48f6-9f2a-713a661eae53> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "21c182ce-d17e-48f6-9f2a-713a661eae53";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/beed376f-3db2-4996-ad21-e036e59d2c6d>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/37dc0253-fa11-4e43-a61a-97a2762719b6>,
+                        <http://data.lblod.info/id/contact-punten/d0313472-bfd3-4314-adb0-fd6b16f2e013>.
+
+      <http://data.lblod.info/id/contact-punten/37dc0253-fa11-4e43-a61a-97a2762719b6> a <http://schema.org/ContactPoint>;
+        mu:uuid "37dc0253-fa11-4e43-a61a-97a2762719b6";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/d0313472-bfd3-4314-adb0-fd6b16f2e013> a <http://schema.org/ContactPoint>;
+        mu:uuid "d0313472-bfd3-4314-adb0-fd6b16f2e013";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/beed376f-3db2-4996-ad21-e036e59d2c6d> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "beed376f-3db2-4996-ad21-e036e59d2c6d".
+
+      <http://data.lblod.info/id/bestuurseenheden/3b7a6d691943806c23f59d22482dea27e451bd440f91f884aeb42e8c72016ee3> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "3b7a6d691943806c23f59d22482dea27e451bd440f91f884aeb42e8c72016ee3";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Maldegem: Maldegem";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/b213042b-9d5d-4b4c-83fc-ef44c20ebdd5>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/21c182ce-d17e-48f6-9f2a-713a661eae53> .
+    
+
+      <http://data.lblod.info/id/identificatoren/dc225972-0db2-4590-9428-f16148451276> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "dc225972-0db2-4590-9428-f16148451276";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/9d4dc51a-66cc-4688-9313-21aa88122b6b>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/9d4dc51a-66cc-4688-9313-21aa88122b6b> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "9d4dc51a-66cc-4688-9313-21aa88122b6b";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1303".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/5af52ac0-427a-4d55-ab67-89fb1ade16bc> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "5af52ac0-427a-4d55-ab67-89fb1ade16bc";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/87d16851-e585-4329-8f80-4fa4b8bfd609>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/ec1d5bb2-5b06-477f-996f-b9218d2d16df>,
+                        <http://data.lblod.info/id/contact-punten/47eca9ac-0fed-437c-84dd-d81c6d5462d4>.
+
+      <http://data.lblod.info/id/contact-punten/ec1d5bb2-5b06-477f-996f-b9218d2d16df> a <http://schema.org/ContactPoint>;
+        mu:uuid "ec1d5bb2-5b06-477f-996f-b9218d2d16df";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/47eca9ac-0fed-437c-84dd-d81c6d5462d4> a <http://schema.org/ContactPoint>;
+        mu:uuid "47eca9ac-0fed-437c-84dd-d81c6d5462d4";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/87d16851-e585-4329-8f80-4fa4b8bfd609> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "87d16851-e585-4329-8f80-4fa4b8bfd609".
+
+      <http://data.lblod.info/id/bestuurseenheden/1915208b0a66992ee2014df894f7a9c538fe727a975fd9538d9e2c949e1a8471> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "1915208b0a66992ee2014df894f7a9c538fe727a975fd9538d9e2c949e1a8471";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Mechelen";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/dc225972-0db2-4590-9428-f16148451276>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/5af52ac0-427a-4d55-ab67-89fb1ade16bc> .
+    
+
+      <http://data.lblod.info/id/identificatoren/396ae372-a9b9-492d-b485-65eddc58a8da> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "396ae372-a9b9-492d-b485-65eddc58a8da";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/d562ee63-1755-4520-8b67-84b666db5cb9>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/d562ee63-1755-4520-8b67-84b666db5cb9> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "d562ee63-1755-4520-8b67-84b666db5cb9";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1304".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/aa49ce01-33c7-40c9-bacc-c0a411d96647> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "aa49ce01-33c7-40c9-bacc-c0a411d96647";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/802a0997-8a59-412c-b7a0-1512ff3fcdfb>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/2d88247e-e8ef-4d8b-b3fd-64aad74cef2a>,
+                        <http://data.lblod.info/id/contact-punten/da8cfe6e-4de6-451f-9717-189be12a5440>.
+
+      <http://data.lblod.info/id/contact-punten/2d88247e-e8ef-4d8b-b3fd-64aad74cef2a> a <http://schema.org/ContactPoint>;
+        mu:uuid "2d88247e-e8ef-4d8b-b3fd-64aad74cef2a";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/da8cfe6e-4de6-451f-9717-189be12a5440> a <http://schema.org/ContactPoint>;
+        mu:uuid "da8cfe6e-4de6-451f-9717-189be12a5440";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/802a0997-8a59-412c-b7a0-1512ff3fcdfb> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "802a0997-8a59-412c-b7a0-1512ff3fcdfb".
+
+      <http://data.lblod.info/id/bestuurseenheden/73777b2512fc25f16554612a13b0de2265a56540a5ea6665bf69a8b5a805569a> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "73777b2512fc25f16554612a13b0de2265a56540a5ea6665bf69a8b5a805569a";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Mechelen/Willebroek";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/396ae372-a9b9-492d-b485-65eddc58a8da>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/aa49ce01-33c7-40c9-bacc-c0a411d96647> .
+    
+
+      <http://data.lblod.info/id/identificatoren/60b189ed-f05a-4e57-8324-0aba0b870ad6> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "60b189ed-f05a-4e57-8324-0aba0b870ad6";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/3c1aa820-6113-4101-8cd4-2d2abcc362b0>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/3c1aa820-6113-4101-8cd4-2d2abcc362b0> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "3c1aa820-6113-4101-8cd4-2d2abcc362b0";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1305".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/fe0ba7bb-ad8f-4a59-9d34-c0e4ad034f62> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "fe0ba7bb-ad8f-4a59-9d34-c0e4ad034f62";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/914da396-475a-49e8-9268-fd6db5016dff>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/b1e3de84-aa7c-435f-8fd4-52e9d24143cf>,
+                        <http://data.lblod.info/id/contact-punten/3192318d-fa59-4ca3-8a9f-5ae48564ac33>.
+
+      <http://data.lblod.info/id/contact-punten/b1e3de84-aa7c-435f-8fd4-52e9d24143cf> a <http://schema.org/ContactPoint>;
+        mu:uuid "b1e3de84-aa7c-435f-8fd4-52e9d24143cf";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/3192318d-fa59-4ca3-8a9f-5ae48564ac33> a <http://schema.org/ContactPoint>;
+        mu:uuid "3192318d-fa59-4ca3-8a9f-5ae48564ac33";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/914da396-475a-49e8-9268-fd6db5016dff> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "914da396-475a-49e8-9268-fd6db5016dff".
+
+      <http://data.lblod.info/id/bestuurseenheden/04e7a09c988feed3cf8df1c51aafe0f0a50811e325f5f5ab8e1b9750f48630fd> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "04e7a09c988feed3cf8df1c51aafe0f0a50811e325f5f5ab8e1b9750f48630fd";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Middelkerke: Middelkerke";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/60b189ed-f05a-4e57-8324-0aba0b870ad6>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/fe0ba7bb-ad8f-4a59-9d34-c0e4ad034f62> .
+    
+
+      <http://data.lblod.info/id/identificatoren/023297aa-f05d-4bda-bd71-d91a028a64f1> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "023297aa-f05d-4bda-bd71-d91a028a64f1";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/372fda81-63e4-424b-82a5-d6babb4f054b>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/372fda81-63e4-424b-82a5-d6babb4f054b> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "372fda81-63e4-424b-82a5-d6babb4f054b";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1306".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/6941f653-5e6f-4b1b-a8a8-8506e190bc6a> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "6941f653-5e6f-4b1b-a8a8-8506e190bc6a";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/eb58abb1-5d8c-4dc8-b774-d5f41a67281f>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/db9f9c6c-b59a-41fc-a157-bf1273a16443>,
+                        <http://data.lblod.info/id/contact-punten/06671850-4cb7-48fb-a73f-e09fefd19b2b>.
+
+      <http://data.lblod.info/id/contact-punten/db9f9c6c-b59a-41fc-a157-bf1273a16443> a <http://schema.org/ContactPoint>;
+        mu:uuid "db9f9c6c-b59a-41fc-a157-bf1273a16443";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/06671850-4cb7-48fb-a73f-e09fefd19b2b> a <http://schema.org/ContactPoint>;
+        mu:uuid "06671850-4cb7-48fb-a73f-e09fefd19b2b";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/eb58abb1-5d8c-4dc8-b774-d5f41a67281f> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "eb58abb1-5d8c-4dc8-b774-d5f41a67281f".
+
+      <http://data.lblod.info/id/bestuurseenheden/3efb7cb7fad9f61917093d42513c8a7153120906e9701b08e3560c8f109e64c1> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "3efb7cb7fad9f61917093d42513c8a7153120906e9701b08e3560c8f109e64c1";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Midden-Limburg";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/023297aa-f05d-4bda-bd71-d91a028a64f1>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/6941f653-5e6f-4b1b-a8a8-8506e190bc6a> .
+    
+
+      <http://data.lblod.info/id/identificatoren/1fd75767-f53c-4ae7-a530-ac18061a8999> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "1fd75767-f53c-4ae7-a530-ac18061a8999";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/305bab2c-74ea-4770-9c3e-3c6680a22bc8>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/305bab2c-74ea-4770-9c3e-3c6680a22bc8> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "305bab2c-74ea-4770-9c3e-3c6680a22bc8";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1307".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/8cf05f09-a6e0-4f60-a7df-97f5c8b4a583> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "8cf05f09-a6e0-4f60-a7df-97f5c8b4a583";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/1f0ad1c8-96a7-45ab-b289-99c1d66ad32c>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/dca69bc9-6abb-4e81-b37b-3ff5e3780468>,
+                        <http://data.lblod.info/id/contact-punten/2527cc08-8012-4784-bccc-e3a9d754fdf6>.
+
+      <http://data.lblod.info/id/contact-punten/dca69bc9-6abb-4e81-b37b-3ff5e3780468> a <http://schema.org/ContactPoint>;
+        mu:uuid "dca69bc9-6abb-4e81-b37b-3ff5e3780468";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/2527cc08-8012-4784-bccc-e3a9d754fdf6> a <http://schema.org/ContactPoint>;
+        mu:uuid "2527cc08-8012-4784-bccc-e3a9d754fdf6";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/1f0ad1c8-96a7-45ab-b289-99c1d66ad32c> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "1f0ad1c8-96a7-45ab-b289-99c1d66ad32c".
+
+      <http://data.lblod.info/id/bestuurseenheden/97a393c64a3c30e619bc115ab8b2bbe0bd7a83265ebb8960c0f1154b9628d340> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "97a393c64a3c30e619bc115ab8b2bbe0bd7a83265ebb8960c0f1154b9628d340";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Neteland: Grobbendonk, Herentals, Herenthout, Olen en Vorselaar";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/1fd75767-f53c-4ae7-a530-ac18061a8999>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/8cf05f09-a6e0-4f60-a7df-97f5c8b4a583> .
+    
+
+      <http://data.lblod.info/id/identificatoren/19c4485e-76fd-4a4b-90d6-015a0f636448> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "19c4485e-76fd-4a4b-90d6-015a0f636448";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/e124b6bd-e8bc-492f-a924-bd03a79518f5>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/e124b6bd-e8bc-492f-a924-bd03a79518f5> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "e124b6bd-e8bc-492f-a924-bd03a79518f5";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1308".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/b9592c93-3200-4d88-85dc-05f0702f99c9> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "b9592c93-3200-4d88-85dc-05f0702f99c9";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/05cf4a63-55f7-4e71-bec6-a92ee96e78f1>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/3870d3db-7f9f-4f34-b5e1-557600ae5993>,
+                        <http://data.lblod.info/id/contact-punten/876684ef-b5e6-438e-9c0d-a754501facd9>.
+
+      <http://data.lblod.info/id/contact-punten/3870d3db-7f9f-4f34-b5e1-557600ae5993> a <http://schema.org/ContactPoint>;
+        mu:uuid "3870d3db-7f9f-4f34-b5e1-557600ae5993";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/876684ef-b5e6-438e-9c0d-a754501facd9> a <http://schema.org/ContactPoint>;
+        mu:uuid "876684ef-b5e6-438e-9c0d-a754501facd9";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/05cf4a63-55f7-4e71-bec6-a92ee96e78f1> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "05cf4a63-55f7-4e71-bec6-a92ee96e78f1".
+
+      <http://data.lblod.info/id/bestuurseenheden/7b1c9132de06d5b3626e7118dc16c7f129d7c911b3298a0f4609725372e64588> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "7b1c9132de06d5b3626e7118dc16c7f129d7c911b3298a0f4609725372e64588";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Ninove: Ninove";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/19c4485e-76fd-4a4b-90d6-015a0f636448>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/b9592c93-3200-4d88-85dc-05f0702f99c9> .
+    
+
+      <http://data.lblod.info/id/identificatoren/a922355d-5485-4ae9-90f1-0cc4cc312bc6> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "a922355d-5485-4ae9-90f1-0cc4cc312bc6";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/e1a276b0-3747-450c-bc1a-3111b336c1e1>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/e1a276b0-3747-450c-bc1a-3111b336c1e1> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "e1a276b0-3747-450c-bc1a-3111b336c1e1";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1309".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/87522c93-06f9-4edb-afa4-97020879da1a> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "87522c93-06f9-4edb-afa4-97020879da1a";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/2756a595-ba52-425f-aa0c-34ee750502c3>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/74468da9-b8a6-4889-921a-54461d95bd16>,
+                        <http://data.lblod.info/id/contact-punten/6c87024e-43b0-45c6-a1ed-fa8d300aa2e6>.
+
+      <http://data.lblod.info/id/contact-punten/74468da9-b8a6-4889-921a-54461d95bd16> a <http://schema.org/ContactPoint>;
+        mu:uuid "74468da9-b8a6-4889-921a-54461d95bd16";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/6c87024e-43b0-45c6-a1ed-fa8d300aa2e6> a <http://schema.org/ContactPoint>;
+        mu:uuid "6c87024e-43b0-45c6-a1ed-fa8d300aa2e6";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/2756a595-ba52-425f-aa0c-34ee750502c3> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "2756a595-ba52-425f-aa0c-34ee750502c3".
+
+      <http://data.lblod.info/id/bestuurseenheden/b7e07299d7acf9e78f802915227b243c31fc56eadfb575039b81fb871eec9755> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "b7e07299d7acf9e78f802915227b243c31fc56eadfb575039b81fb871eec9755";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Oostende: Oostende";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/a922355d-5485-4ae9-90f1-0cc4cc312bc6>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/87522c93-06f9-4edb-afa4-97020879da1a> .
+    
+
+      <http://data.lblod.info/id/identificatoren/d27bffa4-04bc-47fc-ba29-6b9c9be46e05> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "d27bffa4-04bc-47fc-ba29-6b9c9be46e05";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/46afe4d8-99d9-4aee-a648-288f98de664c>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/46afe4d8-99d9-4aee-a648-288f98de664c> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "46afe4d8-99d9-4aee-a648-288f98de664c";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1311".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/f7e41d0b-9690-49af-8901-44293713853a> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "f7e41d0b-9690-49af-8901-44293713853a";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/5289160e-75b2-4b9b-a333-1888d03080aa>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/1a525a8f-2e73-464b-a0fb-ac42703b8819>,
+                        <http://data.lblod.info/id/contact-punten/12fa221a-d2d4-4e0d-bd09-66a290f625ff>.
+
+      <http://data.lblod.info/id/contact-punten/1a525a8f-2e73-464b-a0fb-ac42703b8819> a <http://schema.org/ContactPoint>;
+        mu:uuid "1a525a8f-2e73-464b-a0fb-ac42703b8819";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/12fa221a-d2d4-4e0d-bd09-66a290f625ff> a <http://schema.org/ContactPoint>;
+        mu:uuid "12fa221a-d2d4-4e0d-bd09-66a290f625ff";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/5289160e-75b2-4b9b-a333-1888d03080aa> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "5289160e-75b2-4b9b-a333-1888d03080aa".
+
+      <http://data.lblod.info/id/bestuurseenheden/805a977a29725d94f50bf7f0d91a0de1a727c4eec88940e90035f71c6c9b1655> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "805a977a29725d94f50bf7f0d91a0de1a727c4eec88940e90035f71c6c9b1655";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ ZARA: Zandhoven en Ranst";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/d27bffa4-04bc-47fc-ba29-6b9c9be46e05>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/f7e41d0b-9690-49af-8901-44293713853a> .
+    
+
+      <http://data.lblod.info/id/identificatoren/18ae7fc8-18c4-4d6b-9850-c64051841fac> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "18ae7fc8-18c4-4d6b-9850-c64051841fac";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/2f0ebdb7-2763-4cbe-bf3a-3d5454f35483>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/2f0ebdb7-2763-4cbe-bf3a-3d5454f35483> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "2f0ebdb7-2763-4cbe-bf3a-3d5454f35483";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1312".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/aae15e1a-0115-4208-9c62-cbfe44458e57> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "aae15e1a-0115-4208-9c62-cbfe44458e57";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/325cca7d-894a-4ccb-be92-c1debd1b9c02>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/d0441fd5-5512-491f-a133-fa19527ffb98>,
+                        <http://data.lblod.info/id/contact-punten/9b0cbee1-000b-44b7-b3a1-73cc8e82a369>.
+
+      <http://data.lblod.info/id/contact-punten/d0441fd5-5512-491f-a133-fa19527ffb98> a <http://schema.org/ContactPoint>;
+        mu:uuid "d0441fd5-5512-491f-a133-fa19527ffb98";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/9b0cbee1-000b-44b7-b3a1-73cc8e82a369> a <http://schema.org/ContactPoint>;
+        mu:uuid "9b0cbee1-000b-44b7-b3a1-73cc8e82a369";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/325cca7d-894a-4ccb-be92-c1debd1b9c02> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "325cca7d-894a-4ccb-be92-c1debd1b9c02".
+
+      <http://data.lblod.info/id/bestuurseenheden/93389f5157ceb037c5e38d7b8119cef632528b870e91e209c033bc2eac220cc1> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "93389f5157ceb037c5e38d7b8119cef632528b870e91e209c033bc2eac220cc1";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Regio Rhode & Schelde: Destelbergen, Melle, Merelbeke en Oosterzele";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/18ae7fc8-18c4-4d6b-9850-c64051841fac>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/aae15e1a-0115-4208-9c62-cbfe44458e57> .
+    
+
+      <http://data.lblod.info/id/identificatoren/f2d8a59c-4229-45b1-9c09-5cf40cea86a9> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "f2d8a59c-4229-45b1-9c09-5cf40cea86a9";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/ec815a7d-0994-4cc7-8a2a-9197cab077df>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/ec815a7d-0994-4cc7-8a2a-9197cab077df> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "ec815a7d-0994-4cc7-8a2a-9197cab077df";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1313".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/ba7fdf08-2d37-416c-b533-c9ab1a00e9cf> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "ba7fdf08-2d37-416c-b533-c9ab1a00e9cf";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/60615265-fb98-4be8-961f-34644d2009d8>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/a2566f0b-8a2c-43c2-93c1-da79af4892cf>,
+                        <http://data.lblod.info/id/contact-punten/05d8520d-f6fe-4509-9bd4-753b7e7bf168>.
+
+      <http://data.lblod.info/id/contact-punten/a2566f0b-8a2c-43c2-93c1-da79af4892cf> a <http://schema.org/ContactPoint>;
+        mu:uuid "a2566f0b-8a2c-43c2-93c1-da79af4892cf";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/05d8520d-f6fe-4509-9bd4-753b7e7bf168> a <http://schema.org/ContactPoint>;
+        mu:uuid "05d8520d-f6fe-4509-9bd4-753b7e7bf168";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/60615265-fb98-4be8-961f-34644d2009d8> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "60615265-fb98-4be8-961f-34644d2009d8".
+
+      <http://data.lblod.info/id/bestuurseenheden/f398f3ebafe08244f84eac783b61eac71c60bd39b8ca9ee8d9c2a4dc8638a772> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "f398f3ebafe08244f84eac783b61eac71c60bd39b8ca9ee8d9c2a4dc8638a772";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Ronse: Ronse";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/f2d8a59c-4229-45b1-9c09-5cf40cea86a9>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/ba7fdf08-2d37-416c-b533-c9ab1a00e9cf> .
+    
+
+      <http://data.lblod.info/id/identificatoren/67d76d9b-c4c9-4f1b-8c08-9466627d436c> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "67d76d9b-c4c9-4f1b-8c08-9466627d436c";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/a5928e45-82f7-4916-b30f-f4d2b3f7ce8b>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/a5928e45-82f7-4916-b30f-f4d2b3f7ce8b> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "a5928e45-82f7-4916-b30f-f4d2b3f7ce8b";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1314".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/154fc883-a699-4830-b8ad-6076171c900a> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "154fc883-a699-4830-b8ad-6076171c900a";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/c2674cea-5fe1-4afa-bfbb-e7e3b13bac9e>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/db695ddc-cda4-4270-a303-5ee76b67a79b>,
+                        <http://data.lblod.info/id/contact-punten/04f5a737-22f7-4e62-a4ef-64dd2a6ef72c>.
+
+      <http://data.lblod.info/id/contact-punten/db695ddc-cda4-4270-a303-5ee76b67a79b> a <http://schema.org/ContactPoint>;
+        mu:uuid "db695ddc-cda4-4270-a303-5ee76b67a79b";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/04f5a737-22f7-4e62-a4ef-64dd2a6ef72c> a <http://schema.org/ContactPoint>;
+        mu:uuid "04f5a737-22f7-4e62-a4ef-64dd2a6ef72c";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/c2674cea-5fe1-4afa-bfbb-e7e3b13bac9e> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "c2674cea-5fe1-4afa-bfbb-e7e3b13bac9e".
+
+      <http://data.lblod.info/id/bestuurseenheden/1298cc0fec62af4dcaa86b44d43fe7e3ee3632247e66e8fccd87c0e5c7b7742f> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "1298cc0fec62af4dcaa86b44d43fe7e3ee3632247e66e8fccd87c0e5c7b7742f";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Schoten: Schoten";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/67d76d9b-c4c9-4f1b-8c08-9466627d436c>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/154fc883-a699-4830-b8ad-6076171c900a> .
+    
+
+      <http://data.lblod.info/id/identificatoren/b8c82955-d0fc-4eac-9960-f3a240d00279> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "b8c82955-d0fc-4eac-9960-f3a240d00279";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/a3c31cf3-184a-4670-91fa-e4a9970357d2>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/a3c31cf3-184a-4670-91fa-e4a9970357d2> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "a3c31cf3-184a-4670-91fa-e4a9970357d2";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1315".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/e9e328a9-7047-4b77-a959-73925563804a> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "e9e328a9-7047-4b77-a959-73925563804a";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/c4421ad4-83b0-4fe1-9086-c363d963a474>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/c1e5b010-3d57-41cc-8b27-bb959f05e04f>,
+                        <http://data.lblod.info/id/contact-punten/2f875250-333b-45da-80ef-2413e3b2b677>.
+
+      <http://data.lblod.info/id/contact-punten/c1e5b010-3d57-41cc-8b27-bb959f05e04f> a <http://schema.org/ContactPoint>;
+        mu:uuid "c1e5b010-3d57-41cc-8b27-bb959f05e04f";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/2f875250-333b-45da-80ef-2413e3b2b677> a <http://schema.org/ContactPoint>;
+        mu:uuid "2f875250-333b-45da-80ef-2413e3b2b677";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/c4421ad4-83b0-4fe1-9086-c363d963a474> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "c4421ad4-83b0-4fe1-9086-c363d963a474".
+
+      <http://data.lblod.info/id/bestuurseenheden/0cfc443c59ad06e1292b9805d967f181b989913a1ccc3e3f50a4dd8ca16bc772> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "0cfc443c59ad06e1292b9805d967f181b989913a1ccc3e3f50a4dd8ca16bc772";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Sint-Gillis-Waas/Stekene";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/b8c82955-d0fc-4eac-9960-f3a240d00279>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/e9e328a9-7047-4b77-a959-73925563804a> .
+    
+
+      <http://data.lblod.info/id/identificatoren/584b842b-3189-4d52-b257-0e0f73ad8331> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "584b842b-3189-4d52-b257-0e0f73ad8331";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/cfb02233-366b-4e8c-be0e-b314d0ad90c0>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/cfb02233-366b-4e8c-be0e-b314d0ad90c0> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "cfb02233-366b-4e8c-be0e-b314d0ad90c0";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1316".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/a7b68306-ade2-4a00-af35-985c50abacc3> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "a7b68306-ade2-4a00-af35-985c50abacc3";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/a85f70b5-2d86-4ca2-8efb-851a8f4358c3>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/c223f780-5488-49d6-82da-dc204d7f628d>,
+                        <http://data.lblod.info/id/contact-punten/a7745d28-bdd7-4026-9a22-3e31c9350969>.
+
+      <http://data.lblod.info/id/contact-punten/c223f780-5488-49d6-82da-dc204d7f628d> a <http://schema.org/ContactPoint>;
+        mu:uuid "c223f780-5488-49d6-82da-dc204d7f628d";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/a7745d28-bdd7-4026-9a22-3e31c9350969> a <http://schema.org/ContactPoint>;
+        mu:uuid "a7745d28-bdd7-4026-9a22-3e31c9350969";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/a85f70b5-2d86-4ca2-8efb-851a8f4358c3> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "a85f70b5-2d86-4ca2-8efb-851a8f4358c3".
+
+      <http://data.lblod.info/id/bestuurseenheden/5d55c0281e70d053158a06a7898bb3e1a89ed48cf111c4b6fc2a9502ebafcade> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "5d55c0281e70d053158a06a7898bb3e1a89ed48cf111c4b6fc2a9502ebafcade";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Sint-Niklaas: Sint-Niklaas";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/584b842b-3189-4d52-b257-0e0f73ad8331>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/a7b68306-ade2-4a00-af35-985c50abacc3> .
+    
+
+      <http://data.lblod.info/id/identificatoren/1d115034-f03d-4b9d-94ab-716ee2a95cb0> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "1d115034-f03d-4b9d-94ab-716ee2a95cb0";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/c08195e1-dec7-4d6c-8e55-42bd60e93a75>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/c08195e1-dec7-4d6c-8e55-42bd60e93a75> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "c08195e1-dec7-4d6c-8e55-42bd60e93a75";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1317".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/04364e1a-4441-4e7e-a60a-db8f658af2b6> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "04364e1a-4441-4e7e-a60a-db8f658af2b6";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/728e34b3-23b3-4210-9406-8c0b96d852f6>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/46a93e8a-33dd-4493-9d84-4378d0bfd6ca>,
+                        <http://data.lblod.info/id/contact-punten/b0d41686-185f-4205-af02-d9eadd1578cd>.
+
+      <http://data.lblod.info/id/contact-punten/46a93e8a-33dd-4493-9d84-4378d0bfd6ca> a <http://schema.org/ContactPoint>;
+        mu:uuid "46a93e8a-33dd-4493-9d84-4378d0bfd6ca";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/b0d41686-185f-4205-af02-d9eadd1578cd> a <http://schema.org/ContactPoint>;
+        mu:uuid "b0d41686-185f-4205-af02-d9eadd1578cd";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/728e34b3-23b3-4210-9406-8c0b96d852f6> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "728e34b3-23b3-4210-9406-8c0b96d852f6".
+
+      <http://data.lblod.info/id/bestuurseenheden/b9fd6a7fa1ddabcaa0eb9d2eac74b41d5671623a6799a520308daabb53d5937d> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "b9fd6a7fa1ddabcaa0eb9d2eac74b41d5671623a6799a520308daabb53d5937d";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Sint-Pieters-Leeuw";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/1d115034-f03d-4b9d-94ab-716ee2a95cb0>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/04364e1a-4441-4e7e-a60a-db8f658af2b6> .
+    
+
+      <http://data.lblod.info/id/identificatoren/881033ca-7b5b-409f-8ae0-187cb087cec9> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "881033ca-7b5b-409f-8ae0-187cb087cec9";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/d3b4b9e5-aeb7-47dd-91ff-50d0e30684e9>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/d3b4b9e5-aeb7-47dd-91ff-50d0e30684e9> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "d3b4b9e5-aeb7-47dd-91ff-50d0e30684e9";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1318".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/f0b45cde-1723-4d02-9f13-e9e08ddc43fc> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "f0b45cde-1723-4d02-9f13-e9e08ddc43fc";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/321a9208-bdf2-41fc-9676-8ee54260041c>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/8637a7c8-918e-4d75-832f-e0e59c2e71d3>,
+                        <http://data.lblod.info/id/contact-punten/8965b5b8-92d5-41d2-bc43-e316f5924d8a>.
+
+      <http://data.lblod.info/id/contact-punten/8637a7c8-918e-4d75-832f-e0e59c2e71d3> a <http://schema.org/ContactPoint>;
+        mu:uuid "8637a7c8-918e-4d75-832f-e0e59c2e71d3";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/8965b5b8-92d5-41d2-bc43-e316f5924d8a> a <http://schema.org/ContactPoint>;
+        mu:uuid "8965b5b8-92d5-41d2-bc43-e316f5924d8a";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/321a9208-bdf2-41fc-9676-8ee54260041c> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "321a9208-bdf2-41fc-9676-8ee54260041c".
+
+      <http://data.lblod.info/id/bestuurseenheden/dea71925b69de424a8bb3c90ad5751f39c35df9e85ade437e6f6404b3ba12a42> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "dea71925b69de424a8bb3c90ad5751f39c35df9e85ade437e6f6404b3ba12a42";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Tervuren";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/881033ca-7b5b-409f-8ae0-187cb087cec9>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/f0b45cde-1723-4d02-9f13-e9e08ddc43fc> .
+    
+
+      <http://data.lblod.info/id/identificatoren/0c9d8b5d-1d08-45af-8a5d-3949f9727386> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "0c9d8b5d-1d08-45af-8a5d-3949f9727386";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/5b82eb1a-9d9b-4386-9d80-930163a189db>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/5b82eb1a-9d9b-4386-9d80-930163a189db> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "5b82eb1a-9d9b-4386-9d80-930163a189db";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1319".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/cf4f1b17-c750-4261-bc3e-60fe5c0bee69> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "cf4f1b17-c750-4261-bc3e-60fe5c0bee69";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/186ba6b3-9913-46f6-b333-230cc4aa495d>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/97ec3c55-cf53-402e-b025-cb48e704e560>,
+                        <http://data.lblod.info/id/contact-punten/f3a1e17a-26a3-4a5c-af3d-d75611a94b5a>.
+
+      <http://data.lblod.info/id/contact-punten/97ec3c55-cf53-402e-b025-cb48e704e560> a <http://schema.org/ContactPoint>;
+        mu:uuid "97ec3c55-cf53-402e-b025-cb48e704e560";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/f3a1e17a-26a3-4a5c-af3d-d75611a94b5a> a <http://schema.org/ContactPoint>;
+        mu:uuid "f3a1e17a-26a3-4a5c-af3d-d75611a94b5a";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/186ba6b3-9913-46f6-b333-230cc4aa495d> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "186ba6b3-9913-46f6-b333-230cc4aa495d".
+
+      <http://data.lblod.info/id/bestuurseenheden/cdcd4403-d4cd-4400-80a3-9882d79933f4> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "cdcd4403-d4cd-4400-80a3-9882d79933f4";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Voer & Dijle: Bertem, Huldenberg, Oud-Heverlee en Tervuren";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/0c9d8b5d-1d08-45af-8a5d-3949f9727386>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/cf4f1b17-c750-4261-bc3e-60fe5c0bee69> .
+    
+
+      <http://data.lblod.info/id/identificatoren/5bd95dfc-17ed-41e4-8046-b7c6b4a8894b> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "5bd95dfc-17ed-41e4-8046-b7c6b4a8894b";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/f51f2b48-95b5-473a-bddf-5fa3a407f799>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/f51f2b48-95b5-473a-bddf-5fa3a407f799> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "f51f2b48-95b5-473a-bddf-5fa3a407f799";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1320".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/32d3f362-c0ca-4572-88c5-88c8e9a96078> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "32d3f362-c0ca-4572-88c5-88c8e9a96078";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/82189d30-da4c-496e-9560-aac1eae76eb3>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/b9147153-d307-4218-8c57-7e11037cc2ce>,
+                        <http://data.lblod.info/id/contact-punten/4238a00e-8f46-4d81-a252-e7687177e4a1>.
+
+      <http://data.lblod.info/id/contact-punten/b9147153-d307-4218-8c57-7e11037cc2ce> a <http://schema.org/ContactPoint>;
+        mu:uuid "b9147153-d307-4218-8c57-7e11037cc2ce";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/4238a00e-8f46-4d81-a252-e7687177e4a1> a <http://schema.org/ContactPoint>;
+        mu:uuid "4238a00e-8f46-4d81-a252-e7687177e4a1";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/82189d30-da4c-496e-9560-aac1eae76eb3> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "82189d30-da4c-496e-9560-aac1eae76eb3".
+
+      <http://data.lblod.info/id/bestuurseenheden/92609bcab00475b084e747cb49f942abfb9e737ab023a999c69baf60acb8c06d> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "92609bcab00475b084e747cb49f942abfb9e737ab023a999c69baf60acb8c06d";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Voeren: Voeren";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/5bd95dfc-17ed-41e4-8046-b7c6b4a8894b>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/32d3f362-c0ca-4572-88c5-88c8e9a96078> .
+    
+
+      <http://data.lblod.info/id/identificatoren/279e0cb8-09b1-491e-97bd-ecb5cd4e3543> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "279e0cb8-09b1-491e-97bd-ecb5cd4e3543";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/fbb7f291-012c-4b22-b401-e0a6c51ffc0b>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/fbb7f291-012c-4b22-b401-e0a6c51ffc0b> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "fbb7f291-012c-4b22-b401-e0a6c51ffc0b";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1321".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/de0b36f6-ade3-41c2-9a21-5fdbc98ac58f> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "de0b36f6-ade3-41c2-9a21-5fdbc98ac58f";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/6978fd46-377c-4e51-b9d1-b97d236fc4e6>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/60c31521-dcb3-44b2-bf96-cb06e68608d6>,
+                        <http://data.lblod.info/id/contact-punten/50fbab60-51c8-4515-9614-338d4cc1f1f0>.
+
+      <http://data.lblod.info/id/contact-punten/60c31521-dcb3-44b2-bf96-cb06e68608d6> a <http://schema.org/ContactPoint>;
+        mu:uuid "60c31521-dcb3-44b2-bf96-cb06e68608d6";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/50fbab60-51c8-4515-9614-338d4cc1f1f0> a <http://schema.org/ContactPoint>;
+        mu:uuid "50fbab60-51c8-4515-9614-338d4cc1f1f0";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/6978fd46-377c-4e51-b9d1-b97d236fc4e6> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "6978fd46-377c-4e51-b9d1-b97d236fc4e6".
+
+      <http://data.lblod.info/id/bestuurseenheden/ab9269754d1266e010c1878a1199525898f0846ff0e9a0add9e7fbaed42ac43c> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "ab9269754d1266e010c1878a1199525898f0846ff0e9a0add9e7fbaed42ac43c";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Willebroek";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/279e0cb8-09b1-491e-97bd-ecb5cd4e3543>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/de0b36f6-ade3-41c2-9a21-5fdbc98ac58f> .
+    
+
+      <http://data.lblod.info/id/identificatoren/8cfa9713-bd58-420d-98a4-c9b40a1c302d> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "8cfa9713-bd58-420d-98a4-c9b40a1c302d";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/7bddfd9a-ebcc-44f7-b0ac-c3d5fd59ba38>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/7bddfd9a-ebcc-44f7-b0ac-c3d5fd59ba38> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "7bddfd9a-ebcc-44f7-b0ac-c3d5fd59ba38";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1322".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/787af8a8-b320-4315-aede-ac7a2fe3bc0f> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "787af8a8-b320-4315-aede-ac7a2fe3bc0f";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/19099f39-956d-44c7-8e72-7266a587ac6d>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/7880d54a-26ec-4f83-a125-ed027df68940>,
+                        <http://data.lblod.info/id/contact-punten/03c54fed-16c5-46be-a297-96da193dda97>.
+
+      <http://data.lblod.info/id/contact-punten/7880d54a-26ec-4f83-a125-ed027df68940> a <http://schema.org/ContactPoint>;
+        mu:uuid "7880d54a-26ec-4f83-a125-ed027df68940";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/03c54fed-16c5-46be-a297-96da193dda97> a <http://schema.org/ContactPoint>;
+        mu:uuid "03c54fed-16c5-46be-a297-96da193dda97";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/19099f39-956d-44c7-8e72-7266a587ac6d> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "19099f39-956d-44c7-8e72-7266a587ac6d".
+
+      <http://data.lblod.info/id/bestuurseenheden/782682349b24078a97dc181bdb7dc62fb2cabc072878fc75a29f4ed70c86250d> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "782682349b24078a97dc181bdb7dc62fb2cabc072878fc75a29f4ed70c86250d";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Zaventem: Zaventem";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/8cfa9713-bd58-420d-98a4-c9b40a1c302d>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/787af8a8-b320-4315-aede-ac7a2fe3bc0f> .
+    
+
+      <http://data.lblod.info/id/identificatoren/bf863330-b308-4159-9a22-ac933c2bd3ea> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "bf863330-b308-4159-9a22-ac933c2bd3ea";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/57c49f99-8afc-4c0a-b0a6-0d9e04e14d23>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/57c49f99-8afc-4c0a-b0a6-0d9e04e14d23> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "57c49f99-8afc-4c0a-b0a6-0d9e04e14d23";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1323".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/8b748170-59cf-4e4f-8d9c-ad81bb52917f> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "8b748170-59cf-4e4f-8d9c-ad81bb52917f";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/53983abe-86f3-4526-b42a-8701301b7329>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/b9f929b5-0cbe-40cb-9564-2df2ab7960bb>,
+                        <http://data.lblod.info/id/contact-punten/c1c461c8-c506-4585-a35b-6bac9881bbf6>.
+
+      <http://data.lblod.info/id/contact-punten/b9f929b5-0cbe-40cb-9564-2df2ab7960bb> a <http://schema.org/ContactPoint>;
+        mu:uuid "b9f929b5-0cbe-40cb-9564-2df2ab7960bb";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/c1c461c8-c506-4585-a35b-6bac9881bbf6> a <http://schema.org/ContactPoint>;
+        mu:uuid "c1c461c8-c506-4585-a35b-6bac9881bbf6";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/53983abe-86f3-4526-b42a-8701301b7329> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "53983abe-86f3-4526-b42a-8701301b7329".
+
+      <http://data.lblod.info/id/bestuurseenheden/e4f4aa293734f92302439270cf98805e4b617088cb19144b558db2dff087d886> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "e4f4aa293734f92302439270cf98805e4b617088cb19144b558db2dff087d886";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Zennevallei: Beersel, Halle en Sint-Pieters-Leeuw";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/bf863330-b308-4159-9a22-ac933c2bd3ea>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/8b748170-59cf-4e4f-8d9c-ad81bb52917f> .
+    
+
+      <http://data.lblod.info/id/identificatoren/756133f2-549c-4c9c-b43e-21b91aa7ec40> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "756133f2-549c-4c9c-b43e-21b91aa7ec40";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/1f67b3cd-4c11-488f-a129-2b697b6ac229>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/1f67b3cd-4c11-488f-a129-2b697b6ac229> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "1f67b3cd-4c11-488f-a129-2b697b6ac229";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1324".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/3c41ccd4-9e62-46a3-aa05-3d546c6a298b> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "3c41ccd4-9e62-46a3-aa05-3d546c6a298b";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/d979837e-f198-4fe2-8df6-b6758e344402>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/5f1433de-6ede-47bd-adc0-cfe83c5197ad>,
+                        <http://data.lblod.info/id/contact-punten/a22564ae-17be-4d00-8606-7cdd7c548b7b>.
+
+      <http://data.lblod.info/id/contact-punten/5f1433de-6ede-47bd-adc0-cfe83c5197ad> a <http://schema.org/ContactPoint>;
+        mu:uuid "5f1433de-6ede-47bd-adc0-cfe83c5197ad";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/a22564ae-17be-4d00-8606-7cdd7c548b7b> a <http://schema.org/ContactPoint>;
+        mu:uuid "a22564ae-17be-4d00-8606-7cdd7c548b7b";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/d979837e-f198-4fe2-8df6-b6758e344402> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "d979837e-f198-4fe2-8df6-b6758e344402".
+
+      <http://data.lblod.info/id/bestuurseenheden/330516b323c00851cf4b93e6d5d7a2ef4591f68ae6e71ad9c1f432ee70521bb2> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "330516b323c00851cf4b93e6d5d7a2ef4591f68ae6e71ad9c1f432ee70521bb2";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Zwijndrecht: Zwijndrecht";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/756133f2-549c-4c9c-b43e-21b91aa7ec40>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/3c41ccd4-9e62-46a3-aa05-3d546c6a298b> .
+    
+
+      <http://data.lblod.info/id/identificatoren/4ffb6e55-8241-442c-b916-2811529316c0> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "4ffb6e55-8241-442c-b916-2811529316c0";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/d5e6ddcf-f3a4-48f8-ab3b-0db932ea7f3a>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/d5e6ddcf-f3a4-48f8-ab3b-0db932ea7f3a> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "d5e6ddcf-f3a4-48f8-ab3b-0db932ea7f3a";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1397".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/18874f25-c522-4f01-b4fd-88f4abc6d451> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "18874f25-c522-4f01-b4fd-88f4abc6d451";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/ca51fc12-aeb1-44ec-ba9e-b68060aa8abe>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/62430027-00dc-4e7b-8381-77fd757e1c86>,
+                        <http://data.lblod.info/id/contact-punten/2541abe5-bbdf-4403-a5fa-b5d26e8b4966>.
+
+      <http://data.lblod.info/id/contact-punten/62430027-00dc-4e7b-8381-77fd757e1c86> a <http://schema.org/ContactPoint>;
+        mu:uuid "62430027-00dc-4e7b-8381-77fd757e1c86";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/2541abe5-bbdf-4403-a5fa-b5d26e8b4966> a <http://schema.org/ContactPoint>;
+        mu:uuid "2541abe5-bbdf-4403-a5fa-b5d26e8b4966";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/ca51fc12-aeb1-44ec-ba9e-b68060aa8abe> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "ca51fc12-aeb1-44ec-ba9e-b68060aa8abe".
+
+      <http://data.lblod.info/id/bestuurseenheden/e7692f99-9a36-43e3-af78-b320390318dc> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "e7692f99-9a36-43e3-af78-b320390318dc";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ CARMA: Genk, As, Oudsbergen, Zutendaal, Houthalen-Helchteren, Bocholt, Bree en Kinrooi";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/4ffb6e55-8241-442c-b916-2811529316c0>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/18874f25-c522-4f01-b4fd-88f4abc6d451> .
+    
+
+      <http://data.lblod.info/id/identificatoren/2295414e-3c10-4184-b37d-9d014907dbe3> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "2295414e-3c10-4184-b37d-9d014907dbe3";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/ff8ade0a-14ea-4d0e-b3bc-aa60066905af>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/ff8ade0a-14ea-4d0e-b3bc-aa60066905af> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "ff8ade0a-14ea-4d0e-b3bc-aa60066905af";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1398".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/f4556ac7-8a00-4be0-b139-fdbd3cc23de6> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "f4556ac7-8a00-4be0-b139-fdbd3cc23de6";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/8daf1061-15d5-493c-b03d-47624f634aa4>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/86ab2a3f-a49b-484c-afd8-39c5bff61b4b>,
+                        <http://data.lblod.info/id/contact-punten/f81d0c7b-4ae5-4565-ae9b-1af2a26790de>.
+
+      <http://data.lblod.info/id/contact-punten/86ab2a3f-a49b-484c-afd8-39c5bff61b4b> a <http://schema.org/ContactPoint>;
+        mu:uuid "86ab2a3f-a49b-484c-afd8-39c5bff61b4b";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/f81d0c7b-4ae5-4565-ae9b-1af2a26790de> a <http://schema.org/ContactPoint>;
+        mu:uuid "f81d0c7b-4ae5-4565-ae9b-1af2a26790de";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/8daf1061-15d5-493c-b03d-47624f634aa4> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "8daf1061-15d5-493c-b03d-47624f634aa4".
+
+      <http://data.lblod.info/id/bestuurseenheden/dad37923-85b4-4c30-8bd6-050061bde51c> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "dad37923-85b4-4c30-8bd6-050061bde51c";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Deinze/Zulte/Lievegem: Deinze, Zulte en Lievegem";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/2295414e-3c10-4184-b37d-9d014907dbe3>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/f4556ac7-8a00-4be0-b139-fdbd3cc23de6> .
+    
+
+      <http://data.lblod.info/id/identificatoren/ce07353f-aa6c-4b17-8f95-7b9f178f93e0> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "ce07353f-aa6c-4b17-8f95-7b9f178f93e0";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/0c4b1a5a-b038-4df2-91c8-8a20ec908472>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/0c4b1a5a-b038-4df2-91c8-8a20ec908472> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "0c4b1a5a-b038-4df2-91c8-8a20ec908472";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1399".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/127f7f3b-0903-471f-8ffc-4b8ca9f93476> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "127f7f3b-0903-471f-8ffc-4b8ca9f93476";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/26eee9aa-92fe-4c8b-9826-b2c5202fdde9>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/e44a6989-bd2c-4041-81a6-5886f5c9b04e>,
+                        <http://data.lblod.info/id/contact-punten/3b8fbdcd-2fa6-4992-a147-7402150f3724>.
+
+      <http://data.lblod.info/id/contact-punten/e44a6989-bd2c-4041-81a6-5886f5c9b04e> a <http://schema.org/ContactPoint>;
+        mu:uuid "e44a6989-bd2c-4041-81a6-5886f5c9b04e";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/3b8fbdcd-2fa6-4992-a147-7402150f3724> a <http://schema.org/ContactPoint>;
+        mu:uuid "3b8fbdcd-2fa6-4992-a147-7402150f3724";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/26eee9aa-92fe-4c8b-9826-b2c5202fdde9> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "26eee9aa-92fe-4c8b-9826-b2c5202fdde9".
+
+      <http://data.lblod.info/id/bestuurseenheden/81334af3-1b6f-4308-aca3-107121462d56> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "81334af3-1b6f-4308-aca3-107121462d56";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Getevallei: Tienen, Hoegaarden, Landen, Linter en Zoutleeuw";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/ce07353f-aa6c-4b17-8f95-7b9f178f93e0>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/127f7f3b-0903-471f-8ffc-4b8ca9f93476> .
+    
+
+      <http://data.lblod.info/id/identificatoren/8dca9b79-53ef-4b83-9e76-e8e4def98bea> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "8dca9b79-53ef-4b83-9e76-e8e4def98bea";
+        skos:notation "SharePoint identificator";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/c2c86fe3-d12f-4a95-b3c4-b0cea594e218>.
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/c2c86fe3-d12f-4a95-b3c4-b0cea594e218> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "c2c86fe3-d12f-4a95-b3c4-b0cea594e218";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1404".
+
+      
+
+      <http://data.lblod.info/id/vestigingen/cdab943d-04c5-4996-8ce2-22d4bae0d27a> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "cdab943d-04c5-4996-8ce2-22d4bae0d27a";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/ca59881b-7ff7-47d1-9def-b0ad1dc8c77e>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/0759f113-6350-4279-b606-b0a8cbe81d5c>,
+                        <http://data.lblod.info/id/contact-punten/32b7e3e0-35ed-47be-8da3-acf7a08eb0e6>.
+
+      <http://data.lblod.info/id/contact-punten/0759f113-6350-4279-b606-b0a8cbe81d5c> a <http://schema.org/ContactPoint>;
+        mu:uuid "0759f113-6350-4279-b606-b0a8cbe81d5c";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/32b7e3e0-35ed-47be-8da3-acf7a08eb0e6> a <http://schema.org/ContactPoint>;
+        mu:uuid "32b7e3e0-35ed-47be-8da3-acf7a08eb0e6";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/ca59881b-7ff7-47d1-9def-b0ad1dc8c77e> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "ca59881b-7ff7-47d1-9def-b0ad1dc8c77e".
+
+      <http://data.lblod.info/id/bestuurseenheden/81dd243d-f66c-4157-b105-5407aa83cb62> a besluit:Bestuurseenheid, org:Organization;
+        mu:uuid "81dd243d-f66c-4157-b105-5407aa83cb62";
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc>;
+        skos:prefLabel  "PZ Rivierenland: Bornem, Puurs-Sint-Amands, Mechelen en Willebroek";
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>;
+         <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/8dca9b79-53ef-4b83-9e76-e8e4def98bea>;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/cdab943d-04c5-4996-8ce2-22d4bae0d27a> .
+    


### PR DESCRIPTION
OP-2703

Requires a reindex to be able to see the PZ and HVZ admin units in the search page !

Note that we are still missing data, mostly the addresses, the related organizations and the contact information.