### PR TITLE
Feature: Added new classification codes for PEVAs

### DIFF
--- a/config/migrations/2024/20240108134546-onboarding-peva/20240108134546-onboarding-peva-classification-code-peva-gemeente.sparql
+++ b/config/migrations/2024/20240108134546-onboarding-peva/20240108134546-onboarding-peva-classification-code-peva-gemeente.sparql
@@ -1,0 +1,20 @@
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX core: <http://mu.semte.ch/vocabularies/core/>
+PREFIX scheme: <http://data.vlaanderen.be/id/conceptscheme/>
+PREFIX code: <http://lblod.data.gift/vocabularies/organisatie/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX lblodorg: <http://lblod.data.gift/vocabularies/organisatie/>
+PREFIX concept: <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/>
+
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    concept:2ad46df5-5c79-4d67-84d5-604c1377231e a skos:Concept ;
+      a lblodorg:BestuurseenheidClassificatieCode ;
+      a ext:BestuurseenheidClassificatieCode ;
+      a ext:OrganizationClassificationCode ;
+      core:uuid "2ad46df5-5c79-4d67-84d5-604c1377231e" ;
+      skos:prefLabel "PEVA gemeente" ;
+      skos:inScheme scheme:BestuurseenheidClassificatieCode ;
+      skos:topConceptOf scheme:BestuurseenheidClassificatieCode .
+  }
+}

--- a/config/migrations/2024/20240108134546-onboarding-peva/20240108134610-onboarding-peva-classification-code-peva-provincie.sparql
+++ b/config/migrations/2024/20240108134546-onboarding-peva/20240108134610-onboarding-peva-classification-code-peva-provincie.sparql
@@ -1,0 +1,20 @@
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX core: <http://mu.semte.ch/vocabularies/core/>
+PREFIX scheme: <http://data.vlaanderen.be/id/conceptscheme/>
+PREFIX code: <http://lblod.data.gift/vocabularies/organisatie/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX lblodorg: <http://lblod.data.gift/vocabularies/organisatie/>
+PREFIX concept: <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/>
+
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    concept:088784b6-e188-48bf-b94f-94665f9e1f53 a skos:Concept ;
+      a lblodorg:BestuurseenheidClassificatieCode ;
+      a ext:BestuurseenheidClassificatieCode ;
+      a ext:OrganizationClassificationCode ;
+      core:uuid "088784b6-e188-48bf-b94f-94665f9e1f53" ;
+      skos:prefLabel "PEVA provincie" ;
+      skos:inScheme scheme:BestuurseenheidClassificatieCode ;
+      skos:topConceptOf scheme:BestuurseenheidClassificatieCode .
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -258,7 +258,7 @@ services:
     restart: always
     logging: *default-logging
   construct-administrative-unit-relationships:
-    image: lblod/construct-administrative-unit-relationships-service:0.1.6
+    image: lblod/construct-administrative-unit-relationships-service:0.1.7
     environment:
       START_DATE_WORSHIP_GOVERNING_BODY: "2023-04-01T00:00:00"
       END_DATE_WORSHIP_GOVERNING_BODY: "2026-03-31T00:00:00"


### PR DESCRIPTION
Adds new classification codes for PEVA municipality and PEVA province which will be onboarded in OP-2640. These new classification codes are specifically defined in the context of OP and are not (yet) part of the upstream standard. 

Frontend PR: https://github.com/lblod/frontend-organization-portal/pull/558