### PR TITLE
Fix: add an alphanumeric only index field for identifiers

### DIFF
--- a/config/search/config.json
+++ b/config/search/config.json
@@ -67,6 +67,18 @@
           "type": "custom",
           "char_filter": [],
           "filter": ["lowercase", "trim", "asciifolding"]
+        },
+        "identifier_normalizer": {
+          "type": "custom",
+          "char_filter": ["identifier_alphanumeric_filter"],
+          "filter": ["lowercase", "trim", "asciifolding"]
+        }
+      },
+      "char_filter": {
+        "identifier_alphanumeric_filter": {
+          "type": "pattern_replace",
+          "pattern": "[^a-zA-Z0-9]",
+          "replacement": ""
         }
       }
     }
@@ -857,9 +869,9 @@
           "identifier": {
             "type": "text",
             "fields": {
-              "field": {
+              "index": {
                 "type": "keyword",
-                "normalizer": "custom_sort_normalizer"
+                "normalizer": "identifier_normalizer"
               }
             }
           }

--- a/config/search/dev/config.json
+++ b/config/search/dev/config.json
@@ -39,6 +39,18 @@
           "type": "custom",
           "char_filter": [],
           "filter": ["lowercase", "trim", "asciifolding"]
+        },
+        "identifier_normalizer": {
+          "type": "custom",
+          "char_filter": ["identifier_alphanumeric_filter"],
+          "filter": ["lowercase", "trim", "asciifolding"]
+        }
+      },
+      "char_filter": {
+        "identifier_alphanumeric_filter": {
+          "type": "pattern_replace",
+          "pattern": "[^a-zA-Z0-9]",
+          "replacement": ""
         }
       }
     }
@@ -830,9 +842,9 @@
           "identifier": {
             "type": "text",
             "fields": {
-              "field": {
+              "index": {
                 "type": "keyword",
-                "normalizer": "custom_sort_normalizer"
+                "normalizer": "identifier_normalizer"
               }
             }
           }


### PR DESCRIPTION
OP-2725

This change allows to fix a bug where units with identifiers containing special characters such as dashes or brackets where not correctly included in the results.