### PR TITLE
Replace https by http in lblodlg prefix

### DIFF
--- a/config/migrations/2022/20220719112423-update-toezicht.sparql.disabled
+++ b/config/migrations/2022/20220719112423-update-toezicht.sparql.disabled
@@ -14,7 +14,7 @@ PREFIX adres: <https://data.vlaanderen.be/ns/adres#>
 PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
 PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
 PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
-PREFIX lblodlg: <https://data.lblod.info/vocabularies/leidinggevenden/>
+PREFIX lblodlg: <http://data.lblod.info/vocabularies/leidinggevenden/>
 PREFIX dc_terms: <http://purl.org/dc/terms/>
 PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>

--- a/config/migrations/2022/20220819133740-delete-bestrokke-islam-orthodox.sparql
+++ b/config/migrations/2022/20220819133740-delete-bestrokke-islam-orthodox.sparql
@@ -15,7 +15,7 @@
   PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
   PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
   PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
-  PREFIX lblodlg: <https://data.lblod.info/vocabularies/leidinggevenden/>
+  PREFIX lblodlg: <http://data.lblod.info/vocabularies/leidinggevenden/>
   PREFIX dc_terms: <http://purl.org/dc/terms/>
   PREFIX foaf: <http://xmlns.com/foaf/0.1/>
   PREFIX skos: <http://www.w3.org/2004/02/skos/core#>

--- a/config/migrations/2022/20220822133740-delete-bestrokke.sparql
+++ b/config/migrations/2022/20220822133740-delete-bestrokke.sparql
@@ -15,7 +15,7 @@
   PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
   PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
   PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
-  PREFIX lblodlg: <https://data.lblod.info/vocabularies/leidinggevenden/>
+  PREFIX lblodlg: <http://data.lblod.info/vocabularies/leidinggevenden/>
   PREFIX dc_terms: <http://purl.org/dc/terms/>
   PREFIX foaf: <http://xmlns.com/foaf/0.1/>
   PREFIX skos: <http://www.w3.org/2004/02/skos/core#>

--- a/config/migrations/2022/20221007132340-delete-bestrokke.sparql
+++ b/config/migrations/2022/20221007132340-delete-bestrokke.sparql
@@ -15,7 +15,7 @@
   PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
   PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
   PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
-  PREFIX lblodlg: <https://data.lblod.info/vocabularies/leidinggevenden/>
+  PREFIX lblodlg: <http://data.lblod.info/vocabularies/leidinggevenden/>
   PREFIX dc_terms: <http://purl.org/dc/terms/>
   PREFIX foaf: <http://xmlns.com/foaf/0.1/>
   PREFIX skos: <http://www.w3.org/2004/02/skos/core#>

--- a/config/migrations/2022/20221015132000-delete-bestrokken-besturen-hemiksem.sparql
+++ b/config/migrations/2022/20221015132000-delete-bestrokken-besturen-hemiksem.sparql
@@ -15,7 +15,7 @@ PREFIX adres: <https://data.vlaanderen.be/ns/adres#>
 PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
 PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
 PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
-PREFIX lblodlg: <https://data.lblod.info/vocabularies/leidinggevenden/>
+PREFIX lblodlg: <http://data.lblod.info/vocabularies/leidinggevenden/>
 PREFIX dc_terms: <http://purl.org/dc/terms/>
 PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>

--- a/config/migrations/2022/20221015134000-delete-bestrokken-besturen-ronse.sparql
+++ b/config/migrations/2022/20221015134000-delete-bestrokken-besturen-ronse.sparql
@@ -15,7 +15,7 @@ PREFIX adres: <https://data.vlaanderen.be/ns/adres#>
 PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
 PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
 PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
-PREFIX lblodlg: <https://data.lblod.info/vocabularies/leidinggevenden/>
+PREFIX lblodlg: <http://data.lblod.info/vocabularies/leidinggevenden/>
 PREFIX dc_terms: <http://purl.org/dc/terms/>
 PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>

--- a/config/migrations/2022/20221019174000-delete-bestrokken-besturen-anglican.sparql
+++ b/config/migrations/2022/20221019174000-delete-bestrokken-besturen-anglican.sparql
@@ -15,7 +15,7 @@ PREFIX adres: <https://data.vlaanderen.be/ns/adres#>
 PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
 PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
 PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
-PREFIX lblodlg: <https://data.lblod.info/vocabularies/leidinggevenden/>
+PREFIX lblodlg: <http://data.lblod.info/vocabularies/leidinggevenden/>
 PREFIX dc_terms: <http://purl.org/dc/terms/>
 PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>

--- a/config/migrations/2022/20221222160000-fix-kbo-uris.sparql
+++ b/config/migrations/2022/20221222160000-fix-kbo-uris.sparql
@@ -21,7 +21,7 @@ PREFIX euvoc: <http://publications.europa.eu/ontology/euvoc#>
 PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
 PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
-PREFIX lblodlg: <https://data.lblod.info/vocabularies/leidinggevenden/>
+PREFIX lblodlg: <http://data.lblod.info/vocabularies/leidinggevenden/>
 PREFIX locn: <http://www.w3.org/ns/locn#>
 PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
 PREFIX mu:  <http://mu.semte.ch/vocabularies/core/>

--- a/config/migrations/2023/20230616110000-street-and-bus-number-concatination.sparql
+++ b/config/migrations/2023/20230616110000-street-and-bus-number-concatination.sparql
@@ -14,7 +14,7 @@ PREFIX adres: <https://data.vlaanderen.be/ns/adres#>
 PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
 PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
 PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
-PREFIX lblodlg: <https://data.lblod.info/vocabularies/leidinggevenden/>
+PREFIX lblodlg: <http://data.lblod.info/vocabularies/leidinggevenden/>
 PREFIX dc_terms: <http://purl.org/dc/terms/>
 PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>

--- a/config/migrations/2023/20230627110500-add-missing-country.sparql
+++ b/config/migrations/2023/20230627110500-add-missing-country.sparql
@@ -14,7 +14,7 @@ PREFIX adres: <https://data.vlaanderen.be/ns/adres#>
 PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
 PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
 PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
-PREFIX lblodlg: <https://data.lblod.info/vocabularies/leidinggevenden/>
+PREFIX lblodlg: <http://data.lblod.info/vocabularies/leidinggevenden/>
 PREFIX dc_terms: <http://purl.org/dc/terms/>
 PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>

--- a/config/migrations/2023/20230627111000-add-country-to-full-address.sparql
+++ b/config/migrations/2023/20230627111000-add-country-to-full-address.sparql
@@ -14,7 +14,7 @@ PREFIX adres: <https://data.vlaanderen.be/ns/adres#>
 PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
 PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
 PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
-PREFIX lblodlg: <https://data.lblod.info/vocabularies/leidinggevenden/>
+PREFIX lblodlg: <http://data.lblod.info/vocabularies/leidinggevenden/>
 PREFIX dc_terms: <http://purl.org/dc/terms/>
 PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>

--- a/config/reports/utils.js
+++ b/config/reports/utils.js
@@ -12,7 +12,7 @@ export const PREFIXES = `
   PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
   PREFIX foaf: <http://xmlns.com/foaf/0.1/>
   PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
-  PREFIX lblodlg: <https://data.lblod.info/vocabularies/leidinggevenden/>
+  PREFIX lblodlg: <http://data.lblod.info/vocabularies/leidinggevenden/>
   PREFIX locn: <http://www.w3.org/ns/locn#>
   PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
   PREFIX org: <http://www.w3.org/ns/org#>


### PR DESCRIPTION
This prefix has wrongly been defined with https instead of http in some places. Luckily, it has no impact on the data because everywhere where it has been defined that way, it also never has been used. So here we just rectify the (unused) prefixes to avoid bringing further confusion.

Note: we really just update older migrations for the sake of not confusing devs that would ctrl+F to find that prefix, the migrations will not re-run.