### PR TITLE
Remove mandataris without person

### DIFF
--- a/config/migrations/2023/20231124220109-remove-mandataris-without-person.sparql
+++ b/config/migrations/2023/20231124220109-remove-mandataris-without-person.sparql
@@ -1,0 +1,9 @@
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/mandatarissen/fb8ce507f9dfc141e8353d33a7c0070f> ?p ?o .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/mandatarissen/fb8ce507f9dfc141e8353d33a7c0070f> ?p ?o .
+  }
+}


### PR DESCRIPTION
OP-2867

As the impact is very limited (one mandataris) and it has been like this for a while without anybody noticing I think we can wait for the next release to merge it, hence the merge to the dev branch. It'll require a reindex, but that will be the case anyways with the onboarding of new admin units.