### PR TITLE
Add placeholder variables to prevent deltanotifier being slow

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -245,6 +245,10 @@ services:
       INITIAL_SYNC_JOB_OPERATION: "http://redpencil.data.gift/id/jobs/concept/JobOperation/sp-sync/initialSyncing/organizations"
       HEALING_JOB_OPERATION: "http://redpencil.data.gift/id/jobs/concept/JobOperation/sp-sync/healingOperation/organizations"
       USE_VIRTUOSO_FOR_EXPENSIVE_SELECTS: "true"
+      USERNAME: 'username-to-override'
+      PASSWORD: 'password-to-override'
+      SITE: 'site-to-override'
+      LIST: 'list-to-override'
     links:
       - db:database
     volumes:


### PR DESCRIPTION
Without those placeholder values, on a stack where those variables are not added in the override, the delta notifier becomes extremely slow because it can't reach the sharepoint sync service (that crashed because those essential variables were missing).
With this trick, at least the stack doesn't freeze if locally the variables are not overridden.