### PR TITLE
Bump construct-administrative-unit-relationships-service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -254,7 +254,7 @@ services:
     restart: always
     logging: *default-logging
   construct-administrative-unit-relationships:
-    image: lblod/construct-administrative-unit-relationships-service:0.1.5
+    image: lblod/construct-administrative-unit-relationships-service:0.1.6
     environment:
       START_DATE_WORSHIP_GOVERNING_BODY: "2023-04-01T00:00:00"
       END_DATE_WORSHIP_GOVERNING_BODY: "2026-03-31T00:00:00"


### PR DESCRIPTION
Updated [construct-administrative-unit-relationships-service](https://github.com/lblod/construct-administrative-unit-relationships-service) to v0.1.6 which includes a fix for OCMW verenigingen.