### PR TITLE
Fix vast bureau concept data

### DIFF
--- a/config/migrations/2023/20231107175200-fix-vast-bureau-concept.sparql
+++ b/config/migrations/2023/20231107175200-fix-vast-bureau-concept.sparql
@@ -1,0 +1,31 @@
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000008>
+      <http://www.w3.org/2004/02/skos/core#inScheme> <http://lblod.data.gift/concept-schemes/10caf4a4-1ff5-4c05-917e-56489910d68b> ;
+      <http://www.w3.org/2004/02/skos/core#inScheme> <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+      <http://www.w3.org/2004/02/skos/core#topConceptOf> <http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode> ;
+      <http://mu.semte.ch/vocabularies/ext/appliesWithin> <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000002> .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s ?p <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000008> .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s ?p <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/55ab0e9b8a3b2ca7c5e000008> .
+  }
+}
+;
+DELETE WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s ?p <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/55ab0e9b8a3b2ca7c5e000008> .
+  }
+}
+;
+DELETE WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/55ab0e9b8a3b2ca7c5e000008> ?p ?o .
+  }
+}


### PR DESCRIPTION
OP-2819

# Analysis

<http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/55ab0e9b8a3b2ca7c5e000008> uri has been wrongly introduced via migrations in OP.

Before just removing it, let's assess its impact.

## Impact

We'll check the impact in OP itself as well as in Loket, which consumes part of OP's data

### OP

#### Triples linked to the wrong URI

The real uri is missing some triples, that we wrongfully linked to the wrong uri:
```
http://mu.semte.ch/graphs/public 	http://www.w3.org/2004/02/skos/core#inScheme 	http://lblod.data.gift/concept-schemes/10caf4a4-1ff5-4c05-917e-56489910d68b
http://mu.semte.ch/graphs/public 	http://www.w3.org/2004/02/skos/core#inScheme 	http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode
http://mu.semte.ch/graphs/public 	http://www.w3.org/2004/02/skos/core#topConceptOf 	http://data.vlaanderen.be/id/conceptscheme/BestuursorgaanClassificatieCode
http://mu.semte.ch/graphs/public 	http://mu.semte.ch/vocabularies/ext/appliesWithin 	http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000002
```

#### Triples linking to the wrong URI

Two bestuursfunctie codes are linking to the wrong uri and need to be corrected:
```
http://mu.semte.ch/graphs/public 	http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000017 	http://mu.semte.ch/vocabularies/ext/appliesTo
http://mu.semte.ch/graphs/public 	http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000018 	http://mu.semte.ch/vocabularies/ext/appliesTo
```

### Loket

#### Triples linked to the wrong URI

None

#### Triples linking to the wrong URI

None

### CVP

#### Triples linked to the wrong URI

Type, uuid and prefLabel in http://mu.semte.ch/graphs/landing-zone/op-public

#### Triples linking to the wrong URI

None

### WOP

#### Triples linked to the wrong URI

Type, uuid and prefLabel in http://mu.semte.ch/graphs/public & http://mu.semte.ch/graphs/ingest

#### Triples linking to the wrong URI

None

## Fixing strategy

The impact is rather limited on the consuming applications. For this reason, the strategy will be to delete the wrong URI in OP in the public graph. The healing process of the delta producers will then produce deltas for the removed data and the consumers will then automatically fix the consuming applications' data.