### PR TITLE
Feature: Import data for public OCMW associations

### DIFF
--- a/config/dev-migrations/20240201000000-remove-ocmw-association-wieltjesgracht.sparql
+++ b/config/dev-migrations/20240201000000-remove-ocmw-association-wieltjesgracht.sparql
@@ -1,0 +1,199 @@
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX locn: <http://www.w3.org/ns/locn#>
+PREFIX schema: <http://schema.org/>
+PREFIX regorg: <http://www.w3.org/ns/regorg#>
+PREFIX person: <http://www.w3.org/ns/person#>
+PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
+PREFIX dbpedia: <http://dbpedia.org/ontology/>
+PREFIX adms: <http://www.w3.org/ns/adms#>
+PREFIX euro: <http://data.europa.eu/m8g/>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX organisatie: <https://data.vlaanderen.be/ns/organisatie#>
+PREFIX persoon: <https://data.vlaanderen.be/ns/persoon#>
+PREFIX adres: <https://data.vlaanderen.be/ns/adres#>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX lblodlg: <http://data.lblod.info/vocabularies/leidinggevenden/>
+PREFIX lblodorg: <https://data.lblod.info/vocabularies/organisatie/>
+PREFIX lblodgeneriek: <https://data.lblod.info/vocabularies/generiek/>
+PREFIX dc_terms: <http://purl.org/dc/terms/>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX euvoc: <http://publications.europa.eu/ontology/euvoc#>
+PREFIX ere: <http://data.lblod.info/vocabularies/erediensten/>
+PREFIX ch: <http://data.lblod.info/vocabularies/contacthub/>
+PREFIX code: <http://lblod.data.gift/vocabularies/organisatie/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX geo: <http://www.opengis.net/ont/geosparql#>
+PREFIX nacebel: <http://data.gift/vocabularies/nace-bel/>
+PREFIX core: <http://mu.semte.ch/vocabularies/core/>
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    <http://data.lblod.info/id/bestuursorganen/0f87572fb2968c17383dc7574320031dffa339f17a974e3b194588d685c1fc5d> a besluit:Bestuursorgaan ;
+    core:uuid """0f87572fb2968c17383dc7574320031dffa339f17a974e3b194588d685c1fc5d""" ;
+    skos:prefLabel ?governingBodyLabel ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/7d1254994765887e47ee3c9a2551f6a790a02a1747809285f52e7e690c12f2ca> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?administrativeUnit core:uuid """7d1254994765887e47ee3c9a2551f6a790a02a1747809285f52e7e690c12f2ca""" ;
+    skos:prefLabel ?administrativeUnitLabel .
+    BIND(CONCAT("""Leidend Ambtenaar""", " ", ?administrativeUnitLabel) as ?governingBodyLabel)
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    <http://data.lblod.info/id/bestuursorganen/e891dc823e0d924a94cd067d0b291c169c95695cdd73a3c259e79c39e91d0034> a besluit:Bestuursorgaan ;
+    core:uuid """e891dc823e0d924a94cd067d0b291c169c95695cdd73a3c259e79c39e91d0034""" ;
+    skos:prefLabel ?governingBodyLabel ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/7d1254994765887e47ee3c9a2551f6a790a02a1747809285f52e7e690c12f2ca> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?administrativeUnit core:uuid """7d1254994765887e47ee3c9a2551f6a790a02a1747809285f52e7e690c12f2ca""" ;
+    skos:prefLabel ?administrativeUnitLabel .
+    BIND(CONCAT("""Algemene vergadering""", " ", ?administrativeUnitLabel) as ?governingBodyLabel)
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    <http://data.lblod.info/id/bestuursorganen/16875d1ad2294295c576de9837756a4c6796d3ee7e0b7ebd6e8d3e8f65930353> a besluit:Bestuursorgaan ;
+    core:uuid """16875d1ad2294295c576de9837756a4c6796d3ee7e0b7ebd6e8d3e8f65930353""" ;
+    skos:prefLabel ?governingBodyLabel ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/7d1254994765887e47ee3c9a2551f6a790a02a1747809285f52e7e690c12f2ca> ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?administrativeUnit core:uuid """7d1254994765887e47ee3c9a2551f6a790a02a1747809285f52e7e690c12f2ca""" ;
+    skos:prefLabel ?administrativeUnitLabel .
+    BIND(CONCAT("""Raad van bestuur""", " ", ?administrativeUnitLabel) as ?governingBodyLabel)
+  }
+}
+;
+DELETE DATA {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    <http://data.lblod.info/id/bestuurseenheden/7d1254994765887e47ee3c9a2551f6a790a02a1747809285f52e7e690c12f2ca> core:uuid """7d1254994765887e47ee3c9a2551f6a790a02a1747809285f52e7e690c12f2ca""".
+    <http://data.lblod.info/id/bestuurseenheden/7d1254994765887e47ee3c9a2551f6a790a02a1747809285f52e7e690c12f2ca> a besluit:Bestuurseenheid.
+    <http://data.lblod.info/id/bestuurseenheden/7d1254994765887e47ee3c9a2551f6a790a02a1747809285f52e7e690c12f2ca> a org:Organization.
+    <http://data.lblod.info/id/bestuurseenheden/7d1254994765887e47ee3c9a2551f6a790a02a1747809285f52e7e690c12f2ca> a dc_terms:Agent.
+    <http://data.lblod.info/id/bestuurseenheden/7d1254994765887e47ee3c9a2551f6a790a02a1747809285f52e7e690c12f2ca> skos:prefLabel """VERENIGING OCMW-WIELTJESGRACHT""".
+
+    <http://data.lblod.info/id/bestuurseenheden/7d1254994765887e47ee3c9a2551f6a790a02a1747809285f52e7e690c12f2ca> org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9>.
+
+    # Site
+    <http://data.lblod.info/id/contact-punten/6585490A8CEC3153DEA3A208> core:uuid """6585490A8CEC3153DEA3A208""" .
+    <http://data.lblod.info/id/contact-punten/6585490A8CEC3153DEA3A208> a schema:ContactPoint .
+    <http://data.lblod.info/id/contact-punten/6585490A8CEC3153DEA3A208> schema:email """mail@adres.com""" .
+    <http://data.lblod.info/id/contact-punten/6585490A8CEC3153DEA3A208> schema:telephone """tel:+3211211430""" .
+    <http://data.lblod.info/id/contact-punten/6585490A8CEC3153DEA3A208> foaf:page """https://www.vlaanderen.be""" .
+    <http://data.lblod.info/id/contact-punten/6585490A8CEC3153DEA3A208> schema:contactType """Primary""" .
+
+    <http://data.lblod.info/id/contact-punten/6585490B8CEC3153DEA3A209> core:uuid """6585490B8CEC3153DEA3A209""" .
+    <http://data.lblod.info/id/contact-punten/6585490B8CEC3153DEA3A209> a schema:ContactPoint .
+    <http://data.lblod.info/id/contact-punten/6585490B8CEC3153DEA3A209> schema:telephone """tel:+3211211431""" .
+    <http://data.lblod.info/id/contact-punten/6585490B8CEC3153DEA3A209> schema:contactType """Secondary""" .
+
+    <http://data.lblod.info/id/adressen/6585490B8CEC3153DEA3A20A> core:uuid """6585490B8CEC3153DEA3A20A""" .
+    <http://data.lblod.info/id/adressen/6585490B8CEC3153DEA3A20A> a locn:Address .
+    <http://data.lblod.info/id/adressen/6585490B8CEC3153DEA3A20A> adres:Adresvoorstelling.huisnummer """1""" .
+    <http://data.lblod.info/id/adressen/6585490B8CEC3153DEA3A20A> locn:thoroughfare """Oude Markt""" .
+    <http://data.lblod.info/id/adressen/6585490B8CEC3153DEA3A20A> locn:postCode """3000""" .
+    <http://data.lblod.info/id/adressen/6585490B8CEC3153DEA3A20A> adres:gemeentenaam """Leuven""" .
+    <http://data.lblod.info/id/adressen/6585490B8CEC3153DEA3A20A> locn:adminUnitL2 """Vlaams-Brabant""" .
+    <http://data.lblod.info/id/adressen/6585490B8CEC3153DEA3A20A> adres:land """België""" .
+    <http://data.lblod.info/id/adressen/6585490B8CEC3153DEA3A20A> locn:fullAddress """Oude Markt 1, 3000 Leuven, België""" .
+    <http://data.lblod.info/id/adressen/6585490B8CEC3153DEA3A20A> adres:verwijstNaar <https://data.vlaanderen.be/id/adres/294733> .
+    <http://data.lblod.info/id/adressen/6585490B8CEC3153DEA3A20A> dc_terms:source <http://lblod.data.gift/concepts/e59c97a9-4e95-4d65-9696-756de47fbc1f> .
+
+    <http://data.lblod.info/id/vestigingen/6585490B8CEC3153DEA3A20B> core:uuid """6585490B8CEC3153DEA3A20B""" .
+    <http://data.lblod.info/id/vestigingen/6585490B8CEC3153DEA3A20B> a org:Site .
+    <http://data.lblod.info/id/vestigingen/6585490B8CEC3153DEA3A20B> organisatie:bestaatUit <http://data.lblod.info/id/adressen/6585490B8CEC3153DEA3A20A> .
+    <http://data.lblod.info/id/vestigingen/6585490B8CEC3153DEA3A20B> org:siteAddress <http://data.lblod.info/id/contact-punten/6585490A8CEC3153DEA3A208> .
+    <http://data.lblod.info/id/vestigingen/6585490B8CEC3153DEA3A20B> org:siteAddress <http://data.lblod.info/id/contact-punten/6585490B8CEC3153DEA3A209> .
+    <http://data.lblod.info/id/vestigingen/6585490B8CEC3153DEA3A20B> ere:vestigingstype <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd> .
+    <http://data.lblod.info/id/bestuurseenheden/7d1254994765887e47ee3c9a2551f6a790a02a1747809285f52e7e690c12f2ca> org:hasPrimarySite <http://data.lblod.info/id/vestigingen/6585490B8CEC3153DEA3A20B> .
+
+    # KBO number
+    <http://data.lblod.info/id/gestructureerdeIdentificatoren/65856287B12D00C739F23920> core:uuid """65856287B12D00C739F23920""".
+    <http://data.lblod.info/id/gestructureerdeIdentificatoren/65856287B12D00C739F23920> a generiek:GestructureerdeIdentificator.
+    <http://data.lblod.info/id/gestructureerdeIdentificatoren/65856287B12D00C739F23920> generiek:lokaleIdentificator """0262925527""".
+    <http://data.lblod.info/id/identificatoren/65856287B12D00C739F23921> core:uuid """65856287B12D00C739F23921""".
+    <http://data.lblod.info/id/identificatoren/65856287B12D00C739F23921> a adms:Identifier.
+    <http://data.lblod.info/id/identificatoren/65856287B12D00C739F23921> skos:notation """KBO nummer""".
+    <http://data.lblod.info/id/identificatoren/65856287B12D00C739F23921> generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/65856287B12D00C739F23920>.
+    <http://data.lblod.info/id/bestuurseenheden/7d1254994765887e47ee3c9a2551f6a790a02a1747809285f52e7e690c12f2ca> adms:identifier <http://data.lblod.info/id/identificatoren/65856287B12D00C739F23921>.
+
+    # Sharepoint identifier
+    <http://data.lblod.info/id/gestructureerdeIdentificatoren/65856287B12D00C739F23922> core:uuid """65856287B12D00C739F23922""".
+    <http://data.lblod.info/id/gestructureerdeIdentificatoren/65856287B12D00C739F23922> a generiek:GestructureerdeIdentificator.
+    <http://data.lblod.info/id/gestructureerdeIdentificatoren/65856287B12D00C739F23922> generiek:lokaleIdentificator """sp-id-test""" .
+    <http://data.lblod.info/id/identificatoren/65856287B12D00C739F23923> core:uuid """65856287B12D00C739F23923""".
+    <http://data.lblod.info/id/identificatoren/65856287B12D00C739F23923> a adms:Identifier.
+    <http://data.lblod.info/id/identificatoren/65856287B12D00C739F23923> skos:notation """SharePoint identificator""".
+    <http://data.lblod.info/id/identificatoren/65856287B12D00C739F23923> generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/65856287B12D00C739F23922> .
+    <http://data.lblod.info/id/bestuurseenheden/7d1254994765887e47ee3c9a2551f6a790a02a1747809285f52e7e690c12f2ca> adms:identifier <http://data.lblod.info/id/identificatoren/65856287B12D00C739F23923> .
+
+    # OVO number
+    <http://data.lblod.info/id/bestuurseenheden/7d1254994765887e47ee3c9a2551f6a790a02a1747809285f52e7e690c12f2ca> adms:identifier <http://data.lblod.info/id/identificatoren/d5713a51-40d4-4b79-bf72-0d917f78c37b> .
+    <http://data.lblod.info/id/identificatoren/d5713a51-40d4-4b79-bf72-0d917f78c37b> a adms:Identifier ;
+      core:uuid """d5713a51-40d4-4b79-bf72-0d917f78c37b""" ;
+      skos:notation "OVO-nummer" ;
+      generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/438b542b-6841-4137-b8da-287b394328ee> .
+    <http://data.lblod.info/id/gestructureerdeIdentificatoren/438b542b-6841-4137-b8da-287b394328ee> a generiek:GestructureerdeIdentificator ;
+      core:uuid """438b542b-6841-4137-b8da-287b394328ee""" ;
+      generiek:lokaleIdentificator "OVO009999" .
+
+    <http://data.lblod.info/id/bestuurseenheden/7d1254994765887e47ee3c9a2551f6a790a02a1747809285f52e7e690c12f2ca> besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/a8040e566e7a22dfc6a83a7176d105abc68ab1bf1a89e94a1333c8f049131837>.
+
+    <http://data.lblod.info/id/bestuurseenheden/7d1254994765887e47ee3c9a2551f6a790a02a1747809285f52e7e690c12f2ca> regorg:orgStatus <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>.
+
+    <http://data.lblod.info/id/bestuurseenheden/8a162fa437a54cb657b57514e4e0135ec106fce3206c29cd2f90b1859ed90dab> org:hasSubOrganization <http://data.lblod.info/id/bestuurseenheden/7d1254994765887e47ee3c9a2551f6a790a02a1747809285f52e7e690c12f2ca>.
+
+    <http://data.lblod.info/id/bestuurseenheden/8a162fa437a54cb657b57514e4e0135ec106fce3206c29cd2f90b1859ed90dab> ext:isFounderOfOrganization <http://data.lblod.info/id/bestuurseenheden/7d1254994765887e47ee3c9a2551f6a790a02a1747809285f52e7e690c12f2ca>.
+  }
+}
+;
+DELETE DATA {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    <http://data.lblod.info/id/bestuursorganen/47e52223b3e27ad63c7233f93df0331f6d45bfb743f81d1110cbca4b3ac933ee> a besluit:Bestuursorgaan ;
+    core:uuid """47e52223b3e27ad63c7233f93df0331f6d45bfb743f81d1110cbca4b3ac933ee""" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/16875d1ad2294295c576de9837756a4c6796d3ee7e0b7ebd6e8d3e8f65930353> ;
+    mandaat:bindingStart "1971-11-03T00:00:00.000Z"^^xsd:dateTime .
+  }
+}
+;
+DELETE DATA {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    <http://data.lblod.info/id/bestuursorganen/be22b1988874583b0773677665596200c9586f758207cdf335278a9380180d86> a besluit:Bestuursorgaan ;
+    core:uuid """be22b1988874583b0773677665596200c9586f758207cdf335278a9380180d86""" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/e891dc823e0d924a94cd067d0b291c169c95695cdd73a3c259e79c39e91d0034> ;
+    mandaat:bindingStart "1971-11-03T00:00:00.000Z"^^xsd:dateTime .
+  }
+}
+;
+DELETE DATA {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    <http://data.lblod.info/id/bestuursorganen/a48a21167ca609b76d621be5d5714e28f48711f1eb49d704985d1476565fdd66> a besluit:Bestuursorgaan ;
+    core:uuid """a48a21167ca609b76d621be5d5714e28f48711f1eb49d704985d1476565fdd66""" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/0f87572fb2968c17383dc7574320031dffa339f17a974e3b194588d685c1fc5d> ;
+    mandaat:bindingStart "2019-01-01T00:00:00.000Z"^^xsd:dateTime .
+  }
+}
+;
+DELETE DATA {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    <http://data.lblod.info/id/bestuursorganen/a48a21167ca609b76d621be5d5714e28f48711f1eb49d704985d1476565fdd66> lblodlg:heeftBestuursfunctie <http://data.lblod.info/id/bestuursfuncties/73e7ef49c748e7f475feb952355f4a6bee2db1d85cd30b17b722a6291739b490> .
+
+    <http://data.lblod.info/id/bestuursfuncties/73e7ef49c748e7f475feb952355f4a6bee2db1d85cd30b17b722a6291739b490> a lblodlg:Bestuursfunctie ;
+    core:uuid """73e7ef49c748e7f475feb952355f4a6bee2db1d85cd30b17b722a6291739b490""" ;
+    org:role <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/855489b9-b584-4f34-90b2-39aea808cd9f> ;
+    skos:prefLabel """VERENIGING OCMW-WIELTJESGRACHT Leidend ambtenaar""" .
+  }
+}

--- a/config/migrations/2024/20240212141020-onboarding-public-ocmw-associations/20240212141020-import-public-ocmw-associations-loket.graph
+++ b/config/migrations/2024/20240212141020-onboarding-public-ocmw-associations/20240212141020-import-public-ocmw-associations-loket.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/administrative-unit

--- a/config/migrations/2024/20240212141020-onboarding-public-ocmw-associations/20240212141020-import-public-ocmw-associations-loket.ttl
+++ b/config/migrations/2024/20240212141020-onboarding-public-ocmw-associations/20240212141020-import-public-ocmw-associations-loket.ttl
@@ -1,0 +1,3769 @@
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix besluit: <http://data.vlaanderen.be/ns/besluit#> .
+@prefix generiek: <https://data.vlaanderen.be/ns/generiek#> .
+@prefix mandaat: <http://data.vlaanderen.be/ns/mandaat#> .
+@prefix mu: <http://mu.semte.ch/vocabularies/core/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://data.lblod.info/id/bestuursorganen/0007e9b1efceccf7ad651776accb8570f361f4e2ee0947122f9a79fc334a10e5> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "0007e9b1efceccf7ad651776accb8570f361f4e2ee0947122f9a79fc334a10e5" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/9856b50a423a3de6285b0022ebdf1dcd6d28e682352ab5c6a0709ae7516f5ce7> .
+
+<http://data.lblod.info/id/bestuursorganen/0177b9626f9a14708053758e9690da0f4b54bfe8f42300d21a0e9f30bb57fb9c> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "0177b9626f9a14708053758e9690da0f4b54bfe8f42300d21a0e9f30bb57fb9c" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/2ae807cdb4146b5a36c19e7d6870049dbf201863a2fa029ccb92f6485107edf0> .
+
+<http://data.lblod.info/id/bestuursorganen/0241c23151e89c935338e66e3b311769c66af75970908b3a63e5a21dab852051> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "0241c23151e89c935338e66e3b311769c66af75970908b3a63e5a21dab852051" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/ed2f9903bcd8a367679df8cfb6c6a9c09d5e7b26a0d43d9816eebdc48de0c8c5> .
+
+<http://data.lblod.info/id/bestuursorganen/03ab4035a1d587d2ff76b9970dd0163f6a6d78592c0badadc0e33bc58894ca92> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "03ab4035a1d587d2ff76b9970dd0163f6a6d78592c0badadc0e33bc58894ca92" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/ade075793dadf91c3ba68d847b278fc95c9eefd4193c3c63ca1c4362a36d3e04> .
+
+<http://data.lblod.info/id/bestuursorganen/0502e6d56bbef7652cbe046c9c750f115d85723561c803fb3218ec39de7e209f> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "0502e6d56bbef7652cbe046c9c750f115d85723561c803fb3218ec39de7e209f" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/55c1c2d4b5c9475076827774a7d0e7f16feab3e06c941920d8faac5d20dfa2ea> .
+
+<http://data.lblod.info/id/bestuursorganen/05ce17a2c4e5ae2d28312b9a477a9b21cafbdd3917a5e7dddc97a8d4e55f6b93> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "05ce17a2c4e5ae2d28312b9a477a9b21cafbdd3917a5e7dddc97a8d4e55f6b93" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/924e96efdc2b53c68ab93aa3b5059b3e7f6fbba48c196b5efb5b3ee1cf381fbc> .
+
+<http://data.lblod.info/id/bestuursorganen/06c8a5d17a95c731738e5cd821f972ae7b342d7b52700525071b63a8fa877abe> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "06c8a5d17a95c731738e5cd821f972ae7b342d7b52700525071b63a8fa877abe" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/17e8cef9d6d0c8160643b5ecca1a854ea63223b1a45e09bce7d2d05300631e08> .
+
+<http://data.lblod.info/id/bestuursorganen/0789acf2-1263-44cc-9696-b8ace1a45bef> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "0789acf2-1263-44cc-9696-b8ace1a45bef" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/6f5c354b-d24b-468a-9035-59df478865d3> .
+
+<http://data.lblod.info/id/bestuursorganen/07ee737a7a0b266a1e4b81f3f5b8663c151b7d3ee69a8c1565a7d184dfd6891a> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "07ee737a7a0b266a1e4b81f3f5b8663c151b7d3ee69a8c1565a7d184dfd6891a" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/57edc726d375bacb4a3041cd5052ac05608141aef009435165d30a924e35660d> .
+
+<http://data.lblod.info/id/bestuursorganen/08f35a2e902ccf13bcd285fa26465ea309d83e69391611cd4438046647a04b3a> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "08f35a2e902ccf13bcd285fa26465ea309d83e69391611cd4438046647a04b3a" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/349706e35ec52e89b42628c6135a2959190f9dbb16d67c3db2a654026ba87dd1> .
+
+<http://data.lblod.info/id/bestuursorganen/092a3888-fe32-4e46-9704-4f20b1d30c28> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "092a3888-fe32-4e46-9704-4f20b1d30c28" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/803f4437-0403-478e-a4c4-c7984bf295bb> .
+
+<http://data.lblod.info/id/bestuursorganen/0ac69787fdbdc9b510808e0a6481aef97e8245f842de0b360308caf82f358858> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "0ac69787fdbdc9b510808e0a6481aef97e8245f842de0b360308caf82f358858" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/0c0a571475b700fb920da8561c50f8d4db1f5739b9941bf00f4c3ec5ff2b62fb> .
+
+<http://data.lblod.info/id/bestuursorganen/0b5ec98b-8160-4af8-a2b8-84bb452adc78> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "0b5ec98b-8160-4af8-a2b8-84bb452adc78" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/340ed583-e7b4-4bff-940a-f3cbc98df65a> .
+
+<http://data.lblod.info/id/bestuursorganen/0cc7abe94890895696bb141955d251d4ab1c30b023f7efdada1ec5d6cd4702cf> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "0cc7abe94890895696bb141955d251d4ab1c30b023f7efdada1ec5d6cd4702cf" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/a2f523f134b282572a0f104ca3540f566d0a609bbd096758d2f28be76392eda5> .
+
+<http://data.lblod.info/id/bestuursorganen/0e8753dd669ef5c7c70fd08ba7fc96093679eede2d3d0268f164fa85a68d4c5c> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "0e8753dd669ef5c7c70fd08ba7fc96093679eede2d3d0268f164fa85a68d4c5c" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/e5204e8f3787a606039371ea86bee5c7c77257890ee606475af944c5e0d0556e> .
+
+<http://data.lblod.info/id/bestuursorganen/0f2f93d8b77e2dd255fcca88615b0ff164f46218c882b77d06c52a1196981029> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "0f2f93d8b77e2dd255fcca88615b0ff164f46218c882b77d06c52a1196981029" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/7410611802576726b030f75502f605f19acdfe39bdaac33c8257e498efdee439> .
+
+<http://data.lblod.info/id/bestuursorganen/102b92011d092d548911dbb9b758fb4ece8b7810d71b3b242c0f15c418cc9da7> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "102b92011d092d548911dbb9b758fb4ece8b7810d71b3b242c0f15c418cc9da7" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/807ea0d1ac72a2a20550b0b9bfc793ceef74799474c7589c039e3a6bd2c14656> .
+
+<http://data.lblod.info/id/bestuursorganen/10d39db2c6fa90dab5a5d53da1789619b57ae5319d72ce6f05291cf3a60bc24f> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "10d39db2c6fa90dab5a5d53da1789619b57ae5319d72ce6f05291cf3a60bc24f" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/ec9ec7c6886fe1bb05e2f95c534435d2f122fe050bf089832511499a2f9ecffd> .
+
+<http://data.lblod.info/id/bestuursorganen/11a2899e993c650de4c8dbd7f5414a29c415be5f587ce07e4844709b0ebe68c5> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "11a2899e993c650de4c8dbd7f5414a29c415be5f587ce07e4844709b0ebe68c5" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/aa28bbec2240ce8908cf40cd7e00274a0cc0ee5d6397171da8bf9bb18445bead> .
+
+<http://data.lblod.info/id/bestuursorganen/11ae967498b85f77d0ab1974127a4b2cee8b65161f87fcaaf143960281fa9cf6> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "11ae967498b85f77d0ab1974127a4b2cee8b65161f87fcaaf143960281fa9cf6" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/a0a342bbddd41483a282d13247e328767b871c3396a8bc1851ef5efcc50797f0> .
+
+<http://data.lblod.info/id/bestuursorganen/120a3777dfa31dd69cde486f9e087a51501f33e07f5a4a5ad59fe79cc2ad85a9> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "120a3777dfa31dd69cde486f9e087a51501f33e07f5a4a5ad59fe79cc2ad85a9" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/febe05a13c6fe777d66b7183c9b8749a6b7de21c57594387ee0b99c9ab0950bb> .
+
+<http://data.lblod.info/id/bestuursorganen/14de7390504fa71aa8ff690599261672045fa2bce063f81fdfedfd2e7dea9250> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "14de7390504fa71aa8ff690599261672045fa2bce063f81fdfedfd2e7dea9250" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/4bd7cd264961452ea3fdc3179a85c2f67ddbc08d813db63e10c47cf8edf42291> .
+
+<http://data.lblod.info/id/bestuursorganen/16683b0c47089e68787a651779d4dd08336acb65ec7da603218e33bda6518ead> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "16683b0c47089e68787a651779d4dd08336acb65ec7da603218e33bda6518ead" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/a441e3f68206297197481c65ccb44991569cc05a46c4819c763bb35968847450> .
+
+<http://data.lblod.info/id/bestuursorganen/16ea19c6-2e54-438b-bf69-e0dcfea6b6cd> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "16ea19c6-2e54-438b-bf69-e0dcfea6b6cd" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/14858678-b8fd-48ad-a9b1-9448b8709b39> .
+
+<http://data.lblod.info/id/bestuursorganen/1758db8f6a1675fe09abdb2f904b37496260fe1df445fb29e12dc7d47d55f9ec> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "1758db8f6a1675fe09abdb2f904b37496260fe1df445fb29e12dc7d47d55f9ec" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/0e60719bc5a766fc988a124930c35c2e078d6224af1a05ca35b10c44dc1313e6> .
+
+<http://data.lblod.info/id/bestuursorganen/19044711bdb682bd1aba3907b439b39dcc5993f1777dd006feff27ab96825255> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "19044711bdb682bd1aba3907b439b39dcc5993f1777dd006feff27ab96825255" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/51008306c233870136e5717ca75703ec94b09b53bbca80376e37fbbca61e1c1a> .
+
+<http://data.lblod.info/id/bestuursorganen/1a41bc77-53d5-4958-b31a-5d091c010abb> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "1a41bc77-53d5-4958-b31a-5d091c010abb" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/374ffe1f-f106-40c8-9cbb-9ce564e330ac> .
+
+<http://data.lblod.info/id/bestuursorganen/1acf2eb6229344603540be600101393e2258b935e031b7ce8cb0ba3d8cd17a8b> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "1acf2eb6229344603540be600101393e2258b935e031b7ce8cb0ba3d8cd17a8b" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/134751eec423d8fe504bab494ee548857278e9e1aba0aa36815672f11887f863> .
+
+<http://data.lblod.info/id/bestuursorganen/1b08d48ec4326adbb2ccabb3a341f21f8696ec4c7f04bae559f2cfac12904c1a> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "1b08d48ec4326adbb2ccabb3a341f21f8696ec4c7f04bae559f2cfac12904c1a" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/fb5a9b9130209721b8fd3b8107cf16381e24afffeb3e8f08a51f11ce298bb72b> .
+
+<http://data.lblod.info/id/bestuursorganen/1bec88cf-6ee8-41cc-8772-6565f1a146fb> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "1bec88cf-6ee8-41cc-8772-6565f1a146fb" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/cab8ee54-2a46-42d6-b2fa-e4bb3e02cc1d> .
+
+<http://data.lblod.info/id/bestuursorganen/1c10cc2d-919e-451a-be2e-9dddfb28a0a3> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "1c10cc2d-919e-451a-be2e-9dddfb28a0a3" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/a586e06f-8d27-44ba-9e26-5607919ae297> .
+
+<http://data.lblod.info/id/bestuursorganen/1dddc7f6c37dd868c169f37a46e343de837ac7561afa04c3dcd74fe1ef00a86c> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "1dddc7f6c37dd868c169f37a46e343de837ac7561afa04c3dcd74fe1ef00a86c" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/138be34133b48d60ca723ffd758ef523b6fbbfb2e997a27a0c2cdef7f77f13cd> .
+
+<http://data.lblod.info/id/bestuursorganen/1e10c155-1128-4ab7-8d49-345c85e022f3> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "1e10c155-1128-4ab7-8d49-345c85e022f3" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/a8b6543b-de72-48cd-8b1e-ff035783f818> .
+
+<http://data.lblod.info/id/bestuursorganen/1e24ced5-7d5e-45e6-940d-ed3e342c681e> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "1e24ced5-7d5e-45e6-940d-ed3e342c681e" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/486dc6e5-d230-4eec-88d5-4e9da825f827> .
+
+<http://data.lblod.info/id/bestuursorganen/1efe43c653e46774ff5359027df5f64c62bb0ec42f2eeced283d4dc30d1b9237> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "1efe43c653e46774ff5359027df5f64c62bb0ec42f2eeced283d4dc30d1b9237" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/be26ea1157c81770ff3146425e628b4b52fa1a85635a78c792a50ebbca904c4c> .
+
+<http://data.lblod.info/id/bestuursorganen/20d8d72ed811d49fa31b11f80cab53b9b766a05fa77b184cc0e42d7eb4e3e2df> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "20d8d72ed811d49fa31b11f80cab53b9b766a05fa77b184cc0e42d7eb4e3e2df" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/2030e1c6377d1ea4e3a1ed772b3445bcdd48349df9e67308f70e5518e264010e> .
+
+<http://data.lblod.info/id/bestuursorganen/2194270c-3fb2-4af6-9d28-369e12620f45> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "2194270c-3fb2-4af6-9d28-369e12620f45" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/5b78d6f7-b639-4e5c-9cec-83d986cc6ff4> .
+
+<http://data.lblod.info/id/bestuursorganen/22a12169-4fb2-4745-b2c0-e7cc9e258331> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "22a12169-4fb2-4745-b2c0-e7cc9e258331" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/e16a28b9-cc8a-4e07-9b95-b5e7feefad82> .
+
+<http://data.lblod.info/id/bestuursorganen/25d403cd-30eb-4065-bd37-a99d7e6deb44> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2012-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "25d403cd-30eb-4065-bd37-a99d7e6deb44" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/32205ec8-61f8-4d92-9d58-fbdd09805896> .
+
+<http://data.lblod.info/id/bestuursorganen/266f17a7-783f-4a65-ab86-1c77bbdedbd2> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "266f17a7-783f-4a65-ab86-1c77bbdedbd2" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/1a8f3ad6-4122-4ba2-8fd1-5c5e67e35580> .
+
+<http://data.lblod.info/id/bestuursorganen/26edd4aec98231ea0bf474a8f3472ebb6e48db9e531f1bf3976f58300a0ecb32> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "26edd4aec98231ea0bf474a8f3472ebb6e48db9e531f1bf3976f58300a0ecb32" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/7dd1c24411211763b70fc2830bea815371eb1fa6bf7af875c6cb92ab04f2d79e> .
+
+<http://data.lblod.info/id/bestuursorganen/27db1ba82ae89a12c0754641b302c5915e714be34e5a423cc99069e5a7719e40> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "27db1ba82ae89a12c0754641b302c5915e714be34e5a423cc99069e5a7719e40" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/2a6e6fa5d0c2f53176ef6f94368400aeac5bf86dc2f236f3e3ed021583ff56c0> .
+
+<http://data.lblod.info/id/bestuursorganen/27dc18781381d104cf2a582abd320c6515f3a0ef74194d468767894f08f0f3fc> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "27dc18781381d104cf2a582abd320c6515f3a0ef74194d468767894f08f0f3fc" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/012bfab9c8aa65d11b85c7decd08640609220f1f1bd7fb46d4634b2deb829bbf> .
+
+<http://data.lblod.info/id/bestuursorganen/292571e9f6ea58bf2c777a15d2c7887ee63259a546e706050b87d2f900506871> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "292571e9f6ea58bf2c777a15d2c7887ee63259a546e706050b87d2f900506871" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/b032c7f6d879a41d4dd4466bb95bcb1ab0364180ba95256d94e1c396a8dcd58c> .
+
+<http://data.lblod.info/id/bestuursorganen/2abf83ac58cc03a5fdd4714a5a40c1ff512bdd5bad3f747d567b953a0c82c67c> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "2abf83ac58cc03a5fdd4714a5a40c1ff512bdd5bad3f747d567b953a0c82c67c" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/352c564ca0cbd2fa0de4026df046570dac3682fe7721fb1239a61ca1c1307618> .
+
+<http://data.lblod.info/id/bestuursorganen/2d5e702ed27480f3d067a08d56848101e9839d5fa6293d1520f0fe07b84fa70b> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "2d5e702ed27480f3d067a08d56848101e9839d5fa6293d1520f0fe07b84fa70b" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/89660a0ffd877a5734e323e655d1e468579dd3b481f72858d611fed8b2c4ac5f> .
+
+<http://data.lblod.info/id/bestuursorganen/2e10e616-c023-462a-afa2-6fdcc40c3b7f> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2012-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "2e10e616-c023-462a-afa2-6fdcc40c3b7f" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/a3b3e2d4-fe97-4770-9e35-b9751b41b7bb> .
+
+<http://data.lblod.info/id/bestuursorganen/2ecf2f41bb4f992771ea86645d7eab54968e9f91109deaec566e04ccc40e6ab1> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "2ecf2f41bb4f992771ea86645d7eab54968e9f91109deaec566e04ccc40e6ab1" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/483e8597eb9bcaf2b3fe3fbbfa1401f338c393aee7ea478e9c000e14f9df0ba4> .
+
+<http://data.lblod.info/id/bestuursorganen/2f7d268866437e3ca4ca4be4153ea8b11a9dece5dde6db85ebfd5a27d4d3ae33> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "2f7d268866437e3ca4ca4be4153ea8b11a9dece5dde6db85ebfd5a27d4d3ae33" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/636051f8596f9d63cc5e178b7ba39ca118081dc263f7666291819b4081a595e3> .
+
+<http://data.lblod.info/id/bestuursorganen/30ca75ef-2d5e-4c6f-b1e0-5e3d654b4873> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "30ca75ef-2d5e-4c6f-b1e0-5e3d654b4873" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/0cea0f1d-4575-40ba-84f4-37f6a81db96a> .
+
+<http://data.lblod.info/id/bestuursorganen/323fff99072c346a565cac3df45a2e7fa4a9b76180c74d8f0b76ceb9b10da9c3> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "323fff99072c346a565cac3df45a2e7fa4a9b76180c74d8f0b76ceb9b10da9c3" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/8b27e419fd0633e7a61e831ead346fd24dc286c4b507a0e4d9df970643f96e81> .
+
+<http://data.lblod.info/id/bestuursorganen/3496487a8bb4a72b3385dafd97ca4cb40220e450916586e1cc16fdce47c8983a> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "3496487a8bb4a72b3385dafd97ca4cb40220e450916586e1cc16fdce47c8983a" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/a03ac5b07e5f63a3a2bf49c90d24ee856d678bea5a5986fb3a9cc6706c54d6f5> .
+
+<http://data.lblod.info/id/bestuursorganen/34dddf99c4d406655c830cebec7a28e61416c6d5a47c8770f2cf39da4991afa4> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "34dddf99c4d406655c830cebec7a28e61416c6d5a47c8770f2cf39da4991afa4" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/877ae60709f2b3771e0d2fbd9cb6b2a5865d117eabced9994a133ad73eb0b8c7> .
+
+<http://data.lblod.info/id/bestuursorganen/35396dd5d85456bf2f7034615354d67be0ce0f7badda3da00456bc0396ffa4f9> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "35396dd5d85456bf2f7034615354d67be0ce0f7badda3da00456bc0396ffa4f9" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/e0e3561ae822d6cb065227206b2cdffa7bbfd8d4011b20ae8346e869aba4dbb7> .
+
+<http://data.lblod.info/id/bestuursorganen/3605585750c9698f31c08d3cf415e1786cf1b8cc5e852e9b6a8e68d33bd17a41> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "3605585750c9698f31c08d3cf415e1786cf1b8cc5e852e9b6a8e68d33bd17a41" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/a590f8e672aee0afee3d18a4f7c0c33590e27fa4002c97e56271ed430752e2ca> .
+
+<http://data.lblod.info/id/bestuursorganen/360afb091485183274c728a11dc6dc7bc118208caaed92f6e28b9f582d59c6b3> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "360afb091485183274c728a11dc6dc7bc118208caaed92f6e28b9f582d59c6b3" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/1169bfd71836de152b831b92192d93b37faa605f0113c9c6ebd040df192db91b> .
+
+<http://data.lblod.info/id/bestuursorganen/3818103a2206128e969284b1ae466a2a2b8ef59e594da6343b62a0dbec53d365> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "3818103a2206128e969284b1ae466a2a2b8ef59e594da6343b62a0dbec53d365" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/1efa5abfb22067a71d30b9082aa69b3806cdc4485776f17df7ca9ddcc4b1332b> .
+
+<http://data.lblod.info/id/bestuursorganen/39180312ac5aa7133857ac69931965676ff5d7ad625494fcdd8e5d085693a4c9> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "39180312ac5aa7133857ac69931965676ff5d7ad625494fcdd8e5d085693a4c9" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/792e71d7759caceb91d35b0394f37092da0bf561c44a23174e00bca32a29baec> .
+
+<http://data.lblod.info/id/bestuursorganen/3a964c1c-05d7-416f-b139-907982def267> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "3a964c1c-05d7-416f-b139-907982def267" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/91ce61e4-2327-47fa-b66b-da55ba52c7b9> .
+
+<http://data.lblod.info/id/bestuursorganen/3b54f8eb38243859f014907f7ecdfaa8deed7e88ac1d1d7f6f11fe5ce7e27b65> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "3b54f8eb38243859f014907f7ecdfaa8deed7e88ac1d1d7f6f11fe5ce7e27b65" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/14e889437c4bd40d8afca9725b99a74b86d65d097f273da14aef10c98b896569> .
+
+<http://data.lblod.info/id/bestuursorganen/3c9ec00c-e412-4934-a7a3-465f2cd7a3a3> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "3c9ec00c-e412-4934-a7a3-465f2cd7a3a3" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/7fa97fa1-40a8-4804-a9be-6d9fad4e0b31> .
+
+<http://data.lblod.info/id/bestuursorganen/3f1b21563aa678d41e9d2dc5771bca2bdfb96086a8284b49971c0882698d3178> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "3f1b21563aa678d41e9d2dc5771bca2bdfb96086a8284b49971c0882698d3178" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/c8135b99bd90d4615bbe38cc64e417f9115c16c277485ce60f17907cb9217aa6> .
+
+<http://data.lblod.info/id/bestuursorganen/3f3d048313075b3d938608cbee5ba0f9c4aed43a521de1a28c5dcecf9a855f94> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "3f3d048313075b3d938608cbee5ba0f9c4aed43a521de1a28c5dcecf9a855f94" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/11028e912034205db754dbc1951f6ef894b979dac0d91b7cd5efd18d5b379ac7> .
+
+<http://data.lblod.info/id/bestuursorganen/3f789d930a9d55360706a1d24b310f9920a7f4a7652d6f290629acef22dd2a3b> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "3f789d930a9d55360706a1d24b310f9920a7f4a7652d6f290629acef22dd2a3b" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/c5d52fb494cf6d7c041a1fbe4a067025c4449c775f5a10822beb0e68e30fa878> .
+
+<http://data.lblod.info/id/bestuursorganen/42765d96-6109-4fc9-af3f-a21e0a6396c3> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "42765d96-6109-4fc9-af3f-a21e0a6396c3" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/ff713b04-b01b-4568-b066-d717627dc629> .
+
+<http://data.lblod.info/id/bestuursorganen/42e65b8fdf9652b7ea21ef51eecf4c555872a0167e64b310a34c8bc21cdb7d60> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "42e65b8fdf9652b7ea21ef51eecf4c555872a0167e64b310a34c8bc21cdb7d60" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/9496c8f9a09b2d0e322bfffca794a8f0bdb0e216ba48251e1706bf07e55f624d> .
+
+<http://data.lblod.info/id/bestuursorganen/433350f833652a291e7acb2fb8ff0e7ae47a773507987bdb55b4130270baa86c> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "433350f833652a291e7acb2fb8ff0e7ae47a773507987bdb55b4130270baa86c" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/e8c8f41c182c0e37b305f6d4742571bf4b13d275f0d74ad3b86a85f1bd80628d> .
+
+<http://data.lblod.info/id/bestuursorganen/4478bcc8c9daaf939aab3e75aaab64c060a7d3b1aed1fbcf3530f9dd59b2c72e> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "4478bcc8c9daaf939aab3e75aaab64c060a7d3b1aed1fbcf3530f9dd59b2c72e" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/69a9ba82b60b97393be13ef2d7ffdcca858edea2b95696e9542f93b3e9e3bc2f> .
+
+<http://data.lblod.info/id/bestuursorganen/46f50ed2ec66853bc054e62180deb9a224decf31198003b7ace3368748cc8afc> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "46f50ed2ec66853bc054e62180deb9a224decf31198003b7ace3368748cc8afc" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/1f1013412ac395144f109e14fd8bf4f5b944ccb35de732c879faf6195189c33b> .
+
+<http://data.lblod.info/id/bestuursorganen/4a96141046521ac3958d074a9fbbc7f55b4088f2714891c70533b10311c4d4a1> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "4a96141046521ac3958d074a9fbbc7f55b4088f2714891c70533b10311c4d4a1" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/cc611cfe86fb7ff78d39aa5fead65d2ca52ce05bca63d78ad5e05394e622afe0> .
+
+<http://data.lblod.info/id/bestuursorganen/4c0af34b8cbf6885aaed4f9a38b6803927a691acea719c65e72bcf2a67eb5156> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "4c0af34b8cbf6885aaed4f9a38b6803927a691acea719c65e72bcf2a67eb5156" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/dbc846999ceb8305f096245b6bcaa982b8794280de72fa75cb6dfbb6f1e777a3> .
+
+<http://data.lblod.info/id/bestuursorganen/4cecfa9c28fcc5f050da431c0f74f8a8f37c89072679fc13aa4bf755c4161e21> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "4cecfa9c28fcc5f050da431c0f74f8a8f37c89072679fc13aa4bf755c4161e21" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/6fe8cf62e278b33d033213dbc6d6a53f5e2b9f465299eb7a27a9521e4fdf6013> .
+
+<http://data.lblod.info/id/bestuursorganen/4d639828ac589677dc7f17898cd954ecca977a002f7be6690f4c30de54cc284b> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "4d639828ac589677dc7f17898cd954ecca977a002f7be6690f4c30de54cc284b" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/34f1dd71f3b15f6228131d6ab4daa364836a9a157c3856c2ca0c848ddc490f9a> .
+
+<http://data.lblod.info/id/bestuursorganen/4dcbcd0d438c5bc7c9b9e5e0612ff20fd98758915461da1003448bb7ea7b1f72> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "4dcbcd0d438c5bc7c9b9e5e0612ff20fd98758915461da1003448bb7ea7b1f72" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/12705da83796cc4360553d9422583965f5853e4b368e82bbb1eff115b1a14a0a> .
+
+<http://data.lblod.info/id/bestuursorganen/4e67550c98e3d1a5a19571cce19e94d8c1f0b0836cbcdcc7814d737086c371c6> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "4e67550c98e3d1a5a19571cce19e94d8c1f0b0836cbcdcc7814d737086c371c6" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/8e7000123fccaa964c28466031d69fd19d74e602ae953a764d47e0d0dba447f8> .
+
+<http://data.lblod.info/id/bestuursorganen/4e7749d7-9f31-4d7b-9b10-7f29a829838b> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "4e7749d7-9f31-4d7b-9b10-7f29a829838b" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/8d2c1131-4a60-4128-b118-e01875732deb> .
+
+<http://data.lblod.info/id/bestuursorganen/4e9295a2-03a5-4be7-8877-31d14cc5ab40> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "4e9295a2-03a5-4be7-8877-31d14cc5ab40" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/e150b67e-27ae-4e62-8f7a-ab0bbf72989e> .
+
+<http://data.lblod.info/id/bestuursorganen/4ec22de6f28a8c9337269ca6d96d7c013edfc5bc9875a2e6b2b1abad2adb6e7c> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "4ec22de6f28a8c9337269ca6d96d7c013edfc5bc9875a2e6b2b1abad2adb6e7c" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/f26dbf88e676afccbaa30724bdd45f847c7cdc444bf0108bbb9596e5f7d64e93> .
+
+<http://data.lblod.info/id/bestuursorganen/4f0d7cb3950ffb9497173df96e80b8a7ad6282d6bf4e1724b77292a25f9ced0e> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "4f0d7cb3950ffb9497173df96e80b8a7ad6282d6bf4e1724b77292a25f9ced0e" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/feb648f5f843f462c8a4b0561cc060fe9859fe51c6255c41e38a6e0eab454d2a> .
+
+<http://data.lblod.info/id/bestuursorganen/50e4593f-6331-481c-a5df-1978fae720e3> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "50e4593f-6331-481c-a5df-1978fae720e3" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/319b266a-5a65-4283-8b35-90de314d12d7> .
+
+<http://data.lblod.info/id/bestuursorganen/52d39e32-f3da-4a79-baef-5aba5f9e012a> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "52d39e32-f3da-4a79-baef-5aba5f9e012a" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/2de56bae-fc09-4c0d-bbe0-8d06512b9ffd> .
+
+<http://data.lblod.info/id/bestuursorganen/549d78c7b34fa36d1d0f20be38744a8072980c9e701f4d7a2be0c541cb7130ff> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "549d78c7b34fa36d1d0f20be38744a8072980c9e701f4d7a2be0c541cb7130ff" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/6df0361e8a93327d387375983a878d58c36b9c9823110d5e460f591c7662f9c8> .
+
+<http://data.lblod.info/id/bestuursorganen/54c6895deae73439752313919881bed1f328f6a4666d29dad2176f89bdb70d54> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "54c6895deae73439752313919881bed1f328f6a4666d29dad2176f89bdb70d54" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/1c11f8622afcac2f4f354d58f30c2bf2bf13759761eb5e3183b8072a306a2d85> .
+
+<http://data.lblod.info/id/bestuursorganen/55544e33b2e77fc68fe062186fa5d516567f9bae426aeb4e86146626fffa7940> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "55544e33b2e77fc68fe062186fa5d516567f9bae426aeb4e86146626fffa7940" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/3191c35e7b3be29c17dff2f411da2f5618073915c377b11872623dc21f86a895> .
+
+<http://data.lblod.info/id/bestuursorganen/5578a882-b829-4c63-a4dd-c606ec67f2ef> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "5578a882-b829-4c63-a4dd-c606ec67f2ef" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/570a636d-9d51-493d-b743-cf8011192ea2> .
+
+<http://data.lblod.info/id/bestuursorganen/59bda33d-5a92-41ca-b0a3-b13929c3ebec> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "59bda33d-5a92-41ca-b0a3-b13929c3ebec" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/f71f0fff-976f-4b7f-a061-4379c8ffb9fc> .
+
+<http://data.lblod.info/id/bestuursorganen/59c17789-f34f-4e7e-9336-34a795994777> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "59c17789-f34f-4e7e-9336-34a795994777" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/674256f3-2c6a-46a5-9b1a-782fea05b81f> .
+
+<http://data.lblod.info/id/bestuursorganen/5ab1740c93b5370796d64a5c25b7fe5e574f3239e0ee7cb442821815ad9249fe> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "5ab1740c93b5370796d64a5c25b7fe5e574f3239e0ee7cb442821815ad9249fe" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/fc106c7f74f6bb4c33c725262a1fafba900bcd1dcfcf5ac527d2a8fb3fab23d9> .
+
+<http://data.lblod.info/id/bestuursorganen/5adbe11fae8cb994763513436e9acfd6ba05172fef46ede45fe735feaebe3b0c> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "5adbe11fae8cb994763513436e9acfd6ba05172fef46ede45fe735feaebe3b0c" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/84b70c75e283bd8535a6e8d88906c0362dc32ad6b358ea17fd164f145c5a9c0d> .
+
+<http://data.lblod.info/id/bestuursorganen/5d4fe4a0b550805196996481f9f19b72a5e553f306dfc7e9d64343da6bb085ac> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "5d4fe4a0b550805196996481f9f19b72a5e553f306dfc7e9d64343da6bb085ac" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/3d0219682cd87d6f60099ca1e3b0303a0c03767e606786f95ddbe42362c74a3c> .
+
+<http://data.lblod.info/id/bestuursorganen/60cf891cb7e038bef18d639a543ee21d9717e414c94dbc4a7401fb3c3f68a7ff> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "60cf891cb7e038bef18d639a543ee21d9717e414c94dbc4a7401fb3c3f68a7ff" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/edd1078b9eb1550d808cf14862d6b344ca4d658cb5ef9126196a547ed141a27a> .
+
+<http://data.lblod.info/id/bestuursorganen/618ef3d9-4c2a-412f-ad78-04a401e4988e> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "618ef3d9-4c2a-412f-ad78-04a401e4988e" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/618ec332-8afc-48e9-ac9d-f5f6ed5123b2> .
+
+<http://data.lblod.info/id/bestuursorganen/6267371a-1dbd-47c2-be4c-b914c54259a9> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "6267371a-1dbd-47c2-be4c-b914c54259a9" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/162a99f3-d7a4-4af1-bed8-197880c582ae> .
+
+<http://data.lblod.info/id/bestuursorganen/646ab28a-5101-4c10-8dd4-0fe935641bc2> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "646ab28a-5101-4c10-8dd4-0fe935641bc2" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/2ee39027-ef8e-4292-a3bc-108dfb97c058> .
+
+<http://data.lblod.info/id/bestuursorganen/650000b1-8352-4108-903d-e332a7c67eb1> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "650000b1-8352-4108-903d-e332a7c67eb1" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/04d8494c-257b-4854-ad1b-fec1f67a2438> .
+
+<http://data.lblod.info/id/bestuursorganen/661c80000f84ff5f6ea025f4c3c809ed4fcb4fab2f4c5b531c6027c744e0dc6f> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "661c80000f84ff5f6ea025f4c3c809ed4fcb4fab2f4c5b531c6027c744e0dc6f" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/a2050f795a675ddf354f6518b06e1eb6df9bdd54cf8270eec97d10db2e0b1b95> .
+
+<http://data.lblod.info/id/bestuursorganen/67a06e04-4d59-462a-a8e5-dbda20ac2a54> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "67a06e04-4d59-462a-a8e5-dbda20ac2a54" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/b8daa4ae-0f5e-4737-8d9c-626572f738c1> .
+
+<http://data.lblod.info/id/bestuursorganen/696a99b5e42c774e8ecf4e2ecf61f14f3c1c6b480263476b10d34d570f04f234> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "696a99b5e42c774e8ecf4e2ecf61f14f3c1c6b480263476b10d34d570f04f234" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/3173eac13b480ff339392ed97dbd6a9d71f5ff6602c72411db5c0d5409c9068e> .
+
+<http://data.lblod.info/id/bestuursorganen/6bac703f4e5318e5fa87bae6d3ec3bbc53587ce86a053554197837e74b3112a6> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "6bac703f4e5318e5fa87bae6d3ec3bbc53587ce86a053554197837e74b3112a6" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/36543f720af76d6aa152dfe1ff4aa56d1a3912f027eee01248c4ab4bd9b11f56> .
+
+<http://data.lblod.info/id/bestuursorganen/718ec720869953ac31535c6d548e1474e6dba8f4fefb984b19ba78cf34ec96cb> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "718ec720869953ac31535c6d548e1474e6dba8f4fefb984b19ba78cf34ec96cb" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/d2645d0b57a154063c200973c0b5f42d73d5b46469770f2d6f5ddf8082a0c9ac> .
+
+<http://data.lblod.info/id/bestuursorganen/723cd2febfaf4d521e36aa6d0bebbf9ff087106188b7920fc6b56c2640dff585> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "723cd2febfaf4d521e36aa6d0bebbf9ff087106188b7920fc6b56c2640dff585" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/eb62aae47a313d98530347ed575a4da993da40c28bf22e786cdf84163cdd293c> .
+
+<http://data.lblod.info/id/bestuursorganen/734e1688c34eb1c79d418293d26b37ebeb7a61daf7216afbcd30a8d78321ee15> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "734e1688c34eb1c79d418293d26b37ebeb7a61daf7216afbcd30a8d78321ee15" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/413542e9ce5222c6cbd5de1ab25ee2dc5bbd94aa9305732439220468214f6e1f> .
+
+<http://data.lblod.info/id/bestuursorganen/7382fcd7cfcb3b8ea9bf4acf3ee4e8cef5fe59bdb409de7bef71132e3ced525a> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "7382fcd7cfcb3b8ea9bf4acf3ee4e8cef5fe59bdb409de7bef71132e3ced525a" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/946d80ef274c352312bc9c06d7804858d3a2b92889cb0415325f79da2835e8d3> .
+
+<http://data.lblod.info/id/bestuursorganen/74a3277e80486a4ae673b7889307e14eba8ee4853b155aa7f6f71d6c62fa8823> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "74a3277e80486a4ae673b7889307e14eba8ee4853b155aa7f6f71d6c62fa8823" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/98788c03536f7d48a0d50f14fd139c7cf18122f080ca84e12d6640b4dbfc60b1> .
+
+<http://data.lblod.info/id/bestuursorganen/74e363fb043b8406b68c7c42106c7dc137ec97fb5af6051b8b2f37bb318efe0b> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "74e363fb043b8406b68c7c42106c7dc137ec97fb5af6051b8b2f37bb318efe0b" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/c7755ff82a4c1e151c3824dbc68d4487f2660a1c610f48d1af07a5fcb8f3d34a> .
+
+<http://data.lblod.info/id/bestuursorganen/7507293c5c04e6e750a4040dbb5146da99d3788774d852dd37f2036a76b49b04> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "7507293c5c04e6e750a4040dbb5146da99d3788774d852dd37f2036a76b49b04" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/42c214fc37d385c918c6a6a47eb66ff0f6c598c829495f0638a43318946ed2bd> .
+
+<http://data.lblod.info/id/bestuursorganen/75c0a1fd-d4f6-4aa7-a06c-abf6b1ce1ca8> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "75c0a1fd-d4f6-4aa7-a06c-abf6b1ce1ca8" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/3067b07c-1a3f-4681-b7e1-8670b5f6483c> .
+
+<http://data.lblod.info/id/bestuursorganen/76edd00c0af74dfb2c64ff01b417b91ca33d27f7a8e71ec090c08e90e11618f6> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "76edd00c0af74dfb2c64ff01b417b91ca33d27f7a8e71ec090c08e90e11618f6" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/7b791aa58fb7b2007cfbbcfeda3a0ec327bff2d2247f3e571cc7a7289906bfeb> .
+
+<http://data.lblod.info/id/bestuursorganen/786115cc-3b90-4127-b1f9-4c96c508b27a> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "786115cc-3b90-4127-b1f9-4c96c508b27a" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/f6c535e8-b922-4bb0-8123-88e3f24c4a0c> .
+
+<http://data.lblod.info/id/bestuursorganen/7c051e715b08cd9c4b90c473d43310bce90135b0cf2ea9a34383090cfae584b2> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "7c051e715b08cd9c4b90c473d43310bce90135b0cf2ea9a34383090cfae584b2" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/c69958e3108028cfc38113f1781223ef1b2031a961d096a6a1b61021972e3b4e> .
+
+<http://data.lblod.info/id/bestuursorganen/7c230f6c-b7b1-4ad1-b9c2-deec4cf9bff4> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "7c230f6c-b7b1-4ad1-b9c2-deec4cf9bff4" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/61e08c45-8fa9-441e-bf46-fc8e85833809> .
+
+<http://data.lblod.info/id/bestuursorganen/7dfa9b6ff2d184aa06de708b9e3ef237ce8daa07e0eeef6d84bfb5dc6c726396> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "7dfa9b6ff2d184aa06de708b9e3ef237ce8daa07e0eeef6d84bfb5dc6c726396" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/fefd211ec0a93aae6bc2ef49330e071a8e05a5ad55f2db4bdf3e9e18c0aa921b> .
+
+<http://data.lblod.info/id/bestuursorganen/7e6da269e6cc94fda5c4c4aa6a2d7bb2f3460ccf7267cbd7002e49fd57b40e9b> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "7e6da269e6cc94fda5c4c4aa6a2d7bb2f3460ccf7267cbd7002e49fd57b40e9b" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/cd8a7b518bccccaadbde24a3174484a8180634d33a87b0ef68a7f4876d80b962> .
+
+<http://data.lblod.info/id/bestuursorganen/7fb858d2d5db4d53b9491e6ff4cc97f434d7d4c874260487c227dd1d3ad51da7> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "7fb858d2d5db4d53b9491e6ff4cc97f434d7d4c874260487c227dd1d3ad51da7" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/1cd356885fff8bcaef2c772d96e415a50e86d5dcf9eb9006d69b2dff9615e357> .
+
+<http://data.lblod.info/id/bestuursorganen/81177c0eca8aecf2cb3b54da55d75d4203bc9d1d7be42b6ef54ee36bf7696f77> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "81177c0eca8aecf2cb3b54da55d75d4203bc9d1d7be42b6ef54ee36bf7696f77" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/ea222f4557ab8f46a92ead81cc885bb2b0dd94694affd6e4fbcd01da9863a9ee> .
+
+<http://data.lblod.info/id/bestuursorganen/821818d245d8af10feb5911f8e03bea66429c4bc96f7c7b63033f08d582cfe6f> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "821818d245d8af10feb5911f8e03bea66429c4bc96f7c7b63033f08d582cfe6f" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/f8424ef32532db4572e866ff1f2644bdd1b738bced68cf70c2c117b7afa5eb8b> .
+
+<http://data.lblod.info/id/bestuursorganen/821c645fa1b74cde06d94d465a69e388918b3fb2b0573ec35108e4dba6797dde> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "821c645fa1b74cde06d94d465a69e388918b3fb2b0573ec35108e4dba6797dde" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/596d0888a52cee639b5e1f18bc6fb2d8cc626ed68e92d1243fa2eb390a760055> .
+
+<http://data.lblod.info/id/bestuursorganen/838e0686-5faa-48a4-903f-8f6abc94aa4c> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2012-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "838e0686-5faa-48a4-903f-8f6abc94aa4c" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/214768c3-edae-4dd8-897f-81aa48fb54fe> .
+
+<http://data.lblod.info/id/bestuursorganen/8581154b-05f8-47ec-9e92-76e6395dc898> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "8581154b-05f8-47ec-9e92-76e6395dc898" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/9c70d2fc-64be-4916-ba20-df9f9d27562c> .
+
+<http://data.lblod.info/id/bestuursorganen/868fa75d9b9107eeb2b49d990bfa0e67bb297a26c82a7af575b154cc99104bec> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "868fa75d9b9107eeb2b49d990bfa0e67bb297a26c82a7af575b154cc99104bec" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/7b00d41053e455f5f9b213ec4f9bd92b803955f076dd290bf15ac5546f2e8349> .
+
+<http://data.lblod.info/id/bestuursorganen/87953f720e0dab5f4c7cf28ebca1a2e3fb0b27a6b534a02f19bc6c88c0dbae7a> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "87953f720e0dab5f4c7cf28ebca1a2e3fb0b27a6b534a02f19bc6c88c0dbae7a" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/414b873bc52cabee55cdd6d5df7ba211dc668e86164c1a8c1e743f5a0d539281> .
+
+<http://data.lblod.info/id/bestuursorganen/87fb808d-f838-4db3-8dad-64a63b1fd27c> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "87fb808d-f838-4db3-8dad-64a63b1fd27c" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/fb918cf2-6a8f-41f5-a4a8-4a57f979ccfe> .
+
+<http://data.lblod.info/id/bestuursorganen/8ac3d8fa-14fb-4bf9-9068-173c4e5f6bcf> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "8ac3d8fa-14fb-4bf9-9068-173c4e5f6bcf" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/d46795a1-b4d9-48ac-89db-e6ae36681995> .
+
+<http://data.lblod.info/id/bestuursorganen/8b4bfcd7e1618640950c7b07a0639ed15c542ffca4514d18f09abb85c521a38d> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "8b4bfcd7e1618640950c7b07a0639ed15c542ffca4514d18f09abb85c521a38d" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/613ba23ce05408d28f6cad6713357424349e3718e6344796b42633e08f75f48b> .
+
+<http://data.lblod.info/id/bestuursorganen/8c11ab01ef79a78735b6d3bd7a6f733b1f91d94e5ca7ff1eb1b0e810c48be9c7> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "8c11ab01ef79a78735b6d3bd7a6f733b1f91d94e5ca7ff1eb1b0e810c48be9c7" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/01ddcbef8aeea5ea14b08c3cb2bebd4667fb1dd54e9b8c8006c0296b43d4f47c> .
+
+<http://data.lblod.info/id/bestuursorganen/8c726ea24bd6c2116dea777de04220b7da1a7abbc357d3659dcd062bbccfa4a8> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "8c726ea24bd6c2116dea777de04220b7da1a7abbc357d3659dcd062bbccfa4a8" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/da698ecb726c4107d4bd43456daf5af052ea010a80be1260093d1d253dd57120> .
+
+<http://data.lblod.info/id/bestuursorganen/8dbfe24072f19a408cff44522af31bdf174c5a43179aba7dda55ffee55a00afd> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "8dbfe24072f19a408cff44522af31bdf174c5a43179aba7dda55ffee55a00afd" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/2e327ab30efb59feb0209f8552b3057fe5c1a0dfafb01ee2e09ac4556c585db3> .
+
+<http://data.lblod.info/id/bestuursorganen/8dcb56310e52a366219b95d99870d804a20c667d9ea9c6eedcdac6ca63af3f7f> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "8dcb56310e52a366219b95d99870d804a20c667d9ea9c6eedcdac6ca63af3f7f" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/77d0d52a412a21902e8d2ad7e71ea313760dc171cd76c9156e31dfed8eb10a0c> .
+
+<http://data.lblod.info/id/bestuursorganen/8eb1767c6edd4336701fd4777703e5179d728defe9b44e76ba9c3a3a17e6164e> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "8eb1767c6edd4336701fd4777703e5179d728defe9b44e76ba9c3a3a17e6164e" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/2c7ef3a805d1e3d771ddeed4cd7b42602a4ae935dd3be7d1c9465a7db5e1064f> .
+
+<http://data.lblod.info/id/bestuursorganen/8f9cc1ca-732f-45c7-a772-92236739713e> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "8f9cc1ca-732f-45c7-a772-92236739713e" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/ffaa492a-f385-49a5-8338-ba0b1790d84f> .
+
+<http://data.lblod.info/id/bestuursorganen/8fa5f7e5204707ff5909fd6e4ca0176ad6fab5f35eb83aa7a0849ea023ee07f1> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "8fa5f7e5204707ff5909fd6e4ca0176ad6fab5f35eb83aa7a0849ea023ee07f1" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/d2868361888efbb6f9652c1d2c9c2a65633f15614fec640ced6e26f947508911> .
+
+<http://data.lblod.info/id/bestuursorganen/9006d328a2326b2c4182604c9a9f8fa27b14d0e9dcb8c052db2d31cf2eeb7616> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "9006d328a2326b2c4182604c9a9f8fa27b14d0e9dcb8c052db2d31cf2eeb7616" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/dd89cc72231cb871864097c8229f07bd63e115531b32de5102b8f2cca247d68b> .
+
+<http://data.lblod.info/id/bestuursorganen/902dc805c2d79afcb5070b123dc94df8f616954ae61bc798b2a1f65067fc1bbf> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "902dc805c2d79afcb5070b123dc94df8f616954ae61bc798b2a1f65067fc1bbf" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/c9e4d4e183357a147e9cb9074229253fb220e621defe4ec343d7e030b29fc3fd> .
+
+<http://data.lblod.info/id/bestuursorganen/90cfcc05dd1b252e5ddcabc1f7fb2a7d7b4181537694660e8a57fd2607e66eec> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "90cfcc05dd1b252e5ddcabc1f7fb2a7d7b4181537694660e8a57fd2607e66eec" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/1498530a8759ec33e695878d7528e517e79c176f3b680e7eddaf23a529906beb> .
+
+<http://data.lblod.info/id/bestuursorganen/92093c74dc19b6f8092b5a991d4fa8ae30ded6b57dcc92ed86eebced79706cb9> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "92093c74dc19b6f8092b5a991d4fa8ae30ded6b57dcc92ed86eebced79706cb9" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/3c22db47b7ce7cfd0b3faaf52d4b76b20fcaec34a1b2700bb33739bae4d1ea70> .
+
+<http://data.lblod.info/id/bestuursorganen/93d299bb7cd3fc45a9125d1eb77d65f9febeadaa06c1c5827b24881fbacab91e> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "93d299bb7cd3fc45a9125d1eb77d65f9febeadaa06c1c5827b24881fbacab91e" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/25ffba16bb44085af97558a6989235de8390e8fb809753c5e152e9770cd34efc> .
+
+<http://data.lblod.info/id/bestuursorganen/9414f35d20a4bcc119bd1246716936bd0a8d77f809018ff1763ffc80b24659a6> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "9414f35d20a4bcc119bd1246716936bd0a8d77f809018ff1763ffc80b24659a6" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/85dde6c2ac4eaa9ec6c3c563b29f6738867ed30f057067059c5cd91182efbff4> .
+
+<http://data.lblod.info/id/bestuursorganen/95385b62-eea2-4f3a-9ad3-d10e84c9d18e> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "95385b62-eea2-4f3a-9ad3-d10e84c9d18e" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/ab9efef7-7f98-4204-9a54-d6b4378769c9> .
+
+<http://data.lblod.info/id/bestuursorganen/96995634fc1d7d92b948efc207ac08b79893b49ec2b70eae5b958a5d5d533571> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "96995634fc1d7d92b948efc207ac08b79893b49ec2b70eae5b958a5d5d533571" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/70a43a4956468f814f0083e8972933893becc7e6231950e0dad6a6b6a37a7ae1> .
+
+<http://data.lblod.info/id/bestuursorganen/96af1b7b3c75640ffb87dda8757a38d8ebfbf9bbd698608ed4e6e73d18e3d8fe> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "96af1b7b3c75640ffb87dda8757a38d8ebfbf9bbd698608ed4e6e73d18e3d8fe" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/d92baff8a7562cb556b1bc36b1b212cb38032a006222c3416ffe9f0e6cd62e43> .
+
+<http://data.lblod.info/id/bestuursorganen/9710ad88034d02c8bd49107565a97c29217043c7e8c1a6d88fa6f229edf76447> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "9710ad88034d02c8bd49107565a97c29217043c7e8c1a6d88fa6f229edf76447" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/79fa14c1435a4017130abe3f8d320d54733fc33ab2d04461cea6bba3e1b72099> .
+
+<http://data.lblod.info/id/bestuursorganen/97644976-50a4-4d82-bc77-dee089636cbd> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "97644976-50a4-4d82-bc77-dee089636cbd" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/b76bf1b8-5b8a-4f63-90f7-d0044a7cee63> .
+
+<http://data.lblod.info/id/bestuursorganen/983a922b-bc14-419c-bc5b-3e2a330935e1> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "983a922b-bc14-419c-bc5b-3e2a330935e1" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/6aaf42b4-2d24-42e2-bd7e-d6b88d993ac5> .
+
+<http://data.lblod.info/id/bestuursorganen/992828c3-a9c2-4888-b5ec-7c658ee666a8> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "992828c3-a9c2-4888-b5ec-7c658ee666a8" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/bea9c94f-8498-40e7-92c8-d13d64b46187> .
+
+<http://data.lblod.info/id/bestuursorganen/999f0233-8a01-41f6-bc6c-40e1873ca53b> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "999f0233-8a01-41f6-bc6c-40e1873ca53b" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/27b22bb9-83ea-4ab2-b4bd-7d490b32dc56> .
+
+<http://data.lblod.info/id/bestuursorganen/9b6b17b0e753c72e9b43b0761cb82076e7f2ca78ef98d19646b3441c57dda400> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "9b6b17b0e753c72e9b43b0761cb82076e7f2ca78ef98d19646b3441c57dda400" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/f5e5c533260f018cf7605c894b788f852f4b82bed068ff2e794c54462c228e32> .
+
+<http://data.lblod.info/id/bestuursorganen/9cce4a09b23df199ba658f7d3dc9a16c09ec2a1f4753dc18e71c77832b2c1823> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "9cce4a09b23df199ba658f7d3dc9a16c09ec2a1f4753dc18e71c77832b2c1823" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/84e6099d997a811caa2cc3b40eda678911470e03150469c935bee4769b390e16> .
+
+<http://data.lblod.info/id/bestuursorganen/9cdc4a94e99e616aadd353147b1bd110e3638c6e953aebeb78ae93f84fd3f967> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "9cdc4a94e99e616aadd353147b1bd110e3638c6e953aebeb78ae93f84fd3f967" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/a9631c9ff6da22fa0a2379c0e17d64311035bbd785ae57099e6421ec73652469> .
+
+<http://data.lblod.info/id/bestuursorganen/9d8c2dea-862a-484a-94c4-8e766da5998e> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "9d8c2dea-862a-484a-94c4-8e766da5998e" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/9c3b0c6b-d5bf-4559-aa1a-4803995a04c2> .
+
+<http://data.lblod.info/id/bestuursorganen/a06326710806711be87b0e3a635f11881018e56f1d55187298d38878b838d34b> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "a06326710806711be87b0e3a635f11881018e56f1d55187298d38878b838d34b" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/1b8fbdde8ab60a2f6a465a3cbe8dce23f96c2a3cd9024e77cda624d5c8a8cf34> .
+
+<http://data.lblod.info/id/bestuursorganen/a1714174-95ab-45c8-82d1-04cf3e55eec6> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "a1714174-95ab-45c8-82d1-04cf3e55eec6" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/d7e58222-dc3b-4989-89c8-ae154726f66d> .
+
+<http://data.lblod.info/id/bestuursorganen/a2c15da2-23fa-4f66-a379-15e218b03ba3> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "a2c15da2-23fa-4f66-a379-15e218b03ba3" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/62d0da11-3397-4da1-ade9-d66632292659> .
+
+<http://data.lblod.info/id/bestuursorganen/a2fc889d0be656db1b878b9fbca0d98432f8a593c0ada3e36a0d25773f04c770> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "a2fc889d0be656db1b878b9fbca0d98432f8a593c0ada3e36a0d25773f04c770" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/322a9a77d90a6db1d0f9a696768a49a26e916ad733d14c8050269b3133bb555f> .
+
+<http://data.lblod.info/id/bestuursorganen/a3d4e2b3e29a88265dcecc4134b9eeede86e5b1b433fd5d4de2615bef1bd60c5> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "a3d4e2b3e29a88265dcecc4134b9eeede86e5b1b433fd5d4de2615bef1bd60c5" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/fa04b5e88acbd8d807ff2f2bf115a392ebfafcd9b5a7f9f9de1771496e9cfdd1> .
+
+<http://data.lblod.info/id/bestuursorganen/a44c5c4005648cfd9ed8f018de454e4f24a890798f55ef4666274cd8efe419f7> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "a44c5c4005648cfd9ed8f018de454e4f24a890798f55ef4666274cd8efe419f7" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/773f8b0cd8bb7fb029614d06665b5c12bef064972ffee24a793f59d1d422fff1> .
+
+<http://data.lblod.info/id/bestuursorganen/a7badb9e028aed98ad444209a3fd875ba462426caba08af1b38ffee34951d6a9> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "a7badb9e028aed98ad444209a3fd875ba462426caba08af1b38ffee34951d6a9" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/045fc097648726b851c4ca9b70cc3c90e66a7f44bfbe0282c8bc674cf79ab33b> .
+
+<http://data.lblod.info/id/bestuursorganen/a7e106ca473462d94cf1fcbd34e4857b2e8d81b627e2e6a7fe6bbbea4e7caba1> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "a7e106ca473462d94cf1fcbd34e4857b2e8d81b627e2e6a7fe6bbbea4e7caba1" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/ec026b0f71fc0b92c2b7dab6adbf9f49ddb706029d03ba40ccddb850a748ad65> .
+
+<http://data.lblod.info/id/bestuursorganen/a87606e7-f875-4b42-804c-9be1ab77679b> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "a87606e7-f875-4b42-804c-9be1ab77679b" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/829383d9-661b-49a4-a6cd-46463f1ccf57> .
+
+<http://data.lblod.info/id/bestuursorganen/abe8caddece5909c6d8523cb3dae8564ef2b3d3fe385b365ff41c1504c37b030> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "abe8caddece5909c6d8523cb3dae8564ef2b3d3fe385b365ff41c1504c37b030" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/20465ae33ba8212c474f4ea772c75a207875dd9bb5536593b25ce953e4676434> .
+
+<http://data.lblod.info/id/bestuursorganen/abead5fd8cdf47a31616d4ab49326aa9fc6d20a178ccee9520565c00d7d6c578> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "abead5fd8cdf47a31616d4ab49326aa9fc6d20a178ccee9520565c00d7d6c578" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/2185b2973e4fa95742cbf288043d93314f284c326f6eb2f3d62b8586552fa5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/ac00cda704dd1a50f422fc40cb60f026a27fd35e2e31520a12a72a43651b0a9e> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "ac00cda704dd1a50f422fc40cb60f026a27fd35e2e31520a12a72a43651b0a9e" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/326823c03ef0be17b5d701d6eb8a2e585d1e2bbbda55902a5c1cc6af308709cb> .
+
+<http://data.lblod.info/id/bestuursorganen/ac21c3d7-1df3-4f95-bba1-165647833c41> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "ac21c3d7-1df3-4f95-bba1-165647833c41" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/18bd77af-42ba-4d42-a4ef-325395fdaa95> .
+
+<http://data.lblod.info/id/bestuursorganen/aee0de4dd672c11279d5cde4e6f44f7c9214ca99cf3383daf1a38548b26370aa> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "aee0de4dd672c11279d5cde4e6f44f7c9214ca99cf3383daf1a38548b26370aa" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/fb5e65de611a84055ae286f724e221697037474e99c704ce1bcc30f0399939eb> .
+
+<http://data.lblod.info/id/bestuursorganen/af4a1895-f5c1-4320-81b1-0e6f1ed9860c> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "af4a1895-f5c1-4320-81b1-0e6f1ed9860c" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/6703ddee-84ac-4ef7-8ba4-e62a729d59e2> .
+
+<http://data.lblod.info/id/bestuursorganen/b0695c581cafef532359a2c3591c0389e1a91c7d5b82e6e6cf8cd3084b8b20db> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "b0695c581cafef532359a2c3591c0389e1a91c7d5b82e6e6cf8cd3084b8b20db" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/64e400cf592a48864f63f124bba2fd8f89806e996330774cd1441039ef5ad609> .
+
+<http://data.lblod.info/id/bestuursorganen/b1c6a40bd520109db031e8f81ba6569d85c581124ddd85448f8d2d8c4977a706> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "b1c6a40bd520109db031e8f81ba6569d85c581124ddd85448f8d2d8c4977a706" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/8339649e38b6e128b066467d49240f756d485dc1baa775f71ddd711db2257f9a> .
+
+<http://data.lblod.info/id/bestuursorganen/b35fec68b465281e216e5710555f187a5c330b6ed1a29abffeb5873cdde68849> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "b35fec68b465281e216e5710555f187a5c330b6ed1a29abffeb5873cdde68849" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/eaaff6e72344e426ee4755f13c1f10c1c4cbba57a8f083c83615227b7b40b0f0> .
+
+<http://data.lblod.info/id/bestuursorganen/b4444178-4959-4b2b-8794-1843f68d344f> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "b4444178-4959-4b2b-8794-1843f68d344f" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/30a0fa19-25f7-4c08-9d5f-52de0cbb73a3> .
+
+<http://data.lblod.info/id/bestuursorganen/b446a654-2d92-435e-b86e-90993dfab2be> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "b446a654-2d92-435e-b86e-90993dfab2be" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/6350224c-658b-4b4d-b721-93a34dd1ed52> .
+
+<http://data.lblod.info/id/bestuursorganen/b4f6117c-08c0-4b62-b327-bc45a431386c> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "b4f6117c-08c0-4b62-b327-bc45a431386c" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/6f3fb0ed-c62d-4847-96a0-e64621c1f8a3> .
+
+<http://data.lblod.info/id/bestuursorganen/b523133b6366d85deb44dfe707eb45858f7f25b4e4b8bf099609130996d03ebf> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "b523133b6366d85deb44dfe707eb45858f7f25b4e4b8bf099609130996d03ebf" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/6375568c04a71e2515cf46ba581259c6e2f6cc04c5eaad8f5b5cf5caef599b76> .
+
+<http://data.lblod.info/id/bestuursorganen/b67e1b76ab61388f428c648b35787ce1f1203ecb552665913d8409252db55324> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "b67e1b76ab61388f428c648b35787ce1f1203ecb552665913d8409252db55324" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/f28663295c7bf6e8b2e5ac0bb5edc48406056bd1d0d32aaad7b06eeffa28d8b3> .
+
+<http://data.lblod.info/id/bestuursorganen/b923b72dd391d99c2fefee0b5191529628e9d51c8837ad096dfab816003c72e1> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "b923b72dd391d99c2fefee0b5191529628e9d51c8837ad096dfab816003c72e1" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/c8d142cb32d8fe86159599fd466f55885d47622ca1751390666d1c683276a299> .
+
+<http://data.lblod.info/id/bestuursorganen/b960a7d1b73803dcbc0a30eb9b77b08af5c93f2315c0760a328cfc6e0e0af45d> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "b960a7d1b73803dcbc0a30eb9b77b08af5c93f2315c0760a328cfc6e0e0af45d" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/74d3730b0145031a3becb5edb93d00bfa0a7a3e31393b742eaeeb943da774205> .
+
+<http://data.lblod.info/id/bestuursorganen/ba366ce41fa3f806709efb9aa6f38e661537cd9e017bdf41d4f58f719cdb9e90> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "ba366ce41fa3f806709efb9aa6f38e661537cd9e017bdf41d4f58f719cdb9e90" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/eaa76e59a774804e29ba17404f6829a608d4c551c6685555f68d8881245696a4> .
+
+<http://data.lblod.info/id/bestuursorganen/baabf991fb3f59bc87f4b4fe2294ae59613f5b6f4d50b64cd982893eb8d84b2e> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "baabf991fb3f59bc87f4b4fe2294ae59613f5b6f4d50b64cd982893eb8d84b2e" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/1a70654229874023fb3ff80fcbb9be9c42dd44d319203912d528efc3299cdfd8> .
+
+<http://data.lblod.info/id/bestuursorganen/bbf6fadb54fd2e4eade77a3733d77a7ed048c98dd9a6657fb1f9749914f3f1eb> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "bbf6fadb54fd2e4eade77a3733d77a7ed048c98dd9a6657fb1f9749914f3f1eb" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/648fd202ae981c3fdba75a72fdbcb8919d39125763edad151e76bf642e7ba6ae> .
+
+<http://data.lblod.info/id/bestuursorganen/bc327813fddbe0675f41b2d64f8d31a19a5a633eb44acca7cbea45a4079c4350> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "bc327813fddbe0675f41b2d64f8d31a19a5a633eb44acca7cbea45a4079c4350" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/1fbb52501e70099e4851ee6d86c54becb8b649e809b077a20bf5880b068ad851> .
+
+<http://data.lblod.info/id/bestuursorganen/bdfbfceeab1bb2fcc19de11a8fdb6b3f0830845953cb0628a429cfad7544299f> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "bdfbfceeab1bb2fcc19de11a8fdb6b3f0830845953cb0628a429cfad7544299f" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/6eeb13e21f713c71411532ee9fb5031f5bc1afa4fd42979e3d074d33a675c936> .
+
+<http://data.lblod.info/id/bestuursorganen/c16bc9e577fb33fe0a56f203483bb85a2ebcf5a028a0911b93b953235055cfdd> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "c16bc9e577fb33fe0a56f203483bb85a2ebcf5a028a0911b93b953235055cfdd" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/780a69352adf784f9cbd76488a6b9423b70ce2749188cb921ee7487f7ccb4875> .
+
+<http://data.lblod.info/id/bestuursorganen/c22cbd6ecc6eaa3c34d9fc69745e56bde2ceb1a4e5a848d6a03b521cba09fc5a> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "c22cbd6ecc6eaa3c34d9fc69745e56bde2ceb1a4e5a848d6a03b521cba09fc5a" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/cecca36a16593dd8eca3f4ee15ccb0f7cb5721002bdf2e8ff6b080839efe5611> .
+
+<http://data.lblod.info/id/bestuursorganen/c33cc8426b484438433d004a19ebeab4a12981e077e108b2519b3f912ea72b23> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "c33cc8426b484438433d004a19ebeab4a12981e077e108b2519b3f912ea72b23" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/3c05459a6b0b2696f085146aca7089d873cb76345f16cfb02037e72d3d7174a7> .
+
+<http://data.lblod.info/id/bestuursorganen/c58885c62b50b21b4cfc096c413dde0458c6df03fe9429cb7cfd91d9d3b37ffa> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "c58885c62b50b21b4cfc096c413dde0458c6df03fe9429cb7cfd91d9d3b37ffa" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/43fece0cefc12d012917662b4484cb0af0a5eb56587c5e437e4624392030db3b> .
+
+<http://data.lblod.info/id/bestuursorganen/c6398262a7e9e2ee25e6df0e7bf237b3861f41e06c38f4d241c49f64b5a5643c> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "c6398262a7e9e2ee25e6df0e7bf237b3861f41e06c38f4d241c49f64b5a5643c" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/c62681b6146ed58ae7e1def596f185f8ff1b6b7fe740bfeaa1ade50417ffe062> .
+
+<http://data.lblod.info/id/bestuursorganen/c85c2a7622f9ad4916bf020f938c5bfcf49bd7ee39dae46a16cdb012ff886390> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "c85c2a7622f9ad4916bf020f938c5bfcf49bd7ee39dae46a16cdb012ff886390" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/7632250d4f7ffc9b64763016d9698d2f4aaa2c7728929b2d9e9f4d896b0d6c91> .
+
+<http://data.lblod.info/id/bestuursorganen/c8e77ebc-31dc-4ba5-95f1-6bbc74d95a26> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "c8e77ebc-31dc-4ba5-95f1-6bbc74d95a26" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/f8b0b6ad-b948-43a5-9619-b6e43f063baf> .
+
+<http://data.lblod.info/id/bestuursorganen/c9489c08a013f9cc64a559022e153c934905b583386dd1f4beb78f19891f7126> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "c9489c08a013f9cc64a559022e153c934905b583386dd1f4beb78f19891f7126" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/9136a1cf2a1a4cbe3256fdbd810f9ebd33fb7cc29f73334ccc84356e75dc37d5> .
+
+<http://data.lblod.info/id/bestuursorganen/caa6157ee73d86190667995c804667a96d82526d007354edddd53e9426b06a69> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "caa6157ee73d86190667995c804667a96d82526d007354edddd53e9426b06a69" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/04f8b51bd7d2236f79b4fb879336a1e8e5e5aa5b75f1f67cc3f6576bb5051a6d> .
+
+<http://data.lblod.info/id/bestuursorganen/cbd38dbd0a1ed62ebabf0019007a9c32fb841bcd31a8ea47bc0ecc7de1e8f68f> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "cbd38dbd0a1ed62ebabf0019007a9c32fb841bcd31a8ea47bc0ecc7de1e8f68f" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/f4bc22acf63decd53f8e630d56e2cd78bdf7b2987d925e25acd3ce98cc2a36e1> .
+
+<http://data.lblod.info/id/bestuursorganen/cdbe7729c5d29c9f5b489ae811696b25b8623f4363f9b251863b146165c57c4e> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "cdbe7729c5d29c9f5b489ae811696b25b8623f4363f9b251863b146165c57c4e" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/cb60828256d9434561fa6e455db1ae258de108f18e961ed53ff257be7d933e71> .
+
+<http://data.lblod.info/id/bestuursorganen/ceee55ab15e4aa96eef93b99d39beb1aff47d0917bf88aaac9c871210280d28d> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "ceee55ab15e4aa96eef93b99d39beb1aff47d0917bf88aaac9c871210280d28d" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/7a44fdc6816811eca00350c495a9b18b4acb2e5623be69b6a4321eabad9125c2> .
+
+<http://data.lblod.info/id/bestuursorganen/cfecdc97-5d94-4d09-9d51-69acdcfed6d9> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "cfecdc97-5d94-4d09-9d51-69acdcfed6d9" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/6d5a831e-76a6-4f2d-9fc2-ad36e0fbf540> .
+
+<http://data.lblod.info/id/bestuursorganen/d129a993-e709-4b23-9de7-0671a2ac9e04> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "d129a993-e709-4b23-9de7-0671a2ac9e04" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/b799fb0f-7b05-4528-8b63-29c6e95f252f> .
+
+<http://data.lblod.info/id/bestuursorganen/d15d4561-3078-4452-bb44-41f5dbcde08c> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "d15d4561-3078-4452-bb44-41f5dbcde08c" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/a256f728-2b94-43d5-b12a-2054afaa235a> .
+
+<http://data.lblod.info/id/bestuursorganen/d364690e41508ed4580e7882ac003e18b1c978d8a09ea8016e87e4f9c53e4324> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "d364690e41508ed4580e7882ac003e18b1c978d8a09ea8016e87e4f9c53e4324" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/2df4fc0331e6c7f91eedc9658d962922bee4bfb0c3aac1bcd56de8c36105107a> .
+
+<http://data.lblod.info/id/bestuursorganen/d383d125-3652-43fe-92ce-e1e28d3f2684> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "d383d125-3652-43fe-92ce-e1e28d3f2684" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/81bf654e-29fe-49e0-970f-ea52b85ace46> .
+
+<http://data.lblod.info/id/bestuursorganen/d40ff7222fe9d15f2aa624da3086f307b0241aeaa53549e92025dd2db90523f3> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "d40ff7222fe9d15f2aa624da3086f307b0241aeaa53549e92025dd2db90523f3" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/091e55f8eafd18867abbc7c82d29b238e5ada765d9d1af26fb2565e2128ff6f1> .
+
+<http://data.lblod.info/id/bestuursorganen/d4ae4e90a8178632529ae64a18683601f9c150206ec482c81a5f5f0b686a8d81> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "d4ae4e90a8178632529ae64a18683601f9c150206ec482c81a5f5f0b686a8d81" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/f0309f90d5c4c883dc0d75d8d36ebb7064f41c32f096892822fd46b3c4a146dc> .
+
+<http://data.lblod.info/id/bestuursorganen/d5b848970bcef74f56c7812b86d8e51d9c5d35e6ac5148cb89bbffe4cf2dbff1> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "d5b848970bcef74f56c7812b86d8e51d9c5d35e6ac5148cb89bbffe4cf2dbff1" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/35ecfd71367cdb6da427a11177b8d10ef38f154ce335685a53ecd9a06a2952fd> .
+
+<http://data.lblod.info/id/bestuursorganen/d60971da-9c22-4120-b4df-a9e2f2e70988> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "d60971da-9c22-4120-b4df-a9e2f2e70988" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/61318f50-4072-4307-a017-f185c75c0cfb> .
+
+<http://data.lblod.info/id/bestuursorganen/d641066cde21de78bb4083211c5ada3479201971b62cb1343e349e9d9e3420bc> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "d641066cde21de78bb4083211c5ada3479201971b62cb1343e349e9d9e3420bc" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/8a6777e8b2f374a392f4b86efe4033a178b234b27cf2bb588d7c3a18bd98c13d> .
+
+<http://data.lblod.info/id/bestuursorganen/d9107745-142a-4912-a761-d9633c90825e> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "d9107745-142a-4912-a761-d9633c90825e" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/a66338dc-1c1f-4921-be1c-f826bd04abca> .
+
+<http://data.lblod.info/id/bestuursorganen/da6ba2cb-c39d-469e-9be2-89a8d19ecfd7> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "da6ba2cb-c39d-469e-9be2-89a8d19ecfd7" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/fe36536f-2004-4d53-8246-ce6d14480b2d> .
+
+<http://data.lblod.info/id/bestuursorganen/db2160258099185eb05fa446c05aa79ac70c71b9fd77ead33f4a511cd3921e13> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "db2160258099185eb05fa446c05aa79ac70c71b9fd77ead33f4a511cd3921e13" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/d32f047b36455b50d4b7f812a2668b419be5da47f5cb628e43afc35df036c606> .
+
+<http://data.lblod.info/id/bestuursorganen/dd68153a-728f-4cc9-a581-cfc9bcc1020c> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "dd68153a-728f-4cc9-a581-cfc9bcc1020c" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/f094bca2-c3a4-4071-b862-63a4fb0b62e7> .
+
+<http://data.lblod.info/id/bestuursorganen/e0bbe138-b157-4e51-9541-41a35ee6b764> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "e0bbe138-b157-4e51-9541-41a35ee6b764" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/4623ea58-5556-4ebe-b2c0-5a69af726315> .
+
+<http://data.lblod.info/id/bestuursorganen/e12b86b1-c457-4b86-beb0-4a306e8678e2> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "e12b86b1-c457-4b86-beb0-4a306e8678e2" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/79f76bbe-1d81-4848-9da6-e12a88c5703e> .
+
+<http://data.lblod.info/id/bestuursorganen/e196ad56dfd54744f6918c1a803f2fcd8352f3fb83ee401b58910d750022297c> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "e196ad56dfd54744f6918c1a803f2fcd8352f3fb83ee401b58910d750022297c" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/313e4008d3b89b04966c34bae1611df360432235decd2b09b7452d0b5f30dfb4> .
+
+<http://data.lblod.info/id/bestuursorganen/e210d25e4f82d48f3f0600e33773c8b235e9f9bf4d6093b5fd3f4af357f6de7a> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "e210d25e4f82d48f3f0600e33773c8b235e9f9bf4d6093b5fd3f4af357f6de7a" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/4117ea61de87a287d076ac4949eded73ab787c60700452f115be8f7af1b81401> .
+
+<http://data.lblod.info/id/bestuursorganen/e2f50002a45288b826bb6efdbfc89ec73431943c816864612c93ebd54b37562c> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "e2f50002a45288b826bb6efdbfc89ec73431943c816864612c93ebd54b37562c" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/ef8a409d09f0b9191ce88fe47257b5e3942022c0c557f2fc2d90eda35f6e0abc> .
+
+<http://data.lblod.info/id/bestuursorganen/e391f745936f0f8dc0b35bddfa9823b6f15c722a523f6f1a78958d759169e244> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "e391f745936f0f8dc0b35bddfa9823b6f15c722a523f6f1a78958d759169e244" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/c0e30b4c65187cbf13759d5d70762f74e1c3616266b8324754dea83a06952c8b> .
+
+<http://data.lblod.info/id/bestuursorganen/e3ab36ad0e2f87de9c749db308484af0d0083ca008495942ca40c0adc7f03a4c> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "e3ab36ad0e2f87de9c749db308484af0d0083ca008495942ca40c0adc7f03a4c" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/228319052d127dec7fc74ca59b5f9996e7fe99bbe7d1780e080002625ef1f661> .
+
+<http://data.lblod.info/id/bestuursorganen/e4170723392a7c8dccbee72e6dfa5be38856a70fdbcb963748c537138631e324> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "e4170723392a7c8dccbee72e6dfa5be38856a70fdbcb963748c537138631e324" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/ad92ee5019bfccf17ea44ea27f6b253c0d241079d56af5999f12eb2405d80596> .
+
+<http://data.lblod.info/id/bestuursorganen/e4a76d0c-f03b-4bc4-81d2-2828f2c193af> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "e4a76d0c-f03b-4bc4-81d2-2828f2c193af" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/da674342-ea81-4ee1-b2c7-2f01d769328f> .
+
+<http://data.lblod.info/id/bestuursorganen/e548803cb4cc1414f2acebcb11cba7addd0cb945697a042385b5d45d77ebeb5d> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "e548803cb4cc1414f2acebcb11cba7addd0cb945697a042385b5d45d77ebeb5d" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/d3ba6182840d78f0d80f59dac1344d133ccbb2bd172869b3359a35adf1afdfdc> .
+
+<http://data.lblod.info/id/bestuursorganen/e58cca31887356b73c695a5f5b4eec94329b4c112500c37df19f2208db5cef78> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "e58cca31887356b73c695a5f5b4eec94329b4c112500c37df19f2208db5cef78" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/c6e61059733f91fc0ca48fcfc9406ac9742316ab488820eb8797c8ddc2971a8b> .
+
+<http://data.lblod.info/id/bestuursorganen/e6a39bc6-9ef0-4d1a-81cc-a21e6605b099> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "e6a39bc6-9ef0-4d1a-81cc-a21e6605b099" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/ee3c9b4c-8e84-46dc-a50a-55d37f2a360d> .
+
+<http://data.lblod.info/id/bestuursorganen/e71e7c81-2f41-4b0f-a851-0c667ed05ad2> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "e71e7c81-2f41-4b0f-a851-0c667ed05ad2" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/cc0ed237-e3e8-411e-9580-0a9c265bc916> .
+
+<http://data.lblod.info/id/bestuursorganen/e74568ce74b1bfcc951bad972aa69592e3d12e595ce25420fa264a53ed5aaa90> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "e74568ce74b1bfcc951bad972aa69592e3d12e595ce25420fa264a53ed5aaa90" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/ccb3024222f5c6cb755eb10995caab663e0092cccdbe75f278181ef2b4c71431> .
+
+<http://data.lblod.info/id/bestuursorganen/e8198a519c91474c07d1e13cc07d70b69dd00ebe4ba83bd9418ef9f916bd07c7> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "e8198a519c91474c07d1e13cc07d70b69dd00ebe4ba83bd9418ef9f916bd07c7" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/9a3bd925cf9d00463e74ec37dd490522eabbeb746edebd39c7d5f4126d61b7fe> .
+
+<http://data.lblod.info/id/bestuursorganen/ed31a90f10c58efeb61fff3e4e4246bb3c9a4e40f4a90483c1f6ee9ab09ad0b1> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "ed31a90f10c58efeb61fff3e4e4246bb3c9a4e40f4a90483c1f6ee9ab09ad0b1" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/3a5a0036f93b961dc306329b218399884edb59426cdbe22aa3ade16c73318c78> .
+
+<http://data.lblod.info/id/bestuursorganen/ee5bd719e6fd47e74c96624db2df02da761ffbe1cf0d3d091956282af1d9cd0d> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "ee5bd719e6fd47e74c96624db2df02da761ffbe1cf0d3d091956282af1d9cd0d" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/f9da4d6795520947940e170b0b09859fc303b4dc349aab34ea1e7c7327afc2b7> .
+
+<http://data.lblod.info/id/bestuursorganen/ee5c0c5118a18764de815720c9825758bab592af2c41bad23e3c774b97f6d035> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "ee5c0c5118a18764de815720c9825758bab592af2c41bad23e3c774b97f6d035" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/73d9644ad66ec413085fac71f212f17c7bf240b223a1f13913434a92c3e1aad9> .
+
+<http://data.lblod.info/id/bestuursorganen/ee78a6e9-ec84-4c5c-9dca-5aa3ad5a6e0d> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "ee78a6e9-ec84-4c5c-9dca-5aa3ad5a6e0d" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/1cd094ca-3315-44c0-bd21-e0b8f834d816> .
+
+<http://data.lblod.info/id/bestuursorganen/ef62cc5a1476d1bcc05b8c817b2bf449e3f9adb0bc839d0eb516437e90cdcfd0> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "ef62cc5a1476d1bcc05b8c817b2bf449e3f9adb0bc839d0eb516437e90cdcfd0" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/9820b1f83716266850f3dc2bfee2bda5a4a8a66a665d9b047b70b4b1094de830> .
+
+<http://data.lblod.info/id/bestuursorganen/f167551693d7ff1fbcb21e3d004b586b8796a1e200df40ba3e64ee0efd4e68be> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "f167551693d7ff1fbcb21e3d004b586b8796a1e200df40ba3e64ee0efd4e68be" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/643ddebf51ff4f7bcaf741ea6dcbe226412b70ddba67f78c89cce0ac2d04e144> .
+
+<http://data.lblod.info/id/bestuursorganen/f17295f182997823d6ff07bc0159dd5a3ce7bb46be3d1436e6e90538f6f9ca1a> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "f17295f182997823d6ff07bc0159dd5a3ce7bb46be3d1436e6e90538f6f9ca1a" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/a655b43877df07f5ea5cc12f9bba03a8215d6adc036ce440a38ba2e3b5433e0e> .
+
+<http://data.lblod.info/id/bestuursorganen/f1c71afa-496b-44b9-91f4-6aab4374871a> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2012-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "f1c71afa-496b-44b9-91f4-6aab4374871a" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/aadad537-a93c-4ed7-bd85-f5c9c8a36a7c> .
+
+<http://data.lblod.info/id/bestuursorganen/f22ed856055eace4d929a0f643f2bbbf3189e0635512e823ac4840bde2b189f8> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "f22ed856055eace4d929a0f643f2bbbf3189e0635512e823ac4840bde2b189f8" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/d43fced592855aec5cb9bc4d39d15e53773b20b68723d4f5acc1831e23262f93> .
+
+<http://data.lblod.info/id/bestuursorganen/f26e32a0c5ee565f660ceddf17cb73576d000623b27804782629d8993bbf63ad> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "f26e32a0c5ee565f660ceddf17cb73576d000623b27804782629d8993bbf63ad" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/6e794d492ad601828a326de6e1a5e7ba547451a0c074ce621fa1cc190c40f387> .
+
+<http://data.lblod.info/id/bestuursorganen/f2e53c4c8bd3cf80415c1d863742027024896496940d940a4e9759729ea0b5f8> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "f2e53c4c8bd3cf80415c1d863742027024896496940d940a4e9759729ea0b5f8" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/0c71098f40c9064cac0e6c7a4ee8e8bb6708eeb879086f8d28da7ffb983ca8cd> .
+
+<http://data.lblod.info/id/bestuursorganen/f45557b342be24ef911ba13d2ee896b4560777d266be0bb502e3a692a116cf34> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "f45557b342be24ef911ba13d2ee896b4560777d266be0bb502e3a692a116cf34" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/8afcf3f6e86469c558e48393c903540c2a58b1cac6886b2a14c7f758e458452f> .
+
+<http://data.lblod.info/id/bestuursorganen/f4fc32ed8cb6c2d442026adab1c9d91330d2e8b58b282800ba14f42f271d7daf> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "f4fc32ed8cb6c2d442026adab1c9d91330d2e8b58b282800ba14f42f271d7daf" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/3fbf7af96a9c2ceee8db63c47cfa5ba4b1e117063b9d14790f4f293485f8d4f9> .
+
+<http://data.lblod.info/id/bestuursorganen/f6c325ff-b314-4885-8792-623983db0767> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "f6c325ff-b314-4885-8792-623983db0767" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/d612b65d-0669-40db-b583-680b98df64ce> .
+
+<http://data.lblod.info/id/bestuursorganen/f77140396dba29e4cdd4c4c7636604f8ecc05eaa880d9033ddd13cec8ae44ebd> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "f77140396dba29e4cdd4c4c7636604f8ecc05eaa880d9033ddd13cec8ae44ebd" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/43bff61b2d279770f3840fc1e260272e00e6e847288acd4bebe5698862c853a8> .
+
+<http://data.lblod.info/id/bestuursorganen/fb7e1e096f4e94feb17468326a8b1ec41667b93067447f5518c6b551f49a87f0> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "fb7e1e096f4e94feb17468326a8b1ec41667b93067447f5518c6b551f49a87f0" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/92c89c763ab59f59dce9c03c95a9531dc3c92647d6c3f540ce005262f7cb4832> .
+
+<http://data.lblod.info/id/bestuursorganen/fd2785c0673b6901271933679b6ee8cffeb1b09ea5bdfa8c5a15e8df558e659c> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "fd2785c0673b6901271933679b6ee8cffeb1b09ea5bdfa8c5a15e8df558e659c" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/56f7cb1efd09d3dc29c340df3b5ab610da61f38ffb28581e790dacbedc0797eb> .
+
+<http://data.lblod.info/id/bestuursorganen/fdf011516569be6bfa345771c56dec1f7091d75a9e970048fc9fdf7aeb6f2674> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2019-01-01T00:00:00"^^xsd:dateTime ;
+    mu:uuid "fdf011516569be6bfa345771c56dec1f7091d75a9e970048fc9fdf7aeb6f2674" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/24ede2ecc843ef56bd8a89a750484a5ce1e20251c3ba47d51dbe678df14ca4a7> .
+
+<http://data.lblod.info/id/bestuursorganen/fe2dac18c9af507896c01326dfb4843c7643a763a63074e094bb7638dbab544d> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "fe2dac18c9af507896c01326dfb4843c7643a763a63074e094bb7638dbab544d" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/73fdff741c46c1fc492c6f4910c3f8ee9fa49cc155f17a41212b95450a90f44e> .
+
+<http://data.lblod.info/id/bestuursorganen/ff49a7c81010e851065d979b152a477e68d0018f3c110d636e75b3de887ae7e4> a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "1971-11-03T00:00:00"^^xsd:dateTime ;
+    mu:uuid "ff49a7c81010e851065d979b152a477e68d0018f3c110d636e75b3de887ae7e4" ;
+    generiek:isTijdspecialisatieVan <http://data.lblod.info/id/bestuursorganen/9b8f05c639875623922b15c3d94585e89f9f6ac6a0b7ff0490f2784472862a55> .
+
+<http://data.lblod.info/id/bestuursorganen/012bfab9c8aa65d11b85c7decd08640609220f1f1bd7fb46d4634b2deb829bbf> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/0964427f9f2e113607681e5c25bf744a41bc412a94e1c0acc784a48d79441df6> ;
+    mu:uuid "012bfab9c8aa65d11b85c7decd08640609220f1f1bd7fb46d4634b2deb829bbf" ;
+    skos:prefLabel "Leidend Ambtenaar WOONDIENST REGIO IZEGEM" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/01ddcbef8aeea5ea14b08c3cb2bebd4667fb1dd54e9b8c8006c0296b43d4f47c> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/265f6bcddea9c9e994472376c40bd5591df678ab9fdba41d5d65933467d83f59> ;
+    mu:uuid "01ddcbef8aeea5ea14b08c3cb2bebd4667fb1dd54e9b8c8006c0296b43d4f47c" ;
+    skos:prefLabel "Leidend Ambtenaar Vereniging De Schakelaar" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/045fc097648726b851c4ca9b70cc3c90e66a7f44bfbe0282c8bc674cf79ab33b> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/7a26207c8531ac7c1dba8efd78870dd90d2ad64cb0cf3e666529e60e10e73a2d> ;
+    mu:uuid "045fc097648726b851c4ca9b70cc3c90e66a7f44bfbe0282c8bc674cf79ab33b" ;
+    skos:prefLabel "Raad van bestuur AUTONOME VERENIGING \"HET DAK\"" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/04d8494c-257b-4854-ad1b-fec1f67a2438> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/a9b3046e-331e-4668-b5cc-2da7bb09e354> ;
+    mu:uuid "04d8494c-257b-4854-ad1b-fec1f67a2438" ;
+    skos:prefLabel "Algemene vergadering Kina" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/04f8b51bd7d2236f79b4fb879336a1e8e5e5aa5b75f1f67cc3f6576bb5051a6d> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/e7ff93ecd6ec0ad906e179e3ccb1cea698e30013e888fa28c725b272beef3b99> ;
+    mu:uuid "04f8b51bd7d2236f79b4fb879336a1e8e5e5aa5b75f1f67cc3f6576bb5051a6d" ;
+    skos:prefLabel "Leidend Ambtenaar SOCIAAL VERHUURKANTOOR BRUGGE (SVK BRUGGE)" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/091e55f8eafd18867abbc7c82d29b238e5ada765d9d1af26fb2565e2128ff6f1> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/47ac33b7-9321-432c-8ba8-1d284f04addf> ;
+    mu:uuid "091e55f8eafd18867abbc7c82d29b238e5ada765d9d1af26fb2565e2128ff6f1" ;
+    skos:prefLabel "Leidend Ambtenaar Algemeen Ziekenhuis Jan Palfijn Gent" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/0c0a571475b700fb920da8561c50f8d4db1f5739b9941bf00f4c3ec5ff2b62fb> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/7a26207c8531ac7c1dba8efd78870dd90d2ad64cb0cf3e666529e60e10e73a2d> ;
+    mu:uuid "0c0a571475b700fb920da8561c50f8d4db1f5739b9941bf00f4c3ec5ff2b62fb" ;
+    skos:prefLabel "Leidend Ambtenaar AUTONOME VERENIGING \"HET DAK\"" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/0c71098f40c9064cac0e6c7a4ee8e8bb6708eeb879086f8d28da7ffb983ca8cd> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/a79dd82a5e400056b3f233fc646850f57918b6173036efa1c3597971cdc6649f> ;
+    mu:uuid "0c71098f40c9064cac0e6c7a4ee8e8bb6708eeb879086f8d28da7ffb983ca8cd" ;
+    skos:prefLabel "Raad van bestuur Dienst voor schuldbemiddeling Waasland" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/0cea0f1d-4575-40ba-84f4-37f6a81db96a> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/f490a5f5-5f21-4c01-b70e-80d76ad8c256> ;
+    mu:uuid "0cea0f1d-4575-40ba-84f4-37f6a81db96a" ;
+    skos:prefLabel "Algemene vergadering Zorg Stekene" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/0e60719bc5a766fc988a124930c35c2e078d6224af1a05ca35b10c44dc1313e6> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/8cfb6e37e4259b79bffd9027e38e2a10397edf45084122f3939dd19ff378fe9c> ;
+    mu:uuid "0e60719bc5a766fc988a124930c35c2e078d6224af1a05ca35b10c44dc1313e6" ;
+    skos:prefLabel "Raad van bestuur Zorgbedrijf Brasschaat" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/11028e912034205db754dbc1951f6ef894b979dac0d91b7cd5efd18d5b379ac7> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/31db97c9dab7ed09b591d2f3c567d47f70a5fa66c9ce3b4b2aea1e71f1dc8e76> ;
+    mu:uuid "11028e912034205db754dbc1951f6ef894b979dac0d91b7cd5efd18d5b379ac7" ;
+    skos:prefLabel "Algemene vergadering ZORGBEDRIJF KLEIN-BRABANT" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/1169bfd71836de152b831b92192d93b37faa605f0113c9c6ebd040df192db91b> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/9f839b41d7dba917e53c483d35e693b2cefdb89a13a080faa762845af6a9a337> ;
+    mu:uuid "1169bfd71836de152b831b92192d93b37faa605f0113c9c6ebd040df192db91b" ;
+    skos:prefLabel "Leidend Ambtenaar \"Het Eepos (Wonen voor volwassen personen met een handicap)\"" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/12705da83796cc4360553d9422583965f5853e4b368e82bbb1eff115b1a14a0a> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/507182a9d6532733ac375988f8288bd1f5fdc2cfb1bee374bb6f5046bf307d4d> ;
+    mu:uuid "12705da83796cc4360553d9422583965f5853e4b368e82bbb1eff115b1a14a0a" ;
+    skos:prefLabel "Leidend Ambtenaar Welzijnskoepel West-Brabant" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/134751eec423d8fe504bab494ee548857278e9e1aba0aa36815672f11887f863> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/559066ee63a3bbb4dbcaac93d9da15d9e81891e17e8a1d104a5ed356daa4aca4> ;
+    mu:uuid "134751eec423d8fe504bab494ee548857278e9e1aba0aa36815672f11887f863" ;
+    skos:prefLabel "Raad van bestuur Zorgvereniging OPcura" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/138be34133b48d60ca723ffd758ef523b6fbbfb2e997a27a0c2cdef7f77f13cd> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/265f6bcddea9c9e994472376c40bd5591df678ab9fdba41d5d65933467d83f59> ;
+    mu:uuid "138be34133b48d60ca723ffd758ef523b6fbbfb2e997a27a0c2cdef7f77f13cd" ;
+    skos:prefLabel "Raad van bestuur Vereniging De Schakelaar" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/14858678-b8fd-48ad-a9b1-9448b8709b39> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/47ac33b7-9321-432c-8ba8-1d284f04addf> ;
+    mu:uuid "14858678-b8fd-48ad-a9b1-9448b8709b39" ;
+    skos:prefLabel "Raad van bestuur Algemeen Ziekenhuis Jan Palfijn Gent" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/1498530a8759ec33e695878d7528e517e79c176f3b680e7eddaf23a529906beb> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/559066ee63a3bbb4dbcaac93d9da15d9e81891e17e8a1d104a5ed356daa4aca4> ;
+    mu:uuid "1498530a8759ec33e695878d7528e517e79c176f3b680e7eddaf23a529906beb" ;
+    skos:prefLabel "Algemene vergadering Zorgvereniging OPcura" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/14e889437c4bd40d8afca9725b99a74b86d65d097f273da14aef10c98b896569> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/84ccc300d580fb3de6b36fab26524b43da45e7213d205b57b9db715dc24d35f3> ;
+    mu:uuid "14e889437c4bd40d8afca9725b99a74b86d65d097f273da14aef10c98b896569" ;
+    skos:prefLabel "Leidend Ambtenaar VERENIGING 'T SAS" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/162a99f3-d7a4-4af1-bed8-197880c582ae> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/d9c35f09-2a47-4ecf-b078-4cbe86ad8527> ;
+    mu:uuid "162a99f3-d7a4-4af1-bed8-197880c582ae" ;
+    skos:prefLabel "Raad van bestuur De Steenoven" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/17e8cef9d6d0c8160643b5ecca1a854ea63223b1a45e09bce7d2d05300631e08> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/8d71b78b3048c4062561b199811a6de7d49c8553c794b6cc62a565e683681ed4> ;
+    mu:uuid "17e8cef9d6d0c8160643b5ecca1a854ea63223b1a45e09bce7d2d05300631e08" ;
+    skos:prefLabel "Raad van bestuur Zorg Houthalen-Helchteren" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/18bd77af-42ba-4d42-a4ef-325395fdaa95> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/530dbb2c-a798-4cae-b42e-737b80b83b22> ;
+    mu:uuid "18bd77af-42ba-4d42-a4ef-325395fdaa95" ;
+    skos:prefLabel "Raad van bestuur Welzijnsvereniging De Wijngaard" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/1a70654229874023fb3ff80fcbb9be9c42dd44d319203912d528efc3299cdfd8> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/836436cd7bc957ec9eb24865c628c5707b4a1fbbae5cccebfaf1df0983f888be> ;
+    mu:uuid "1a70654229874023fb3ff80fcbb9be9c42dd44d319203912d528efc3299cdfd8" ;
+    skos:prefLabel "Leidend Ambtenaar Zorg Izegem" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/1a8f3ad6-4122-4ba2-8fd1-5c5e67e35580> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/dbb530bd-a765-49e6-8c3e-4fed14d44c4e> ;
+    mu:uuid "1a8f3ad6-4122-4ba2-8fd1-5c5e67e35580" ;
+    skos:prefLabel "Leidend Ambtenaar Welzijnsvereniging Sleutelzorg" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/1b8fbdde8ab60a2f6a465a3cbe8dce23f96c2a3cd9024e77cda624d5c8a8cf34> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/7152ffbc9f34208fdba63318b1d7e87980937c71cc36dfc24d5303567436f4b8> ;
+    mu:uuid "1b8fbdde8ab60a2f6a465a3cbe8dce23f96c2a3cd9024e77cda624d5c8a8cf34" ;
+    skos:prefLabel "Algemene vergadering Woonzorgnetwerk Edegem" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/1c11f8622afcac2f4f354d58f30c2bf2bf13759761eb5e3183b8072a306a2d85> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/559066ee63a3bbb4dbcaac93d9da15d9e81891e17e8a1d104a5ed356daa4aca4> ;
+    mu:uuid "1c11f8622afcac2f4f354d58f30c2bf2bf13759761eb5e3183b8072a306a2d85" ;
+    skos:prefLabel "Leidend Ambtenaar Zorgvereniging OPcura" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/1cd094ca-3315-44c0-bd21-e0b8f834d816> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/386f7c72-1c2b-49ea-b9fa-664abf86d15f> ;
+    mu:uuid "1cd094ca-3315-44c0-bd21-e0b8f834d816" ;
+    skos:prefLabel "Raad van bestuur Ziekenhuis Oost-Limburg, autonome verzorgingsinstelling" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/1cd356885fff8bcaef2c772d96e415a50e86d5dcf9eb9006d69b2dff9615e357> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/836436cd7bc957ec9eb24865c628c5707b4a1fbbae5cccebfaf1df0983f888be> ;
+    mu:uuid "1cd356885fff8bcaef2c772d96e415a50e86d5dcf9eb9006d69b2dff9615e357" ;
+    skos:prefLabel "Raad van bestuur Zorg Izegem" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/1efa5abfb22067a71d30b9082aa69b3806cdc4485776f17df7ca9ddcc4b1332b> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/2176cd7bde027a98b1d3c2f81862327cb8b3fa0df3757ed432371530e743ad5b> ;
+    mu:uuid "1efa5abfb22067a71d30b9082aa69b3806cdc4485776f17df7ca9ddcc4b1332b" ;
+    skos:prefLabel "Leidend Ambtenaar Sociaal Verhuurkantoor Gent" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/1f1013412ac395144f109e14fd8bf4f5b944ccb35de732c879faf6195189c33b> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/e2dfbd3a56dd87414968d7454dcfde193145e331ddcfc86fb48a9c79b5c0cef3> ;
+    mu:uuid "1f1013412ac395144f109e14fd8bf4f5b944ccb35de732c879faf6195189c33b" ;
+    skos:prefLabel "Raad van bestuur VERENIGING WOK" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/1fbb52501e70099e4851ee6d86c54becb8b649e809b077a20bf5880b068ad851> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/53fefc09ccb63625eda802c01cf32df7fe8a14a14f020a89a08e68dc49d43e31> ;
+    mu:uuid "1fbb52501e70099e4851ee6d86c54becb8b649e809b077a20bf5880b068ad851" ;
+    skos:prefLabel "Leidend Ambtenaar SOCiAL" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/2030e1c6377d1ea4e3a1ed772b3445bcdd48349df9e67308f70e5518e264010e> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/2bf97f7faebd616265d004a80cce0319a110319197b657d5a0a1a16d81f34ca2> ;
+    mu:uuid "2030e1c6377d1ea4e3a1ed772b3445bcdd48349df9e67308f70e5518e264010e" ;
+    skos:prefLabel "Leidend Ambtenaar WELZIJNSZORG KEMPEN" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/20465ae33ba8212c474f4ea772c75a207875dd9bb5536593b25ce953e4676434> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/e2dfbd3a56dd87414968d7454dcfde193145e331ddcfc86fb48a9c79b5c0cef3> ;
+    mu:uuid "20465ae33ba8212c474f4ea772c75a207875dd9bb5536593b25ce953e4676434" ;
+    skos:prefLabel "Leidend Ambtenaar VERENIGING WOK" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/214768c3-edae-4dd8-897f-81aa48fb54fe> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/1bbd0f7a-664c-46bd-8ca0-891801b81962> ;
+    mu:uuid "214768c3-edae-4dd8-897f-81aa48fb54fe" ;
+    skos:prefLabel "Algemene vergadering Zorgbedrijf Sint-Truiden" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/2185b2973e4fa95742cbf288043d93314f284c326f6eb2f3d62b8586552fa5b4> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/b7abada470cd56a64d67b5450b35c3e96c07ce5d752d6207d4886ccc8f4852ff> ;
+    mu:uuid "2185b2973e4fa95742cbf288043d93314f284c326f6eb2f3d62b8586552fa5b4" ;
+    skos:prefLabel "Raad van bestuur AZ ST-JAN Brugge-Oostende A.V." ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/228319052d127dec7fc74ca59b5f9996e7fe99bbe7d1780e080002625ef1f661> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/8d71b78b3048c4062561b199811a6de7d49c8553c794b6cc62a565e683681ed4> ;
+    mu:uuid "228319052d127dec7fc74ca59b5f9996e7fe99bbe7d1780e080002625ef1f661" ;
+    skos:prefLabel "Algemene vergadering Zorg Houthalen-Helchteren" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/24ede2ecc843ef56bd8a89a750484a5ce1e20251c3ba47d51dbe678df14ca4a7> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/96ceb4cf-ece3-417d-914b-3e6eff293e6a> ;
+    mu:uuid "24ede2ecc843ef56bd8a89a750484a5ce1e20251c3ba47d51dbe678df14ca4a7" ;
+    skos:prefLabel "Leidend Ambtenaar Auroraziekenhuis Autonome Verzorgingsinstelling" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/25ffba16bb44085af97558a6989235de8390e8fb809753c5e152e9770cd34efc> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/c4486571e2cf6a0656e29a47a3f210cf9bf732876320953c5759aef27b639842> ;
+    mu:uuid "25ffba16bb44085af97558a6989235de8390e8fb809753c5e152e9770cd34efc" ;
+    skos:prefLabel "Leidend Ambtenaar VERENIGING ONS TEHUIS VOOR ZUID-WEST-VLAANDEREN" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/27b22bb9-83ea-4ab2-b4bd-7d490b32dc56> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/d0ec3d07-a15c-4e04-bcbb-b05083262544> ;
+    mu:uuid "27b22bb9-83ea-4ab2-b4bd-7d490b32dc56" ;
+    skos:prefLabel "Algemene vergadering Zorgpunt Waasland" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/2a6e6fa5d0c2f53176ef6f94368400aeac5bf86dc2f236f3e3ed021583ff56c0> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/2176cd7bde027a98b1d3c2f81862327cb8b3fa0df3757ed432371530e743ad5b> ;
+    mu:uuid "2a6e6fa5d0c2f53176ef6f94368400aeac5bf86dc2f236f3e3ed021583ff56c0" ;
+    skos:prefLabel "Algemene vergadering Sociaal Verhuurkantoor Gent" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/2ae807cdb4146b5a36c19e7d6870049dbf201863a2fa029ccb92f6485107edf0> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/507182a9d6532733ac375988f8288bd1f5fdc2cfb1bee374bb6f5046bf307d4d> ;
+    mu:uuid "2ae807cdb4146b5a36c19e7d6870049dbf201863a2fa029ccb92f6485107edf0" ;
+    skos:prefLabel "Algemene vergadering Welzijnskoepel West-Brabant" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/2c7ef3a805d1e3d771ddeed4cd7b42602a4ae935dd3be7d1c9465a7db5e1064f> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/5072fad918135764714007cea2f3573462199d6cbe7b96d6ac57d1c9b7bde399> ;
+    mu:uuid "2c7ef3a805d1e3d771ddeed4cd7b42602a4ae935dd3be7d1c9465a7db5e1064f" ;
+    skos:prefLabel "Leidend Ambtenaar Vereniging Dodoens" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/2de56bae-fc09-4c0d-bbe0-8d06512b9ffd> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/d0ec3d07-a15c-4e04-bcbb-b05083262544> ;
+    mu:uuid "2de56bae-fc09-4c0d-bbe0-8d06512b9ffd" ;
+    skos:prefLabel "Raad van bestuur Zorgpunt Waasland" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/2df4fc0331e6c7f91eedc9658d962922bee4bfb0c3aac1bcd56de8c36105107a> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/f3f1598c1a9fb9e3666a3001004e4bfdb028da702bb8755655c0946597bb8ea4> ;
+    mu:uuid "2df4fc0331e6c7f91eedc9658d962922bee4bfb0c3aac1bcd56de8c36105107a" ;
+    skos:prefLabel "Algemene vergadering Beschut Wonen - Antwerpen" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/2e327ab30efb59feb0209f8552b3057fe5c1a0dfafb01ee2e09ac4556c585db3> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/6c4179a4684d97c148da2e78ba99579e4145412c6431e1577713e5f095ff4f08> ;
+    mu:uuid "2e327ab30efb59feb0209f8552b3057fe5c1a0dfafb01ee2e09ac4556c585db3" ;
+    skos:prefLabel "Leidend Ambtenaar Zorggroep Orion" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/2ee39027-ef8e-4292-a3bc-108dfb97c058> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/7eff2130-5462-4569-8098-29ceec9e6a22> ;
+    mu:uuid "2ee39027-ef8e-4292-a3bc-108dfb97c058" ;
+    skos:prefLabel "Raad van bestuur ALGEMEEN STEDELIJK ZIEKENHUIS AUTONOME VERZORGINGSINSTELLING" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/3067b07c-1a3f-4681-b7e1-8670b5f6483c> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/27e7a364-fe11-4303-9a43-fc2e1a3510d7> ;
+    mu:uuid "3067b07c-1a3f-4681-b7e1-8670b5f6483c" ;
+    skos:prefLabel "Raad van bestuur Welzijnsvereniging Sint-Gillis-Waas" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/30a0fa19-25f7-4c08-9d5f-52de0cbb73a3> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/4141ab8d-b1e1-4b38-832a-76b4dba20dc7> ;
+    mu:uuid "30a0fa19-25f7-4c08-9d5f-52de0cbb73a3" ;
+    skos:prefLabel "Leidend Ambtenaar Autonome Verzorgingsinstelling Virga Jesseziekenhuis" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/313e4008d3b89b04966c34bae1611df360432235decd2b09b7452d0b5f30dfb4> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/5567394c206a8da9fe1e8ab4dc1d043eabdb5915ecf3d06a9495dc64cc3c691e> ;
+    mu:uuid "313e4008d3b89b04966c34bae1611df360432235decd2b09b7452d0b5f30dfb4" ;
+    skos:prefLabel "Raad van bestuur Vereniging Weldenderend" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/3173eac13b480ff339392ed97dbd6a9d71f5ff6602c72411db5c0d5409c9068e> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/531f08c0-65ac-4f47-ac15-066097ac5756> ;
+    mu:uuid "3173eac13b480ff339392ed97dbd6a9d71f5ff6602c72411db5c0d5409c9068e" ;
+    skos:prefLabel "Leidend Ambtenaar Zorgbedrijf Tielt" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/3191c35e7b3be29c17dff2f411da2f5618073915c377b11872623dc21f86a895> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/d9c35f09-2a47-4ecf-b078-4cbe86ad8527> ;
+    mu:uuid "3191c35e7b3be29c17dff2f411da2f5618073915c377b11872623dc21f86a895" ;
+    skos:prefLabel "Leidend Ambtenaar De Steenoven" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/319b266a-5a65-4283-8b35-90de314d12d7> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/a9b3046e-331e-4668-b5cc-2da7bb09e354> ;
+    mu:uuid "319b266a-5a65-4283-8b35-90de314d12d7" ;
+    skos:prefLabel "Raad van bestuur Kina" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/32205ec8-61f8-4d92-9d58-fbdd09805896> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/50ede269-5c49-41cd-be68-ac135314019c> ;
+    mu:uuid "32205ec8-61f8-4d92-9d58-fbdd09805896" ;
+    skos:prefLabel "Raad van bestuur Algemeen Ziekenhuis Sint-Dimpna" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/322a9a77d90a6db1d0f9a696768a49a26e916ad733d14c8050269b3133bb555f> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/e23cb5929d99c7633348f71af1bf11ab5b8fa3649e34d4e0967a429ee6437bd1> ;
+    mu:uuid "322a9a77d90a6db1d0f9a696768a49a26e916ad733d14c8050269b3133bb555f" ;
+    skos:prefLabel "Raad van bestuur Schuldbemiddeling BODUKAP" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/326823c03ef0be17b5d701d6eb8a2e585d1e2bbbda55902a5c1cc6af308709cb> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/84ccc300d580fb3de6b36fab26524b43da45e7213d205b57b9db715dc24d35f3> ;
+    mu:uuid "326823c03ef0be17b5d701d6eb8a2e585d1e2bbbda55902a5c1cc6af308709cb" ;
+    skos:prefLabel "Raad van bestuur VERENIGING 'T SAS" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/340ed583-e7b4-4bff-940a-f3cbc98df65a> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/d9c35f09-2a47-4ecf-b078-4cbe86ad8527> ;
+    mu:uuid "340ed583-e7b4-4bff-940a-f3cbc98df65a" ;
+    skos:prefLabel "Algemene vergadering De Steenoven" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/349706e35ec52e89b42628c6135a2959190f9dbb16d67c3db2a654026ba87dd1> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/eb31eb0b167e34e43a47ba63cc7bfbbf8e13ce818ede2e7af7bd513b857c8751> ;
+    mu:uuid "349706e35ec52e89b42628c6135a2959190f9dbb16d67c3db2a654026ba87dd1" ;
+    skos:prefLabel "Leidend Ambtenaar RVT/RUSTHUIS NAJAARSZON" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/34f1dd71f3b15f6228131d6ab4daa364836a9a157c3856c2ca0c848ddc490f9a> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/aabc8d18d6b42c555fc9061c1f756bae12c7ab722a4b4d6408e14785d5762500> ;
+    mu:uuid "34f1dd71f3b15f6228131d6ab4daa364836a9a157c3856c2ca0c848ddc490f9a" ;
+    skos:prefLabel "Leidend Ambtenaar Woon- en Zorgbedrijf Wervik" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/352c564ca0cbd2fa0de4026df046570dac3682fe7721fb1239a61ca1c1307618> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/ef67ec9cdeb835268fd4a6f554db25f1bbb081009fa136b597785853076ea937> ;
+    mu:uuid "352c564ca0cbd2fa0de4026df046570dac3682fe7721fb1239a61ca1c1307618" ;
+    skos:prefLabel "Algemene vergadering OPENBARE VERENIGING RONSE" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/35ecfd71367cdb6da427a11177b8d10ef38f154ce335685a53ecd9a06a2952fd> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/0331f7d9259900c12c7cd16e081dca917d6b3ceda358cf69f12a1cdbb734b9ac> ;
+    mu:uuid "35ecfd71367cdb6da427a11177b8d10ef38f154ce335685a53ecd9a06a2952fd" ;
+    skos:prefLabel "Algemene vergadering Woonzorgcentrum van Lierde" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/36543f720af76d6aa152dfe1ff4aa56d1a3912f027eee01248c4ab4bd9b11f56> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/6af38a22fcba9d1701a77d9c869e0f06e11a3291a71a4118a7cd93629ba92c27> ;
+    mu:uuid "36543f720af76d6aa152dfe1ff4aa56d1a3912f027eee01248c4ab4bd9b11f56" ;
+    skos:prefLabel "Leidend Ambtenaar Ruddersstove" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/374ffe1f-f106-40c8-9cbb-9ce564e330ac> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/1165717c-1203-41cd-b434-b041cbe66782> ;
+    mu:uuid "374ffe1f-f106-40c8-9cbb-9ce564e330ac" ;
+    skos:prefLabel "Raad van bestuur ALGEMEEN ZIEKENHUIS WAASLAND" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/3a5a0036f93b961dc306329b218399884edb59426cdbe22aa3ade16c73318c78> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/8d71b78b3048c4062561b199811a6de7d49c8553c794b6cc62a565e683681ed4> ;
+    mu:uuid "3a5a0036f93b961dc306329b218399884edb59426cdbe22aa3ade16c73318c78" ;
+    skos:prefLabel "Leidend Ambtenaar Zorg Houthalen-Helchteren" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/3c05459a6b0b2696f085146aca7089d873cb76345f16cfb02037e72d3d7174a7> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/eb31eb0b167e34e43a47ba63cc7bfbbf8e13ce818ede2e7af7bd513b857c8751> ;
+    mu:uuid "3c05459a6b0b2696f085146aca7089d873cb76345f16cfb02037e72d3d7174a7" ;
+    skos:prefLabel "Raad van bestuur RVT/RUSTHUIS NAJAARSZON" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/3c22db47b7ce7cfd0b3faaf52d4b76b20fcaec34a1b2700bb33739bae4d1ea70> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/f3f1598c1a9fb9e3666a3001004e4bfdb028da702bb8755655c0946597bb8ea4> ;
+    mu:uuid "3c22db47b7ce7cfd0b3faaf52d4b76b20fcaec34a1b2700bb33739bae4d1ea70" ;
+    skos:prefLabel "Leidend Ambtenaar Beschut Wonen - Antwerpen" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/3d0219682cd87d6f60099ca1e3b0303a0c03767e606786f95ddbe42362c74a3c> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/ffec0b97d60ac685f8e95209fdbdee3ba0171511609d109d4252a34fc5bf4160> ;
+    mu:uuid "3d0219682cd87d6f60099ca1e3b0303a0c03767e606786f95ddbe42362c74a3c" ;
+    skos:prefLabel "Algemene vergadering OCMW Vereniging SAKURA" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/3fbf7af96a9c2ceee8db63c47cfa5ba4b1e117063b9d14790f4f293485f8d4f9> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/f7ec3b8b3f74b7656c1769b7b1ec7641e12fe8fcf64564ce0a204e30df498907> ;
+    mu:uuid "3fbf7af96a9c2ceee8db63c47cfa5ba4b1e117063b9d14790f4f293485f8d4f9" ;
+    skos:prefLabel "Algemene vergadering Zorgbedrijf Meetjesland" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/4117ea61de87a287d076ac4949eded73ab787c60700452f115be8f7af1b81401> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/94158248e8e9bd9a05012e06db794178caa74731b2dadcf84f5ad7373f13abcc> ;
+    mu:uuid "4117ea61de87a287d076ac4949eded73ab787c60700452f115be8f7af1b81401" ;
+    skos:prefLabel "Algemene vergadering WOONWINKEL KNOKKE-HEIST" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/413542e9ce5222c6cbd5de1ab25ee2dc5bbd94aa9305732439220468214f6e1f> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/7a26207c8531ac7c1dba8efd78870dd90d2ad64cb0cf3e666529e60e10e73a2d> ;
+    mu:uuid "413542e9ce5222c6cbd5de1ab25ee2dc5bbd94aa9305732439220468214f6e1f" ;
+    skos:prefLabel "Algemene vergadering AUTONOME VERENIGING \"HET DAK\"" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/414b873bc52cabee55cdd6d5df7ba211dc668e86164c1a8c1e743f5a0d539281> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/2176cd7bde027a98b1d3c2f81862327cb8b3fa0df3757ed432371530e743ad5b> ;
+    mu:uuid "414b873bc52cabee55cdd6d5df7ba211dc668e86164c1a8c1e743f5a0d539281" ;
+    skos:prefLabel "Raad van bestuur Sociaal Verhuurkantoor Gent" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/42c214fc37d385c918c6a6a47eb66ff0f6c598c829495f0638a43318946ed2bd> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/6d1c55e517fd1fdcae81e9f07f0875aa9c452bed279e635b94fbe00630e7ae73> ;
+    mu:uuid "42c214fc37d385c918c6a6a47eb66ff0f6c598c829495f0638a43318946ed2bd" ;
+    skos:prefLabel "Leidend Ambtenaar Zorgbedrijf Ouderenzorg Genk" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/43bff61b2d279770f3840fc1e260272e00e6e847288acd4bebe5698862c853a8> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/d0ec3d07-a15c-4e04-bcbb-b05083262544> ;
+    mu:uuid "43bff61b2d279770f3840fc1e260272e00e6e847288acd4bebe5698862c853a8" ;
+    skos:prefLabel "Leidend Ambtenaar Zorgpunt Waasland" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/43fece0cefc12d012917662b4484cb0af0a5eb56587c5e437e4624392030db3b> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/6c4179a4684d97c148da2e78ba99579e4145412c6431e1577713e5f095ff4f08> ;
+    mu:uuid "43fece0cefc12d012917662b4484cb0af0a5eb56587c5e437e4624392030db3b" ;
+    skos:prefLabel "Algemene vergadering Zorggroep Orion" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/4623ea58-5556-4ebe-b2c0-5a69af726315> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/e2bf9406-8c70-4dda-bb88-5771480d9155> ;
+    mu:uuid "4623ea58-5556-4ebe-b2c0-5a69af726315" ;
+    skos:prefLabel "Raad van bestuur Woonzorggroep Voorkempen" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/483e8597eb9bcaf2b3fe3fbbfa1401f338c393aee7ea478e9c000e14f9df0ba4> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/c11ca390da51a65c5e328cd219eb91f5a657bba3d0f47cf995039dbfb1c64105> ;
+    mu:uuid "483e8597eb9bcaf2b3fe3fbbfa1401f338c393aee7ea478e9c000e14f9df0ba4" ;
+    skos:prefLabel "Leidend Ambtenaar W13" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/486dc6e5-d230-4eec-88d5-4e9da825f827> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/251143c6-2094-4ad5-8b54-26cfded0082a> ;
+    mu:uuid "486dc6e5-d230-4eec-88d5-4e9da825f827" ;
+    skos:prefLabel "Raad van bestuur Autonome Verzorginstelling Henri Serruysziekenhuis" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/4bd7cd264961452ea3fdc3179a85c2f67ddbc08d813db63e10c47cf8edf42291> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/e23cb5929d99c7633348f71af1bf11ab5b8fa3649e34d4e0967a429ee6437bd1> ;
+    mu:uuid "4bd7cd264961452ea3fdc3179a85c2f67ddbc08d813db63e10c47cf8edf42291" ;
+    skos:prefLabel "Algemene vergadering Schuldbemiddeling BODUKAP" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/51008306c233870136e5717ca75703ec94b09b53bbca80376e37fbbca61e1c1a> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/0964427f9f2e113607681e5c25bf744a41bc412a94e1c0acc784a48d79441df6> ;
+    mu:uuid "51008306c233870136e5717ca75703ec94b09b53bbca80376e37fbbca61e1c1a" ;
+    skos:prefLabel "Raad van bestuur HUISVESTINGSDIENST REGIO IZEGEM" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/55c1c2d4b5c9475076827774a7d0e7f16feab3e06c941920d8faac5d20dfa2ea> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/14cf807351ef2b7b20c8f481573b576f94cff8d7b8722190f137bc52a4d2e8c8> ;
+    mu:uuid "55c1c2d4b5c9475076827774a7d0e7f16feab3e06c941920d8faac5d20dfa2ea" ;
+    skos:prefLabel "Algemene vergadering Zorgbedrijf Antwerpen" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/56f7cb1efd09d3dc29c340df3b5ab610da61f38ffb28581e790dacbedc0797eb> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/21a70e74dbb297ec42d5cc72ab810178b298d12fc8f679c742d2501f7ce5b6a3> ;
+    mu:uuid "56f7cb1efd09d3dc29c340df3b5ab610da61f38ffb28581e790dacbedc0797eb" ;
+    skos:prefLabel "Algemene vergadering Zorgbedrijf Leuven" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/570a636d-9d51-493d-b743-cf8011192ea2> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/b54baac8-fcbf-426b-8407-542cdc009fee> ;
+    mu:uuid "570a636d-9d51-493d-b743-cf8011192ea2" ;
+    skos:prefLabel "Algemene vergadering ZorgGroep Lommel" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/57edc726d375bacb4a3041cd5052ac05608141aef009435165d30a924e35660d> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/12b3670c672298b9f906f60433ab945a8c8cd2ef8e4b5f922d1fb284da18cd73> ;
+    mu:uuid "57edc726d375bacb4a3041cd5052ac05608141aef009435165d30a924e35660d" ;
+    skos:prefLabel "Algemene vergadering Zorgbedrijf Rivierenland" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/596d0888a52cee639b5e1f18bc6fb2d8cc626ed68e92d1243fa2eb390a760055> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/6d1c55e517fd1fdcae81e9f07f0875aa9c452bed279e635b94fbe00630e7ae73> ;
+    mu:uuid "596d0888a52cee639b5e1f18bc6fb2d8cc626ed68e92d1243fa2eb390a760055" ;
+    skos:prefLabel "Raad van bestuur Zorgbedrijf Ouderenzorg Genk" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/5b78d6f7-b639-4e5c-9cec-83d986cc6ff4> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/dbb530bd-a765-49e6-8c3e-4fed14d44c4e> ;
+    mu:uuid "5b78d6f7-b639-4e5c-9cec-83d986cc6ff4" ;
+    skos:prefLabel "Raad van bestuur Welzijnsvereniging Sleutelzorg" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/61318f50-4072-4307-a017-f185c75c0cfb> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/10ce9d34-953b-4096-9c09-575426b12acc> ;
+    mu:uuid "61318f50-4072-4307-a017-f185c75c0cfb" ;
+    skos:prefLabel "Raad van bestuur Zorgband Leie en Schelde, OCMW-vereniging van publiekrecht" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/613ba23ce05408d28f6cad6713357424349e3718e6344796b42633e08f75f48b> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/d9196423b3657e5484236c769737573e4574e223eaccde6a7b7207d632a6a669> ;
+    mu:uuid "613ba23ce05408d28f6cad6713357424349e3718e6344796b42633e08f75f48b" ;
+    skos:prefLabel "Raad van bestuur WOONDIENST JOGI" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/618ec332-8afc-48e9-ac9d-f5f6ed5123b2> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/4b114b8e-11c5-4bc8-a3c2-4f5f05d7f430> ;
+    mu:uuid "618ec332-8afc-48e9-ac9d-f5f6ed5123b2" ;
+    skos:prefLabel "Raad van bestuur Zorgbedrijf Vilvoorde" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/61e08c45-8fa9-441e-bf46-fc8e85833809> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/fd9abc2a-e346-4bf4-bbfa-e1bba880e2b9> ;
+    mu:uuid "61e08c45-8fa9-441e-bf46-fc8e85833809" ;
+    skos:prefLabel "Algemene vergadering Algemeen Ziekenhuis Lokeren AV" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/62d0da11-3397-4da1-ade9-d66632292659> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/530dbb2c-a798-4cae-b42e-737b80b83b22> ;
+    mu:uuid "62d0da11-3397-4da1-ade9-d66632292659" ;
+    skos:prefLabel "Leidend Ambtenaar Welzijnsvereniging De Wijngaard" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/6350224c-658b-4b4d-b721-93a34dd1ed52> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/c83586e7-9818-4be5-ab24-5e9dcd9b21fd> ;
+    mu:uuid "6350224c-658b-4b4d-b721-93a34dd1ed52" ;
+    skos:prefLabel "Raad van bestuur Algemeen Ziekenhuis Vesalius" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/636051f8596f9d63cc5e178b7ba39ca118081dc263f7666291819b4081a595e3> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/50ede269-5c49-41cd-be68-ac135314019c> ;
+    mu:uuid "636051f8596f9d63cc5e178b7ba39ca118081dc263f7666291819b4081a595e3" ;
+    skos:prefLabel "Leidend Ambtenaar Algemeen Ziekenhuis Sint-Dimpna" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/6375568c04a71e2515cf46ba581259c6e2f6cc04c5eaad8f5b5cf5caef599b76> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/b7abada470cd56a64d67b5450b35c3e96c07ce5d752d6207d4886ccc8f4852ff> ;
+    mu:uuid "6375568c04a71e2515cf46ba581259c6e2f6cc04c5eaad8f5b5cf5caef599b76" ;
+    skos:prefLabel "Leidend Ambtenaar AZ ST-JAN Brugge-Oostende A.V." ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/643ddebf51ff4f7bcaf741ea6dcbe226412b70ddba67f78c89cce0ac2d04e144> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/5072fad918135764714007cea2f3573462199d6cbe7b96d6ac57d1c9b7bde399> ;
+    mu:uuid "643ddebf51ff4f7bcaf741ea6dcbe226412b70ddba67f78c89cce0ac2d04e144" ;
+    skos:prefLabel "Algemene vergadering Vereniging Dodoens" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/648fd202ae981c3fdba75a72fdbcb8919d39125763edad151e76bf642e7ba6ae> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/c11ca390da51a65c5e328cd219eb91f5a657bba3d0f47cf995039dbfb1c64105> ;
+    mu:uuid "648fd202ae981c3fdba75a72fdbcb8919d39125763edad151e76bf642e7ba6ae" ;
+    skos:prefLabel "Raad van bestuur W13" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/64e400cf592a48864f63f124bba2fd8f89806e996330774cd1441039ef5ad609> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/4f452f5ad74a9cf4c6af447cb07157d8dad793abecff39729d7ab2eb582ec290> ;
+    mu:uuid "64e400cf592a48864f63f124bba2fd8f89806e996330774cd1441039ef5ad609" ;
+    skos:prefLabel "Algemene vergadering vereniging voor Samenwerking rond Preventie in het kader van Opvoeding en Onderwijs Regio Brugge" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/6703ddee-84ac-4ef7-8ba4-e62a729d59e2> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/4141ab8d-b1e1-4b38-832a-76b4dba20dc7> ;
+    mu:uuid "6703ddee-84ac-4ef7-8ba4-e62a729d59e2" ;
+    skos:prefLabel "Raad van bestuur Autonome Verzorgingsinstelling Virga Jesseziekenhuis" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/674256f3-2c6a-46a5-9b1a-782fea05b81f> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/cce1926b-51ff-4b66-a702-ea985f1d250b> ;
+    mu:uuid "674256f3-2c6a-46a5-9b1a-782fea05b81f" ;
+    skos:prefLabel "Raad van bestuur A.S.Z. Autonome Verzorgingsinstelling" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/69a9ba82b60b97393be13ef2d7ffdcca858edea2b95696e9542f93b3e9e3bc2f> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/0d30036b943b9b9c3ef70c7c0e59a2325fbe2c455021ddb07bee427f73efcef8> ;
+    mu:uuid "69a9ba82b60b97393be13ef2d7ffdcca858edea2b95696e9542f93b3e9e3bc2f" ;
+    skos:prefLabel "Leidend Ambtenaar Audio" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/6aaf42b4-2d24-42e2-bd7e-d6b88d993ac5> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/c83586e7-9818-4be5-ab24-5e9dcd9b21fd> ;
+    mu:uuid "6aaf42b4-2d24-42e2-bd7e-d6b88d993ac5" ;
+    skos:prefLabel "Algemene vergadering Algemeen Ziekenhuis Vesalius" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/6d5a831e-76a6-4f2d-9fc2-ad36e0fbf540> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/8a301cf9-6611-450c-aa95-b104803180db> ;
+    mu:uuid "6d5a831e-76a6-4f2d-9fc2-ad36e0fbf540" ;
+    skos:prefLabel "Raad van bestuur Welzijnsvereniging Ter Nethe" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/6df0361e8a93327d387375983a878d58c36b9c9823110d5e460f591c7662f9c8> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/6c4179a4684d97c148da2e78ba99579e4145412c6431e1577713e5f095ff4f08> ;
+    mu:uuid "6df0361e8a93327d387375983a878d58c36b9c9823110d5e460f591c7662f9c8" ;
+    skos:prefLabel "Raad van bestuur Zorggroep Orion" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/6e794d492ad601828a326de6e1a5e7ba547451a0c074ce621fa1cc190c40f387> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/2bf97f7faebd616265d004a80cce0319a110319197b657d5a0a1a16d81f34ca2> ;
+    mu:uuid "6e794d492ad601828a326de6e1a5e7ba547451a0c074ce621fa1cc190c40f387" ;
+    skos:prefLabel "Algemene vergadering WELZIJNSZORG KEMPEN" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/6eeb13e21f713c71411532ee9fb5031f5bc1afa4fd42979e3d074d33a675c936> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/aabc8d18d6b42c555fc9061c1f756bae12c7ab722a4b4d6408e14785d5762500> ;
+    mu:uuid "6eeb13e21f713c71411532ee9fb5031f5bc1afa4fd42979e3d074d33a675c936" ;
+    skos:prefLabel "Algemene vergadering Woon- en Zorgbedrijf Wervik" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/6f3fb0ed-c62d-4847-96a0-e64621c1f8a3> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/e2bf9406-8c70-4dda-bb88-5771480d9155> ;
+    mu:uuid "6f3fb0ed-c62d-4847-96a0-e64621c1f8a3" ;
+    skos:prefLabel "Algemene vergadering Woonzorggroep Voorkempen" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/6f5c354b-d24b-468a-9035-59df478865d3> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/749bbdaf-dd7a-45e1-8f2e-98b8834bc295> ;
+    mu:uuid "6f5c354b-d24b-468a-9035-59df478865d3" ;
+    skos:prefLabel "Leidend Ambtenaar Vereniging Onze-Lieve-Vrouweziekenhuis" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/6fe8cf62e278b33d033213dbc6d6a53f5e2b9f465299eb7a27a9521e4fdf6013> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/94158248e8e9bd9a05012e06db794178caa74731b2dadcf84f5ad7373f13abcc> ;
+    mu:uuid "6fe8cf62e278b33d033213dbc6d6a53f5e2b9f465299eb7a27a9521e4fdf6013" ;
+    skos:prefLabel "Leidend Ambtenaar WOONWINKEL KNOKKE-HEIST" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/70a43a4956468f814f0083e8972933893becc7e6231950e0dad6a6b6a37a7ae1> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/836436cd7bc957ec9eb24865c628c5707b4a1fbbae5cccebfaf1df0983f888be> ;
+    mu:uuid "70a43a4956468f814f0083e8972933893becc7e6231950e0dad6a6b6a37a7ae1" ;
+    skos:prefLabel "Algemene vergadering Zorg Izegem" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/73d9644ad66ec413085fac71f212f17c7bf240b223a1f13913434a92c3e1aad9> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/f3f1598c1a9fb9e3666a3001004e4bfdb028da702bb8755655c0946597bb8ea4> ;
+    mu:uuid "73d9644ad66ec413085fac71f212f17c7bf240b223a1f13913434a92c3e1aad9" ;
+    skos:prefLabel "Raad van bestuur Beschut Wonen - Antwerpen" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/73fdff741c46c1fc492c6f4910c3f8ee9fa49cc155f17a41212b95450a90f44e> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/e10b5c6c27e642c4f6ae8b1aa623b1a696318483629e5edbea343ba20038d94c> ;
+    mu:uuid "73fdff741c46c1fc492c6f4910c3f8ee9fa49cc155f17a41212b95450a90f44e" ;
+    skos:prefLabel "Algemene vergadering SOCIAAL VERHUURKANTOOR KOEPEL BREDENE - OOSTENDE" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/7410611802576726b030f75502f605f19acdfe39bdaac33c8257e498efdee439> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/ffec0b97d60ac685f8e95209fdbdee3ba0171511609d109d4252a34fc5bf4160> ;
+    mu:uuid "7410611802576726b030f75502f605f19acdfe39bdaac33c8257e498efdee439" ;
+    skos:prefLabel "Leidend Ambtenaar OCMW Vereniging SAKURA" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/74d3730b0145031a3becb5edb93d00bfa0a7a3e31393b742eaeeb943da774205> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/c0a096f256810f9d51c21456d5ee5bc9a5a471f78c8c699cc58c60730d5b0dbe> ;
+    mu:uuid "74d3730b0145031a3becb5edb93d00bfa0a7a3e31393b742eaeeb943da774205" ;
+    skos:prefLabel "Raad van bestuur SOCIAAL VERHUURKANTOOR WAASLAND" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/7632250d4f7ffc9b64763016d9698d2f4aaa2c7728929b2d9e9f4d896b0d6c91> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/fd620aa85d002529d17747ee2a7350d97633144386c273a53a2ac742367b2b09> ;
+    mu:uuid "7632250d4f7ffc9b64763016d9698d2f4aaa2c7728929b2d9e9f4d896b0d6c91" ;
+    skos:prefLabel "Raad van bestuur Zorgbedrijf Roeselare" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/773f8b0cd8bb7fb029614d06665b5c12bef064972ffee24a793f59d1d422fff1> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/0d30036b943b9b9c3ef70c7c0e59a2325fbe2c455021ddb07bee427f73efcef8> ;
+    mu:uuid "773f8b0cd8bb7fb029614d06665b5c12bef064972ffee24a793f59d1d422fff1" ;
+    skos:prefLabel "Raad van bestuur Audio" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/77d0d52a412a21902e8d2ad7e71ea313760dc171cd76c9156e31dfed8eb10a0c> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/e2bf9406-8c70-4dda-bb88-5771480d9155> ;
+    mu:uuid "77d0d52a412a21902e8d2ad7e71ea313760dc171cd76c9156e31dfed8eb10a0c" ;
+    skos:prefLabel "Leidend Ambtenaar Woonzorggroep Voorkempen" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/780a69352adf784f9cbd76488a6b9423b70ce2749188cb921ee7487f7ccb4875> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/31db97c9dab7ed09b591d2f3c567d47f70a5fa66c9ce3b4b2aea1e71f1dc8e76> ;
+    mu:uuid "780a69352adf784f9cbd76488a6b9423b70ce2749188cb921ee7487f7ccb4875" ;
+    skos:prefLabel "Leidend Ambtenaar ZORGBEDRIJF KLEIN-BRABANT" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/792e71d7759caceb91d35b0394f37092da0bf561c44a23174e00bca32a29baec> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/5567394c206a8da9fe1e8ab4dc1d043eabdb5915ecf3d06a9495dc64cc3c691e> ;
+    mu:uuid "792e71d7759caceb91d35b0394f37092da0bf561c44a23174e00bca32a29baec" ;
+    skos:prefLabel "Leidend Ambtenaar Vereniging Weldenderend" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/79f76bbe-1d81-4848-9da6-e12a88c5703e> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/c83586e7-9818-4be5-ab24-5e9dcd9b21fd> ;
+    mu:uuid "79f76bbe-1d81-4848-9da6-e12a88c5703e" ;
+    skos:prefLabel "Leidend Ambtenaar Algemeen Ziekenhuis Vesalius" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/79fa14c1435a4017130abe3f8d320d54733fc33ab2d04461cea6bba3e1b72099> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/e23cb5929d99c7633348f71af1bf11ab5b8fa3649e34d4e0967a429ee6437bd1> ;
+    mu:uuid "79fa14c1435a4017130abe3f8d320d54733fc33ab2d04461cea6bba3e1b72099" ;
+    skos:prefLabel "Leidend Ambtenaar Schuldbemiddeling BODUKAP" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/7a44fdc6816811eca00350c495a9b18b4acb2e5623be69b6a4321eabad9125c2> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/94158248e8e9bd9a05012e06db794178caa74731b2dadcf84f5ad7373f13abcc> ;
+    mu:uuid "7a44fdc6816811eca00350c495a9b18b4acb2e5623be69b6a4321eabad9125c2" ;
+    skos:prefLabel "Raad van bestuur WOONWINKEL KNOKKE-HEIST" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/7b00d41053e455f5f9b213ec4f9bd92b803955f076dd290bf15ac5546f2e8349> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/03df783df9b22fa5340f962d439c46048ba62f6b4f43bd2497eca20db7cd8617> ;
+    mu:uuid "7b00d41053e455f5f9b213ec4f9bd92b803955f076dd290bf15ac5546f2e8349" ;
+    skos:prefLabel "Leidend Ambtenaar Ons Huis" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/7b791aa58fb7b2007cfbbcfeda3a0ec327bff2d2247f3e571cc7a7289906bfeb> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/68cf1a248013d8921af92322a077e2c74988889defdfea0cc0d467eddf3baf1f> ;
+    mu:uuid "7b791aa58fb7b2007cfbbcfeda3a0ec327bff2d2247f3e571cc7a7289906bfeb" ;
+    skos:prefLabel "Raad van bestuur WELZIJNSBAND MEETJESLAND" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/7dd1c24411211763b70fc2830bea815371eb1fa6bf7af875c6cb92ab04f2d79e> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/6d1c55e517fd1fdcae81e9f07f0875aa9c452bed279e635b94fbe00630e7ae73> ;
+    mu:uuid "7dd1c24411211763b70fc2830bea815371eb1fa6bf7af875c6cb92ab04f2d79e" ;
+    skos:prefLabel "Algemene vergadering Zorgbedrijf Ouderenzorg Genk" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/7fa97fa1-40a8-4804-a9be-6d9fad4e0b31> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/8a301cf9-6611-450c-aa95-b104803180db> ;
+    mu:uuid "7fa97fa1-40a8-4804-a9be-6d9fad4e0b31" ;
+    skos:prefLabel "Leidend Ambtenaar Welzijnsvereniging Ter Nethe" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/803f4437-0403-478e-a4c4-c7984bf295bb> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/e452e23b-95cb-4b75-8825-503288ede636> ;
+    mu:uuid "803f4437-0403-478e-a4c4-c7984bf295bb" ;
+    skos:prefLabel "Leidend Ambtenaar De Zilveren Zwaan" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/807ea0d1ac72a2a20550b0b9bfc793ceef74799474c7589c039e3a6bd2c14656> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/5072fad918135764714007cea2f3573462199d6cbe7b96d6ac57d1c9b7bde399> ;
+    mu:uuid "807ea0d1ac72a2a20550b0b9bfc793ceef74799474c7589c039e3a6bd2c14656" ;
+    skos:prefLabel "Raad van bestuur Vereniging Dodoens" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/81bf654e-29fe-49e0-970f-ea52b85ace46> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/fd9abc2a-e346-4bf4-bbfa-e1bba880e2b9> ;
+    mu:uuid "81bf654e-29fe-49e0-970f-ea52b85ace46" ;
+    skos:prefLabel "Leidend Ambtenaar Algemeen Ziekenhuis Lokeren AV" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/829383d9-661b-49a4-a6cd-46463f1ccf57> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/7eff2130-5462-4569-8098-29ceec9e6a22> ;
+    mu:uuid "829383d9-661b-49a4-a6cd-46463f1ccf57" ;
+    skos:prefLabel "Algemene vergadering ALGEMEEN STEDELIJK ZIEKENHUIS AUTONOME VERZORGINGSINSTELLING" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/8339649e38b6e128b066467d49240f756d485dc1baa775f71ddd711db2257f9a> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/fd620aa85d002529d17747ee2a7350d97633144386c273a53a2ac742367b2b09> ;
+    mu:uuid "8339649e38b6e128b066467d49240f756d485dc1baa775f71ddd711db2257f9a" ;
+    skos:prefLabel "Leidend Ambtenaar Zorgbedrijf Roeselare" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/84b70c75e283bd8535a6e8d88906c0362dc32ad6b358ea17fd164f145c5a9c0d> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/c11ca390da51a65c5e328cd219eb91f5a657bba3d0f47cf995039dbfb1c64105> ;
+    mu:uuid "84b70c75e283bd8535a6e8d88906c0362dc32ad6b358ea17fd164f145c5a9c0d" ;
+    skos:prefLabel "Algemene vergadering W13" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/84e6099d997a811caa2cc3b40eda678911470e03150469c935bee4769b390e16> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/005f263d440315a440c47a34fddec33b7745836d64fe0b033fc82957285e838b> ;
+    mu:uuid "84e6099d997a811caa2cc3b40eda678911470e03150469c935bee4769b390e16" ;
+    skos:prefLabel "Algemene vergadering Zorgvereniging Brugge" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/85dde6c2ac4eaa9ec6c3c563b29f6738867ed30f057067059c5cd91182efbff4> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/0331f7d9259900c12c7cd16e081dca917d6b3ceda358cf69f12a1cdbb734b9ac> ;
+    mu:uuid "85dde6c2ac4eaa9ec6c3c563b29f6738867ed30f057067059c5cd91182efbff4" ;
+    skos:prefLabel "Leidend Ambtenaar Woonzorgcentrum van Lierde" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/877ae60709f2b3771e0d2fbd9cb6b2a5865d117eabced9994a133ad73eb0b8c7> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/8cfb6e37e4259b79bffd9027e38e2a10397edf45084122f3939dd19ff378fe9c> ;
+    mu:uuid "877ae60709f2b3771e0d2fbd9cb6b2a5865d117eabced9994a133ad73eb0b8c7" ;
+    skos:prefLabel "Algemene vergadering Zorgbedrijf Brasschaat" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/89660a0ffd877a5734e323e655d1e468579dd3b481f72858d611fed8b2c4ac5f> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/f490a5f5-5f21-4c01-b70e-80d76ad8c256> ;
+    mu:uuid "89660a0ffd877a5734e323e655d1e468579dd3b481f72858d611fed8b2c4ac5f" ;
+    skos:prefLabel "Leidend Ambtenaar Zorg Stekene" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/8a6777e8b2f374a392f4b86efe4033a178b234b27cf2bb588d7c3a18bd98c13d> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/53fefc09ccb63625eda802c01cf32df7fe8a14a14f020a89a08e68dc49d43e31> ;
+    mu:uuid "8a6777e8b2f374a392f4b86efe4033a178b234b27cf2bb588d7c3a18bd98c13d" ;
+    skos:prefLabel "Raad van bestuur SOCiAL" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/8afcf3f6e86469c558e48393c903540c2a58b1cac6886b2a14c7f758e458452f> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/03df783df9b22fa5340f962d439c46048ba62f6b4f43bd2497eca20db7cd8617> ;
+    mu:uuid "8afcf3f6e86469c558e48393c903540c2a58b1cac6886b2a14c7f758e458452f" ;
+    skos:prefLabel "Algemene vergadering Ons Huis" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/8b27e419fd0633e7a61e831ead346fd24dc286c4b507a0e4d9df970643f96e81> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/0d30036b943b9b9c3ef70c7c0e59a2325fbe2c455021ddb07bee427f73efcef8> ;
+    mu:uuid "8b27e419fd0633e7a61e831ead346fd24dc286c4b507a0e4d9df970643f96e81" ;
+    skos:prefLabel "Algemene vergadering Audio" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/8d2c1131-4a60-4128-b118-e01875732deb> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/531f08c0-65ac-4f47-ac15-066097ac5756> ;
+    mu:uuid "8d2c1131-4a60-4128-b118-e01875732deb" ;
+    skos:prefLabel "Algemene vergadering Zorgbedrijf Tielt" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/8e7000123fccaa964c28466031d69fd19d74e602ae953a764d47e0d0dba447f8> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/eb31eb0b167e34e43a47ba63cc7bfbbf8e13ce818ede2e7af7bd513b857c8751> ;
+    mu:uuid "8e7000123fccaa964c28466031d69fd19d74e602ae953a764d47e0d0dba447f8" ;
+    skos:prefLabel "Algemene vergadering RVT/RUSTHUIS NAJAARSZON" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/9136a1cf2a1a4cbe3256fdbd810f9ebd33fb7cc29f73334ccc84356e75dc37d5> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/0331f7d9259900c12c7cd16e081dca917d6b3ceda358cf69f12a1cdbb734b9ac> ;
+    mu:uuid "9136a1cf2a1a4cbe3256fdbd810f9ebd33fb7cc29f73334ccc84356e75dc37d5" ;
+    skos:prefLabel "Raad van bestuur Woonzorgcentrum van Lierde" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/91ce61e4-2327-47fa-b66b-da55ba52c7b9> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/f490a5f5-5f21-4c01-b70e-80d76ad8c256> ;
+    mu:uuid "91ce61e4-2327-47fa-b66b-da55ba52c7b9" ;
+    skos:prefLabel "Raad van bestuur Zorg Stekene" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/924e96efdc2b53c68ab93aa3b5059b3e7f6fbba48c196b5efb5b3ee1cf381fbc> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/e2dfbd3a56dd87414968d7454dcfde193145e331ddcfc86fb48a9c79b5c0cef3> ;
+    mu:uuid "924e96efdc2b53c68ab93aa3b5059b3e7f6fbba48c196b5efb5b3ee1cf381fbc" ;
+    skos:prefLabel "Algemene vergadering VERENIGING WOK" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/92c89c763ab59f59dce9c03c95a9531dc3c92647d6c3f540ce005262f7cb4832> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/6af38a22fcba9d1701a77d9c869e0f06e11a3291a71a4118a7cd93629ba92c27> ;
+    mu:uuid "92c89c763ab59f59dce9c03c95a9531dc3c92647d6c3f540ce005262f7cb4832" ;
+    skos:prefLabel "Algemene vergadering Ruddersstove" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/946d80ef274c352312bc9c06d7804858d3a2b92889cb0415325f79da2835e8d3> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/b7abada470cd56a64d67b5450b35c3e96c07ce5d752d6207d4886ccc8f4852ff> ;
+    mu:uuid "946d80ef274c352312bc9c06d7804858d3a2b92889cb0415325f79da2835e8d3" ;
+    skos:prefLabel "Algemene vergadering AZ ST-JAN Brugge-Oostende A.V." ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/9496c8f9a09b2d0e322bfffca794a8f0bdb0e216ba48251e1706bf07e55f624d> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/e10b5c6c27e642c4f6ae8b1aa623b1a696318483629e5edbea343ba20038d94c> ;
+    mu:uuid "9496c8f9a09b2d0e322bfffca794a8f0bdb0e216ba48251e1706bf07e55f624d" ;
+    skos:prefLabel "Raad van bestuur SOCIAAL VERHUURKANTOOR KOEPEL BREDENE - OOSTENDE" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/9820b1f83716266850f3dc2bfee2bda5a4a8a66a665d9b047b70b4b1094de830> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/251143c6-2094-4ad5-8b54-26cfded0082a> ;
+    mu:uuid "9820b1f83716266850f3dc2bfee2bda5a4a8a66a665d9b047b70b4b1094de830" ;
+    skos:prefLabel "Algemene vergadering Autonome Verzorginstelling Henri Serruysziekenhuis" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/9856b50a423a3de6285b0022ebdf1dcd6d28e682352ab5c6a0709ae7516f5ce7> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/7152ffbc9f34208fdba63318b1d7e87980937c71cc36dfc24d5303567436f4b8> ;
+    mu:uuid "9856b50a423a3de6285b0022ebdf1dcd6d28e682352ab5c6a0709ae7516f5ce7" ;
+    skos:prefLabel "Raad van bestuur Woonzorgnetwerk Edegem" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/98788c03536f7d48a0d50f14fd139c7cf18122f080ca84e12d6640b4dbfc60b1> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/03df783df9b22fa5340f962d439c46048ba62f6b4f43bd2497eca20db7cd8617> ;
+    mu:uuid "98788c03536f7d48a0d50f14fd139c7cf18122f080ca84e12d6640b4dbfc60b1" ;
+    skos:prefLabel "Raad van bestuur Ons Huis" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/9a3bd925cf9d00463e74ec37dd490522eabbeb746edebd39c7d5f4126d61b7fe> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/d9196423b3657e5484236c769737573e4574e223eaccde6a7b7207d632a6a669> ;
+    mu:uuid "9a3bd925cf9d00463e74ec37dd490522eabbeb746edebd39c7d5f4126d61b7fe" ;
+    skos:prefLabel "Algemene vergadering WOONDIENST JOGI" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/9b8f05c639875623922b15c3d94585e89f9f6ac6a0b7ff0490f2784472862a55> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/079159c373e29e05221c4338a2440e4f58ddababa1d8f94dedf792b5414baf61> ;
+    mu:uuid "9b8f05c639875623922b15c3d94585e89f9f6ac6a0b7ff0490f2784472862a55" ;
+    skos:prefLabel "Raad van bestuur DE BLAUWE LELIE" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/9c3b0c6b-d5bf-4559-aa1a-4803995a04c2> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/530dbb2c-a798-4cae-b42e-737b80b83b22> ;
+    mu:uuid "9c3b0c6b-d5bf-4559-aa1a-4803995a04c2" ;
+    skos:prefLabel "Algemene vergadering Welzijnsvereniging De Wijngaard" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/9c70d2fc-64be-4916-ba20-df9f9d27562c> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/531f08c0-65ac-4f47-ac15-066097ac5756> ;
+    mu:uuid "9c70d2fc-64be-4916-ba20-df9f9d27562c" ;
+    skos:prefLabel "Raad van bestuur Zorgbedrijf Tielt" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/a03ac5b07e5f63a3a2bf49c90d24ee856d678bea5a5986fb3a9cc6706c54d6f5> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/d9196423b3657e5484236c769737573e4574e223eaccde6a7b7207d632a6a669> ;
+    mu:uuid "a03ac5b07e5f63a3a2bf49c90d24ee856d678bea5a5986fb3a9cc6706c54d6f5" ;
+    skos:prefLabel "Leidend Ambtenaar WOONDIENST JOGI" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/a0a342bbddd41483a282d13247e328767b871c3396a8bc1851ef5efcc50797f0> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/e9612bfd21b5b805074e751d03224dae38f8c4c91a89fd34f1f4007c3978ba91> ;
+    mu:uuid "a0a342bbddd41483a282d13247e328767b871c3396a8bc1851ef5efcc50797f0" ;
+    skos:prefLabel "Algemene vergadering Zorgbedrijf Harelbeke" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/a2050f795a675ddf354f6518b06e1eb6df9bdd54cf8270eec97d10db2e0b1b95> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/4f452f5ad74a9cf4c6af447cb07157d8dad793abecff39729d7ab2eb582ec290> ;
+    mu:uuid "a2050f795a675ddf354f6518b06e1eb6df9bdd54cf8270eec97d10db2e0b1b95" ;
+    skos:prefLabel "Leidend Ambtenaar vereniging voor Samenwerking rond Preventie in het kader van Opvoeding en Onderwijs Regio Brugge" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/a256f728-2b94-43d5-b12a-2054afaa235a> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/7eff2130-5462-4569-8098-29ceec9e6a22> ;
+    mu:uuid "a256f728-2b94-43d5-b12a-2054afaa235a" ;
+    skos:prefLabel "Leidend Ambtenaar ALGEMEEN STEDELIJK ZIEKENHUIS AUTONOME VERZORGINGSINSTELLING" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/a2f523f134b282572a0f104ca3540f566d0a609bbd096758d2f28be76392eda5> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/927c0e00-65db-4003-b3ef-715428141de8> ;
+    mu:uuid "a2f523f134b282572a0f104ca3540f566d0a609bbd096758d2f28be76392eda5" ;
+    skos:prefLabel "Leidend Ambtenaar SOCIAAL VERHUURKANTOOR MELLE - DESTELBERGEN" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/a3b3e2d4-fe97-4770-9e35-b9751b41b7bb> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/1bbd0f7a-664c-46bd-8ca0-891801b81962> ;
+    mu:uuid "a3b3e2d4-fe97-4770-9e35-b9751b41b7bb" ;
+    skos:prefLabel "Raad van bestuur Zorgbedrijf Sint-Truiden" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/a441e3f68206297197481c65ccb44991569cc05a46c4819c763bb35968847450> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/31db97c9dab7ed09b591d2f3c567d47f70a5fa66c9ce3b4b2aea1e71f1dc8e76> ;
+    mu:uuid "a441e3f68206297197481c65ccb44991569cc05a46c4819c763bb35968847450" ;
+    skos:prefLabel "Raad van bestuur ZORGBEDRIJF KLEIN-BRABANT" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/a586e06f-8d27-44ba-9e26-5607919ae297> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/8a301cf9-6611-450c-aa95-b104803180db> ;
+    mu:uuid "a586e06f-8d27-44ba-9e26-5607919ae297" ;
+    skos:prefLabel "Algemene vergadering Welzijnsvereniging Ter Nethe" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/a590f8e672aee0afee3d18a4f7c0c33590e27fa4002c97e56271ed430752e2ca> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/21a70e74dbb297ec42d5cc72ab810178b298d12fc8f679c742d2501f7ce5b6a3> ;
+    mu:uuid "a590f8e672aee0afee3d18a4f7c0c33590e27fa4002c97e56271ed430752e2ca" ;
+    skos:prefLabel "Leidend Ambtenaar Zorgbedrijf Leuven" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/a655b43877df07f5ea5cc12f9bba03a8215d6adc036ce440a38ba2e3b5433e0e> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/fd620aa85d002529d17747ee2a7350d97633144386c273a53a2ac742367b2b09> ;
+    mu:uuid "a655b43877df07f5ea5cc12f9bba03a8215d6adc036ce440a38ba2e3b5433e0e" ;
+    skos:prefLabel "Algemene vergadering Zorgbedrijf Roeselare" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/a66338dc-1c1f-4921-be1c-f826bd04abca> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/fd9abc2a-e346-4bf4-bbfa-e1bba880e2b9> ;
+    mu:uuid "a66338dc-1c1f-4921-be1c-f826bd04abca" ;
+    skos:prefLabel "Raad van bestuur Algemeen Ziekenhuis Lokeren AV" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/a8b6543b-de72-48cd-8b1e-ff035783f818> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/386f7c72-1c2b-49ea-b9fa-664abf86d15f> ;
+    mu:uuid "a8b6543b-de72-48cd-8b1e-ff035783f818" ;
+    skos:prefLabel "Algemene vergadering Ziekenhuis Oost-Limburg, autonome verzorgingsinstelling" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/a9631c9ff6da22fa0a2379c0e17d64311035bbd785ae57099e6421ec73652469> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/77a07ee1348f6ef3b81ab685368d02c33812d92364e667f68fcdd073b050d949> ;
+    mu:uuid "a9631c9ff6da22fa0a2379c0e17d64311035bbd785ae57099e6421ec73652469" ;
+    skos:prefLabel "Raad van bestuur WELZIJNKOEPEL KLEIN-BRABANT-VAARTLAND" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/aa28bbec2240ce8908cf40cd7e00274a0cc0ee5d6397171da8bf9bb18445bead> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/7152ffbc9f34208fdba63318b1d7e87980937c71cc36dfc24d5303567436f4b8> ;
+    mu:uuid "aa28bbec2240ce8908cf40cd7e00274a0cc0ee5d6397171da8bf9bb18445bead" ;
+    skos:prefLabel "Leidend Ambtenaar Woonzorgnetwerk Edegem" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/aadad537-a93c-4ed7-bd85-f5c9c8a36a7c> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/50ede269-5c49-41cd-be68-ac135314019c> ;
+    mu:uuid "aadad537-a93c-4ed7-bd85-f5c9c8a36a7c" ;
+    skos:prefLabel "Algemene vergadering Algemeen Ziekenhuis Sint-Dimpna" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/ab9efef7-7f98-4204-9a54-d6b4378769c9> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/b54baac8-fcbf-426b-8407-542cdc009fee> ;
+    mu:uuid "ab9efef7-7f98-4204-9a54-d6b4378769c9" ;
+    skos:prefLabel "Leidend Ambtenaar ZorgGroep Lommel" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/ad92ee5019bfccf17ea44ea27f6b253c0d241079d56af5999f12eb2405d80596> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/8cfb6e37e4259b79bffd9027e38e2a10397edf45084122f3939dd19ff378fe9c> ;
+    mu:uuid "ad92ee5019bfccf17ea44ea27f6b253c0d241079d56af5999f12eb2405d80596" ;
+    skos:prefLabel "Leidend Ambtenaar Zorgbedrijf Brasschaat" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/ade075793dadf91c3ba68d847b278fc95c9eefd4193c3c63ca1c4362a36d3e04> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/079159c373e29e05221c4338a2440e4f58ddababa1d8f94dedf792b5414baf61> ;
+    mu:uuid "ade075793dadf91c3ba68d847b278fc95c9eefd4193c3c63ca1c4362a36d3e04" ;
+    skos:prefLabel "Leidend Ambtenaar DE BLAUWE LELIE" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/b032c7f6d879a41d4dd4466bb95bcb1ab0364180ba95256d94e1c396a8dcd58c> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/005f263d440315a440c47a34fddec33b7745836d64fe0b033fc82957285e838b> ;
+    mu:uuid "b032c7f6d879a41d4dd4466bb95bcb1ab0364180ba95256d94e1c396a8dcd58c" ;
+    skos:prefLabel "Leidend Ambtenaar Zorgvereniging Brugge" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/b76bf1b8-5b8a-4f63-90f7-d0044a7cee63> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/b54baac8-fcbf-426b-8407-542cdc009fee> ;
+    mu:uuid "b76bf1b8-5b8a-4f63-90f7-d0044a7cee63" ;
+    skos:prefLabel "Raad van bestuur ZorgGroep Lommel" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/b799fb0f-7b05-4528-8b63-29c6e95f252f> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/cce1926b-51ff-4b66-a702-ea985f1d250b> ;
+    mu:uuid "b799fb0f-7b05-4528-8b63-29c6e95f252f" ;
+    skos:prefLabel "Algemene vergadering A.S.Z. Autonome Verzorgingsinstelling" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/b8daa4ae-0f5e-4737-8d9c-626572f738c1> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/cce1926b-51ff-4b66-a702-ea985f1d250b> ;
+    mu:uuid "b8daa4ae-0f5e-4737-8d9c-626572f738c1" ;
+    skos:prefLabel "Leidend Ambtenaar A.S.Z. Autonome Verzorgingsinstelling" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/be26ea1157c81770ff3146425e628b4b52fa1a85635a78c792a50ebbca904c4c> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/a79dd82a5e400056b3f233fc646850f57918b6173036efa1c3597971cdc6649f> ;
+    mu:uuid "be26ea1157c81770ff3146425e628b4b52fa1a85635a78c792a50ebbca904c4c" ;
+    skos:prefLabel "Leidend Ambtenaar Dienst voor schuldbemiddeling Waasland" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/bea9c94f-8498-40e7-92c8-d13d64b46187> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/10ce9d34-953b-4096-9c09-575426b12acc> ;
+    mu:uuid "bea9c94f-8498-40e7-92c8-d13d64b46187" ;
+    skos:prefLabel "Leidend Ambtenaar Zorgband Leie en Schelde, OCMW-vereniging van publiekrecht" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/c0e30b4c65187cbf13759d5d70762f74e1c3616266b8324754dea83a06952c8b> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/9f839b41d7dba917e53c483d35e693b2cefdb89a13a080faa762845af6a9a337> ;
+    mu:uuid "c0e30b4c65187cbf13759d5d70762f74e1c3616266b8324754dea83a06952c8b" ;
+    skos:prefLabel "Raad van bestuur \"Het Eepos (Wonen voor volwassen personen met een handicap)\"" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/c5d52fb494cf6d7c041a1fbe4a067025c4449c775f5a10822beb0e68e30fa878> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/6cdf24341364ad76bcff1bc07f1ec33591bd8ae0f6814a3694f8a00b61d2fc67> ;
+    mu:uuid "c5d52fb494cf6d7c041a1fbe4a067025c4449c775f5a10822beb0e68e30fa878" ;
+    skos:prefLabel "Leidend Ambtenaar WELZIJNSREGIO NOORD-LIMBURG" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/c62681b6146ed58ae7e1def596f185f8ff1b6b7fe740bfeaa1ade50417ffe062> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/1bbd0f7a-664c-46bd-8ca0-891801b81962> ;
+    mu:uuid "c62681b6146ed58ae7e1def596f185f8ff1b6b7fe740bfeaa1ade50417ffe062" ;
+    skos:prefLabel "Leidend Ambtenaar Zorgbedrijf Sint-Truiden" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/c69958e3108028cfc38113f1781223ef1b2031a961d096a6a1b61021972e3b4e> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/c4486571e2cf6a0656e29a47a3f210cf9bf732876320953c5759aef27b639842> ;
+    mu:uuid "c69958e3108028cfc38113f1781223ef1b2031a961d096a6a1b61021972e3b4e" ;
+    skos:prefLabel "Raad van bestuur VERENIGING ONS TEHUIS VOOR ZUID-WEST-VLAANDEREN" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/c6e61059733f91fc0ca48fcfc9406ac9742316ab488820eb8797c8ddc2971a8b> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/67d72f2e178c4adbd0567865d611248403aecae0e505fbb30d3c932a634c0d2a> ;
+    mu:uuid "c6e61059733f91fc0ca48fcfc9406ac9742316ab488820eb8797c8ddc2971a8b" ;
+    skos:prefLabel "Algemene vergadering SOCIAAL VERHUURKANTOOR LEIE EN SCHELDE" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/c7755ff82a4c1e151c3824dbc68d4487f2660a1c610f48d1af07a5fcb8f3d34a> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/6cdf24341364ad76bcff1bc07f1ec33591bd8ae0f6814a3694f8a00b61d2fc67> ;
+    mu:uuid "c7755ff82a4c1e151c3824dbc68d4487f2660a1c610f48d1af07a5fcb8f3d34a" ;
+    skos:prefLabel "Raad van bestuur WELZIJNSREGIO NOORD-LIMBURG" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/c8135b99bd90d4615bbe38cc64e417f9115c16c277485ce60f17907cb9217aa6> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/507182a9d6532733ac375988f8288bd1f5fdc2cfb1bee374bb6f5046bf307d4d> ;
+    mu:uuid "c8135b99bd90d4615bbe38cc64e417f9115c16c277485ce60f17907cb9217aa6" ;
+    skos:prefLabel "Raad van bestuur Welzijnskoepel West-Brabant" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/c8d142cb32d8fe86159599fd466f55885d47622ca1751390666d1c683276a299> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/ffec0b97d60ac685f8e95209fdbdee3ba0171511609d109d4252a34fc5bf4160> ;
+    mu:uuid "c8d142cb32d8fe86159599fd466f55885d47622ca1751390666d1c683276a299" ;
+    skos:prefLabel "Raad van bestuur OCMW Vereniging SAKURA" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/c9e4d4e183357a147e9cb9074229253fb220e621defe4ec343d7e030b29fc3fd> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/c4486571e2cf6a0656e29a47a3f210cf9bf732876320953c5759aef27b639842> ;
+    mu:uuid "c9e4d4e183357a147e9cb9074229253fb220e621defe4ec343d7e030b29fc3fd" ;
+    skos:prefLabel "Algemene vergadering VERENIGING ONS TEHUIS VOOR ZUID-WEST-VLAANDEREN" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/cab8ee54-2a46-42d6-b2fa-e4bb3e02cc1d> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/e452e23b-95cb-4b75-8825-503288ede636> ;
+    mu:uuid "cab8ee54-2a46-42d6-b2fa-e4bb3e02cc1d" ;
+    skos:prefLabel "Algemene vergadering De Zilveren Zwaan" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/cb60828256d9434561fa6e455db1ae258de108f18e961ed53ff257be7d933e71> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/005f263d440315a440c47a34fddec33b7745836d64fe0b033fc82957285e838b> ;
+    mu:uuid "cb60828256d9434561fa6e455db1ae258de108f18e961ed53ff257be7d933e71" ;
+    skos:prefLabel "Raad van bestuur Zorgvereniging Brugge" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/cc0ed237-e3e8-411e-9580-0a9c265bc916> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/27e7a364-fe11-4303-9a43-fc2e1a3510d7> ;
+    mu:uuid "cc0ed237-e3e8-411e-9580-0a9c265bc916" ;
+    skos:prefLabel "Algemene vergadering Welzijnsvereniging Sint-Gillis-Waas" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/cc611cfe86fb7ff78d39aa5fead65d2ca52ce05bca63d78ad5e05394e622afe0> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/68cf1a248013d8921af92322a077e2c74988889defdfea0cc0d467eddf3baf1f> ;
+    mu:uuid "cc611cfe86fb7ff78d39aa5fead65d2ca52ce05bca63d78ad5e05394e622afe0" ;
+    skos:prefLabel "Leidend Ambtenaar WELZIJNSBAND MEETJESLAND" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/ccb3024222f5c6cb755eb10995caab663e0092cccdbe75f278181ef2b4c71431> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/c0a096f256810f9d51c21456d5ee5bc9a5a471f78c8c699cc58c60730d5b0dbe> ;
+    mu:uuid "ccb3024222f5c6cb755eb10995caab663e0092cccdbe75f278181ef2b4c71431" ;
+    skos:prefLabel "Algemene vergadering SOCIAAL VERHUURKANTOOR WAASLAND" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/cd8a7b518bccccaadbde24a3174484a8180634d33a87b0ef68a7f4876d80b962> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/265f6bcddea9c9e994472376c40bd5591df678ab9fdba41d5d65933467d83f59> ;
+    mu:uuid "cd8a7b518bccccaadbde24a3174484a8180634d33a87b0ef68a7f4876d80b962" ;
+    skos:prefLabel "Algemene vergadering Vereniging De Schakelaar" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/cecca36a16593dd8eca3f4ee15ccb0f7cb5721002bdf2e8ff6b080839efe5611> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/f7ec3b8b3f74b7656c1769b7b1ec7641e12fe8fcf64564ce0a204e30df498907> ;
+    mu:uuid "cecca36a16593dd8eca3f4ee15ccb0f7cb5721002bdf2e8ff6b080839efe5611" ;
+    skos:prefLabel "Raad van bestuur Zorgbedrijf Meetjesland" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/d2645d0b57a154063c200973c0b5f42d73d5b46469770f2d6f5ddf8082a0c9ac> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/2bf97f7faebd616265d004a80cce0319a110319197b657d5a0a1a16d81f34ca2> ;
+    mu:uuid "d2645d0b57a154063c200973c0b5f42d73d5b46469770f2d6f5ddf8082a0c9ac" ;
+    skos:prefLabel "Raad van bestuur WELZIJNSZORG KEMPEN" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/d2868361888efbb6f9652c1d2c9c2a65633f15614fec640ced6e26f947508911> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/21a70e74dbb297ec42d5cc72ab810178b298d12fc8f679c742d2501f7ce5b6a3> ;
+    mu:uuid "d2868361888efbb6f9652c1d2c9c2a65633f15614fec640ced6e26f947508911" ;
+    skos:prefLabel "Raad van bestuur Zorgbedrijf Leuven" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/d32f047b36455b50d4b7f812a2668b419be5da47f5cb628e43afc35df036c606> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/67d72f2e178c4adbd0567865d611248403aecae0e505fbb30d3c932a634c0d2a> ;
+    mu:uuid "d32f047b36455b50d4b7f812a2668b419be5da47f5cb628e43afc35df036c606" ;
+    skos:prefLabel "Leidend Ambtenaar SOCIAAL VERHUURKANTOOR LEIE EN SCHELDE" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/d3ba6182840d78f0d80f59dac1344d133ccbb2bd172869b3359a35adf1afdfdc> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/ef67ec9cdeb835268fd4a6f554db25f1bbb081009fa136b597785853076ea937> ;
+    mu:uuid "d3ba6182840d78f0d80f59dac1344d133ccbb2bd172869b3359a35adf1afdfdc" ;
+    skos:prefLabel "Leidend Ambtenaar OPENBARE VERENIGING RONSE" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/d43fced592855aec5cb9bc4d39d15e53773b20b68723d4f5acc1831e23262f93> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/77a07ee1348f6ef3b81ab685368d02c33812d92364e667f68fcdd073b050d949> ;
+    mu:uuid "d43fced592855aec5cb9bc4d39d15e53773b20b68723d4f5acc1831e23262f93" ;
+    skos:prefLabel "Algemene vergadering WELZIJNKOEPEL KLEIN-BRABANT-VAARTLAND" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/d46795a1-b4d9-48ac-89db-e6ae36681995> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/4b114b8e-11c5-4bc8-a3c2-4f5f05d7f430> ;
+    mu:uuid "d46795a1-b4d9-48ac-89db-e6ae36681995" ;
+    skos:prefLabel "Algemene vergadering Zorgbedrijf Vilvoorde" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/d612b65d-0669-40db-b583-680b98df64ce> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/96ceb4cf-ece3-417d-914b-3e6eff293e6a> ;
+    mu:uuid "d612b65d-0669-40db-b583-680b98df64ce" ;
+    skos:prefLabel "Algemene vergadering Auroraziekenhuis Autonome Verzorgingsinstelling" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/d7e58222-dc3b-4989-89c8-ae154726f66d> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/749bbdaf-dd7a-45e1-8f2e-98b8834bc295> ;
+    mu:uuid "d7e58222-dc3b-4989-89c8-ae154726f66d" ;
+    skos:prefLabel "Raad van bestuur Vereniging Onze-Lieve-Vrouweziekenhuis" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/d92baff8a7562cb556b1bc36b1b212cb38032a006222c3416ffe9f0e6cd62e43> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/14cf807351ef2b7b20c8f481573b576f94cff8d7b8722190f137bc52a4d2e8c8> ;
+    mu:uuid "d92baff8a7562cb556b1bc36b1b212cb38032a006222c3416ffe9f0e6cd62e43" ;
+    skos:prefLabel "Leidend Ambtenaar Zorgbedrijf Antwerpen" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/da674342-ea81-4ee1-b2c7-2f01d769328f> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/10ce9d34-953b-4096-9c09-575426b12acc> ;
+    mu:uuid "da674342-ea81-4ee1-b2c7-2f01d769328f" ;
+    skos:prefLabel "Algemene vergadering Zorgband Leie en Schelde, OCMW-vereniging van publiekrecht" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/da698ecb726c4107d4bd43456daf5af052ea010a80be1260093d1d253dd57120> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/12b3670c672298b9f906f60433ab945a8c8cd2ef8e4b5f922d1fb284da18cd73> ;
+    mu:uuid "da698ecb726c4107d4bd43456daf5af052ea010a80be1260093d1d253dd57120" ;
+    skos:prefLabel "Leidend Ambtenaar Zorgbedrijf Rivierenland" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/dbc846999ceb8305f096245b6bcaa982b8794280de72fa75cb6dfbb6f1e777a3> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/53fefc09ccb63625eda802c01cf32df7fe8a14a14f020a89a08e68dc49d43e31> ;
+    mu:uuid "dbc846999ceb8305f096245b6bcaa982b8794280de72fa75cb6dfbb6f1e777a3" ;
+    skos:prefLabel "Algemene vergadering SOCiAL" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/dd89cc72231cb871864097c8229f07bd63e115531b32de5102b8f2cca247d68b> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/6cdf24341364ad76bcff1bc07f1ec33591bd8ae0f6814a3694f8a00b61d2fc67> ;
+    mu:uuid "dd89cc72231cb871864097c8229f07bd63e115531b32de5102b8f2cca247d68b" ;
+    skos:prefLabel "Algemene vergadering WELZIJNSREGIO NOORD-LIMBURG" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/e0e3561ae822d6cb065227206b2cdffa7bbfd8d4011b20ae8346e869aba4dbb7> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/84ccc300d580fb3de6b36fab26524b43da45e7213d205b57b9db715dc24d35f3> ;
+    mu:uuid "e0e3561ae822d6cb065227206b2cdffa7bbfd8d4011b20ae8346e869aba4dbb7" ;
+    skos:prefLabel "Algemene vergadering VERENIGING 'T SAS" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/e150b67e-27ae-4e62-8f7a-ab0bbf72989e> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/96ceb4cf-ece3-417d-914b-3e6eff293e6a> ;
+    mu:uuid "e150b67e-27ae-4e62-8f7a-ab0bbf72989e" ;
+    skos:prefLabel "Raad van bestuur Auroraziekenhuis Autonome Verzorgingsinstelling" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/e16a28b9-cc8a-4e07-9b95-b5e7feefad82> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/4141ab8d-b1e1-4b38-832a-76b4dba20dc7> ;
+    mu:uuid "e16a28b9-cc8a-4e07-9b95-b5e7feefad82" ;
+    skos:prefLabel "Algemene vergadering Autonome Verzorgingsinstelling Virga Jesseziekenhuis" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/e5204e8f3787a606039371ea86bee5c7c77257890ee606475af944c5e0d0556e> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/4b114b8e-11c5-4bc8-a3c2-4f5f05d7f430> ;
+    mu:uuid "e5204e8f3787a606039371ea86bee5c7c77257890ee606475af944c5e0d0556e" ;
+    skos:prefLabel "Leidend Ambtenaar Zorgbedrijf Vilvoorde" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/e8c8f41c182c0e37b305f6d4742571bf4b13d275f0d74ad3b86a85f1bd80628d> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/a79dd82a5e400056b3f233fc646850f57918b6173036efa1c3597971cdc6649f> ;
+    mu:uuid "e8c8f41c182c0e37b305f6d4742571bf4b13d275f0d74ad3b86a85f1bd80628d" ;
+    skos:prefLabel "Algemene vergadering Dienst voor schuldbemiddeling Waasland" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/ea222f4557ab8f46a92ead81cc885bb2b0dd94694affd6e4fbcd01da9863a9ee> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/9f839b41d7dba917e53c483d35e693b2cefdb89a13a080faa762845af6a9a337> ;
+    mu:uuid "ea222f4557ab8f46a92ead81cc885bb2b0dd94694affd6e4fbcd01da9863a9ee" ;
+    skos:prefLabel "Algemene vergadering \"Het Eepos (Wonen voor volwassen personen met een handicap)\"" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/eaa76e59a774804e29ba17404f6829a608d4c551c6685555f68d8881245696a4> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/68cf1a248013d8921af92322a077e2c74988889defdfea0cc0d467eddf3baf1f> ;
+    mu:uuid "eaa76e59a774804e29ba17404f6829a608d4c551c6685555f68d8881245696a4" ;
+    skos:prefLabel "Algemene vergadering WELZIJNSBAND MEETJESLAND" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/eaaff6e72344e426ee4755f13c1f10c1c4cbba57a8f083c83615227b7b40b0f0> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/4f452f5ad74a9cf4c6af447cb07157d8dad793abecff39729d7ab2eb582ec290> ;
+    mu:uuid "eaaff6e72344e426ee4755f13c1f10c1c4cbba57a8f083c83615227b7b40b0f0" ;
+    skos:prefLabel "Raad van bestuur vereniging voor Samenwerking rond Preventie in het kader van Opvoeding en Onderwijs Regio Brugge" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/eb62aae47a313d98530347ed575a4da993da40c28bf22e786cdf84163cdd293c> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/12b3670c672298b9f906f60433ab945a8c8cd2ef8e4b5f922d1fb284da18cd73> ;
+    mu:uuid "eb62aae47a313d98530347ed575a4da993da40c28bf22e786cdf84163cdd293c" ;
+    skos:prefLabel "Raad van bestuur Zorgbedrijf Rivierenland" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/ec026b0f71fc0b92c2b7dab6adbf9f49ddb706029d03ba40ccddb850a748ad65> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/0964427f9f2e113607681e5c25bf744a41bc412a94e1c0acc784a48d79441df6> ;
+    mu:uuid "ec026b0f71fc0b92c2b7dab6adbf9f49ddb706029d03ba40ccddb850a748ad65" ;
+    skos:prefLabel "Algemene vergadering HUISVESTINGSDIENST REGIO IZEGEM" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/ec9ec7c6886fe1bb05e2f95c534435d2f122fe050bf089832511499a2f9ecffd> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/77a07ee1348f6ef3b81ab685368d02c33812d92364e667f68fcdd073b050d949> ;
+    mu:uuid "ec9ec7c6886fe1bb05e2f95c534435d2f122fe050bf089832511499a2f9ecffd" ;
+    skos:prefLabel "Leidend Ambtenaar WELZIJNKOEPEL KLEIN-BRABANT-VAARTLAND" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/ed2f9903bcd8a367679df8cfb6c6a9c09d5e7b26a0d43d9816eebdc48de0c8c5> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/c0a096f256810f9d51c21456d5ee5bc9a5a471f78c8c699cc58c60730d5b0dbe> ;
+    mu:uuid "ed2f9903bcd8a367679df8cfb6c6a9c09d5e7b26a0d43d9816eebdc48de0c8c5" ;
+    skos:prefLabel "Leidend Ambtenaar SOCIAAL VERHUURKANTOOR WAASLAND" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/edd1078b9eb1550d808cf14862d6b344ca4d658cb5ef9126196a547ed141a27a> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/f7ec3b8b3f74b7656c1769b7b1ec7641e12fe8fcf64564ce0a204e30df498907> ;
+    mu:uuid "edd1078b9eb1550d808cf14862d6b344ca4d658cb5ef9126196a547ed141a27a" ;
+    skos:prefLabel "Leidend Ambtenaar Zorgbedrijf Meetjesland" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/ee3c9b4c-8e84-46dc-a50a-55d37f2a360d> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/386f7c72-1c2b-49ea-b9fa-664abf86d15f> ;
+    mu:uuid "ee3c9b4c-8e84-46dc-a50a-55d37f2a360d" ;
+    skos:prefLabel "Leidend Ambtenaar Ziekenhuis Oost-Limburg, autonome verzorgingsinstelling" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/ef8a409d09f0b9191ce88fe47257b5e3942022c0c557f2fc2d90eda35f6e0abc> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/079159c373e29e05221c4338a2440e4f58ddababa1d8f94dedf792b5414baf61> ;
+    mu:uuid "ef8a409d09f0b9191ce88fe47257b5e3942022c0c557f2fc2d90eda35f6e0abc" ;
+    skos:prefLabel "Algemene vergadering DE BLAUWE LELIE" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/f0309f90d5c4c883dc0d75d8d36ebb7064f41c32f096892822fd46b3c4a146dc> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/5567394c206a8da9fe1e8ab4dc1d043eabdb5915ecf3d06a9495dc64cc3c691e> ;
+    mu:uuid "f0309f90d5c4c883dc0d75d8d36ebb7064f41c32f096892822fd46b3c4a146dc" ;
+    skos:prefLabel "Algemene vergadering Vereniging Weldenderend" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/f094bca2-c3a4-4071-b862-63a4fb0b62e7> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/927c0e00-65db-4003-b3ef-715428141de8> ;
+    mu:uuid "f094bca2-c3a4-4071-b862-63a4fb0b62e7" ;
+    skos:prefLabel "Algemene vergadering SOCIAAL VERHUURKANTOOR MELLE - DESTELBERGEN" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/f26dbf88e676afccbaa30724bdd45f847c7cdc444bf0108bbb9596e5f7d64e93> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/6af38a22fcba9d1701a77d9c869e0f06e11a3291a71a4118a7cd93629ba92c27> ;
+    mu:uuid "f26dbf88e676afccbaa30724bdd45f847c7cdc444bf0108bbb9596e5f7d64e93" ;
+    skos:prefLabel "Raad van bestuur Ruddersstove" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/f28663295c7bf6e8b2e5ac0bb5edc48406056bd1d0d32aaad7b06eeffa28d8b3> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/251143c6-2094-4ad5-8b54-26cfded0082a> ;
+    mu:uuid "f28663295c7bf6e8b2e5ac0bb5edc48406056bd1d0d32aaad7b06eeffa28d8b3" ;
+    skos:prefLabel "Leidend Ambtenaar Autonome Verzorginstelling Henri Serruysziekenhuis" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/f4bc22acf63decd53f8e630d56e2cd78bdf7b2987d925e25acd3ce98cc2a36e1> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/14cf807351ef2b7b20c8f481573b576f94cff8d7b8722190f137bc52a4d2e8c8> ;
+    mu:uuid "f4bc22acf63decd53f8e630d56e2cd78bdf7b2987d925e25acd3ce98cc2a36e1" ;
+    skos:prefLabel "Raad van bestuur Zorgbedrijf Antwerpen" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/f5e5c533260f018cf7605c894b788f852f4b82bed068ff2e794c54462c228e32> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/e9612bfd21b5b805074e751d03224dae38f8c4c91a89fd34f1f4007c3978ba91> ;
+    mu:uuid "f5e5c533260f018cf7605c894b788f852f4b82bed068ff2e794c54462c228e32" ;
+    skos:prefLabel "Leidend Ambtenaar Zorgbedrijf Harelbeke" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/f6c535e8-b922-4bb0-8123-88e3f24c4a0c> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/1165717c-1203-41cd-b434-b041cbe66782> ;
+    mu:uuid "f6c535e8-b922-4bb0-8123-88e3f24c4a0c" ;
+    skos:prefLabel "Algemene vergadering ALGEMEEN ZIEKENHUIS WAASLAND" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/f71f0fff-976f-4b7f-a061-4379c8ffb9fc> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/749bbdaf-dd7a-45e1-8f2e-98b8834bc295> ;
+    mu:uuid "f71f0fff-976f-4b7f-a061-4379c8ffb9fc" ;
+    skos:prefLabel "Algemene vergadering Vereniging Onze-Lieve-Vrouweziekenhuis" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/f8424ef32532db4572e866ff1f2644bdd1b738bced68cf70c2c117b7afa5eb8b> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/aabc8d18d6b42c555fc9061c1f756bae12c7ab722a4b4d6408e14785d5762500> ;
+    mu:uuid "f8424ef32532db4572e866ff1f2644bdd1b738bced68cf70c2c117b7afa5eb8b" ;
+    skos:prefLabel "Raad van bestuur Woon- en Zorgbedrijf Wervik" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/f8b0b6ad-b948-43a5-9619-b6e43f063baf> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/927c0e00-65db-4003-b3ef-715428141de8> ;
+    mu:uuid "f8b0b6ad-b948-43a5-9619-b6e43f063baf" ;
+    skos:prefLabel "Raad van bestuur SOCIAAL VERHUURKANTOOR MELLE - DESTELBERGEN" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/f9da4d6795520947940e170b0b09859fc303b4dc349aab34ea1e7c7327afc2b7> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/27e7a364-fe11-4303-9a43-fc2e1a3510d7> ;
+    mu:uuid "f9da4d6795520947940e170b0b09859fc303b4dc349aab34ea1e7c7327afc2b7" ;
+    skos:prefLabel "Leidend Ambtenaar Welzijnsvereniging Sint-Gillis-Waas" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/fa04b5e88acbd8d807ff2f2bf115a392ebfafcd9b5a7f9f9de1771496e9cfdd1> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/e10b5c6c27e642c4f6ae8b1aa623b1a696318483629e5edbea343ba20038d94c> ;
+    mu:uuid "fa04b5e88acbd8d807ff2f2bf115a392ebfafcd9b5a7f9f9de1771496e9cfdd1" ;
+    skos:prefLabel "Leidend Ambtenaar SOCIAAL VERHUURKANTOOR KOEPEL BREDENE - OOSTENDE" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/fb5a9b9130209721b8fd3b8107cf16381e24afffeb3e8f08a51f11ce298bb72b> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/e9612bfd21b5b805074e751d03224dae38f8c4c91a89fd34f1f4007c3978ba91> ;
+    mu:uuid "fb5a9b9130209721b8fd3b8107cf16381e24afffeb3e8f08a51f11ce298bb72b" ;
+    skos:prefLabel "Raad van bestuur Zorgbedrijf Harelbeke" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/fb5e65de611a84055ae286f724e221697037474e99c704ce1bcc30f0399939eb> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/e7ff93ecd6ec0ad906e179e3ccb1cea698e30013e888fa28c725b272beef3b99> ;
+    mu:uuid "fb5e65de611a84055ae286f724e221697037474e99c704ce1bcc30f0399939eb" ;
+    skos:prefLabel "Raad van bestuur SOCIAAL VERHUURKANTOOR BRUGGE (SVK BRUGGE)" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/fb918cf2-6a8f-41f5-a4a8-4a57f979ccfe> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/1165717c-1203-41cd-b434-b041cbe66782> ;
+    mu:uuid "fb918cf2-6a8f-41f5-a4a8-4a57f979ccfe" ;
+    skos:prefLabel "Leidend Ambtenaar ALGEMEEN ZIEKENHUIS WAASLAND" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/fc106c7f74f6bb4c33c725262a1fafba900bcd1dcfcf5ac527d2a8fb3fab23d9> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/67d72f2e178c4adbd0567865d611248403aecae0e505fbb30d3c932a634c0d2a> ;
+    mu:uuid "fc106c7f74f6bb4c33c725262a1fafba900bcd1dcfcf5ac527d2a8fb3fab23d9" ;
+    skos:prefLabel "Raad van bestuur SOCIAAL VERHUURKANTOOR LEIE EN SCHELDE" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/fe36536f-2004-4d53-8246-ce6d14480b2d> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/dbb530bd-a765-49e6-8c3e-4fed14d44c4e> ;
+    mu:uuid "fe36536f-2004-4d53-8246-ce6d14480b2d" ;
+    skos:prefLabel "Algemene vergadering Welzijnsvereniging Sleutelzorg" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/feb648f5f843f462c8a4b0561cc060fe9859fe51c6255c41e38a6e0eab454d2a> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/ef67ec9cdeb835268fd4a6f554db25f1bbb081009fa136b597785853076ea937> ;
+    mu:uuid "feb648f5f843f462c8a4b0561cc060fe9859fe51c6255c41e38a6e0eab454d2a" ;
+    skos:prefLabel "Raad van bestuur OPENBARE VERENIGING RONSE" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/febe05a13c6fe777d66b7183c9b8749a6b7de21c57594387ee0b99c9ab0950bb> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/a9b3046e-331e-4668-b5cc-2da7bb09e354> ;
+    mu:uuid "febe05a13c6fe777d66b7183c9b8749a6b7de21c57594387ee0b99c9ab0950bb" ;
+    skos:prefLabel "Leidend Ambtenaar Regionaal Instituut voor Dringende Hulpverlening Krisisinfo-Netwerk-Antwerpen" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4> .
+
+<http://data.lblod.info/id/bestuursorganen/fefd211ec0a93aae6bc2ef49330e071a8e05a5ad55f2db4bdf3e9e18c0aa921b> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/e7ff93ecd6ec0ad906e179e3ccb1cea698e30013e888fa28c725b272beef3b99> ;
+    mu:uuid "fefd211ec0a93aae6bc2ef49330e071a8e05a5ad55f2db4bdf3e9e18c0aa921b" ;
+    skos:prefLabel "Algemene vergadering SOCIAAL VERHUURKANTOOR BRUGGE (SVK BRUGGE)" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/bestuursorganen/ff713b04-b01b-4568-b066-d717627dc629> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/e452e23b-95cb-4b75-8825-503288ede636> ;
+    mu:uuid "ff713b04-b01b-4568-b066-d717627dc629" ;
+    skos:prefLabel "Raad van bestuur De Zilveren Zwaan" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> .
+
+<http://data.lblod.info/id/bestuursorganen/ffaa492a-f385-49a5-8338-ba0b1790d84f> a besluit:Bestuursorgaan ;
+    besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/47ac33b7-9321-432c-8ba8-1d284f04addf> ;
+    mu:uuid "ffaa492a-f385-49a5-8338-ba0b1790d84f" ;
+    skos:prefLabel "Algemene vergadering Algemeen Ziekenhuis Jan Palfijn Gent" ;
+    org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/0711bcdeb043fc972f8204b96d407744> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "0711bcdeb043fc972f8204b96d407744" ;
+    generiek:lokaleIdentificator "0267404056" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/07d580c59f081f6169366ea0413c3893> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "07d580c59f081f6169366ea0413c3893" ;
+    generiek:lokaleIdentificator "0786960406" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/082dd38eb4240ed57f72fec7dd6d12d4> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "082dd38eb4240ed57f72fec7dd6d12d4" ;
+    generiek:lokaleIdentificator "0684891363" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/09fbd0da3ad86093de6086c15bc5a3c8> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "09fbd0da3ad86093de6086c15bc5a3c8" ;
+    generiek:lokaleIdentificator "0860256673" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/0f58c3dcca2cd7714f97fb31d8f4aca9> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "0f58c3dcca2cd7714f97fb31d8f4aca9" ;
+    generiek:lokaleIdentificator "0267302405" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/0f9a600476a363e909c8634b234873c7> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "0f9a600476a363e909c8634b234873c7" ;
+    generiek:lokaleIdentificator "0683771509" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/1317fdd3f098049e6515c4edd287d86e> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "1317fdd3f098049e6515c4edd287d86e" ;
+    generiek:lokaleIdentificator "0863329296" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/19f115cd46774b14eefc37346b7f3be5> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "19f115cd46774b14eefc37346b7f3be5" ;
+    generiek:lokaleIdentificator "0863329989" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/1ae0fd6d01729f259670566a702dcfee> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "1ae0fd6d01729f259670566a702dcfee" ;
+    generiek:lokaleIdentificator "0780658572" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/1b329af236f0889037d69771f9055551> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "1b329af236f0889037d69771f9055551" ;
+    generiek:lokaleIdentificator "0630835639" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/1b660922750700f8e178746a5e03dfd9> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "1b660922750700f8e178746a5e03dfd9" ;
+    generiek:lokaleIdentificator "0242469910" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/20210d5ae7cc37ff47d04174e96bb432> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "20210d5ae7cc37ff47d04174e96bb432" ;
+    generiek:lokaleIdentificator "0267313291" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/2458dec3a9e64f3bdc758cfc74ea3f60> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "2458dec3a9e64f3bdc758cfc74ea3f60" ;
+    generiek:lokaleIdentificator "0262926616" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/2470541ce9caa4a3531d9ff49ad5cbe9> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "2470541ce9caa4a3531d9ff49ad5cbe9" ;
+    generiek:lokaleIdentificator "0871928743" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/29995d585d449d07ab981a458d4d8a58> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "29995d585d449d07ab981a458d4d8a58" ;
+    generiek:lokaleIdentificator "0262926319" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/29a6c4b857f838c32f6ddd20c21571b3> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "29a6c4b857f838c32f6ddd20c21571b3" ;
+    generiek:lokaleIdentificator "0458878195" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/2d1954c6ca57477886a14d59f42112ab> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "2d1954c6ca57477886a14d59f42112ab" ;
+    generiek:lokaleIdentificator "0696715960" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/2fc3eb461b662e59f1765d6584e2abbc> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "2fc3eb461b662e59f1765d6584e2abbc" ;
+    generiek:lokaleIdentificator "0809699184" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/3495511e394a2c0a38720788c8b2b3c7> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "3495511e394a2c0a38720788c8b2b3c7" ;
+    generiek:lokaleIdentificator "0687742074" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/3a66b0b9172f955e8862e274bfd11eee> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "3a66b0b9172f955e8862e274bfd11eee" ;
+    generiek:lokaleIdentificator "0886198829" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/409d744fc0801aa7db322dc11105948c> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "409d744fc0801aa7db322dc11105948c" ;
+    generiek:lokaleIdentificator "0685516024" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/40f324235706e17e9b358c275fd1850e> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "40f324235706e17e9b358c275fd1850e" ;
+    generiek:lokaleIdentificator "0889412695" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/4f657eb0bc32e92d8c98306a08924fcd> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "4f657eb0bc32e92d8c98306a08924fcd" ;
+    generiek:lokaleIdentificator "0233210764" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/50adadc59b491d50d909f41422c60695> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "50adadc59b491d50d909f41422c60695" ;
+    generiek:lokaleIdentificator "0831970978" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/5382221f85151892494e2940e79f5619> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "5382221f85151892494e2940e79f5619" ;
+    generiek:lokaleIdentificator "0683473579" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/5902e3caa1fc679e2cfbbce3dab7f009> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "5902e3caa1fc679e2cfbbce3dab7f009" ;
+    generiek:lokaleIdentificator "0871009916" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/59859b8b8b2fbc0c8674d6f14ec2c963> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "59859b8b8b2fbc0c8674d6f14ec2c963" ;
+    generiek:lokaleIdentificator "0267314875" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/5d3b0aecdd79a422fadf751af82e9401> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "5d3b0aecdd79a422fadf751af82e9401" ;
+    generiek:lokaleIdentificator "0680439360" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/5df43a5b255dda118a50cd42b95f4fc1> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "5df43a5b255dda118a50cd42b95f4fc1" ;
+    generiek:lokaleIdentificator "0866242662" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/5f817d6d395145f5178c6dc232d80f57> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "5f817d6d395145f5178c6dc232d80f57" ;
+    generiek:lokaleIdentificator "0684493762" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/61ebe3c6a3a26be349f2734339bb99b1> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "61ebe3c6a3a26be349f2734339bb99b1" ;
+    generiek:lokaleIdentificator "0697787118" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/742e6e58314bf60ee02ce6ee46c6c8f8> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "742e6e58314bf60ee02ce6ee46c6c8f8" ;
+    generiek:lokaleIdentificator "0479985593" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/75bddc0e7e073df97b49739d9fc8aec9> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "75bddc0e7e073df97b49739d9fc8aec9" ;
+    generiek:lokaleIdentificator "0871206587" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/7abb0a6db1813e8fe3f5db9c88c685fc> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "7abb0a6db1813e8fe3f5db9c88c685fc" ;
+    generiek:lokaleIdentificator "0781430812" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/7b49aa0f69b3279b9870edae294b669d> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "7b49aa0f69b3279b9870edae294b669d" ;
+    generiek:lokaleIdentificator "0686537789" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/7e738b64675aafdeae9fc5c8bef794a4> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "7e738b64675aafdeae9fc5c8bef794a4" ;
+    generiek:lokaleIdentificator "0262562568" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/81f82c3227284593a36cf9c2777eb3fc> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "81f82c3227284593a36cf9c2777eb3fc" ;
+    generiek:lokaleIdentificator "0466193777" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/8275002a3c1b7aa1c4c8f6334b5ade5b> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "8275002a3c1b7aa1c4c8f6334b5ade5b" ;
+    generiek:lokaleIdentificator "0267393663" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/855f4680361085f8ab4d328524d15927> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "855f4680361085f8ab4d328524d15927" ;
+    generiek:lokaleIdentificator "0643926085" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/8932ae77eb096f1edb5f51c8582549dd> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "8932ae77eb096f1edb5f51c8582549dd" ;
+    generiek:lokaleIdentificator "0711824305" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/9b26e8f7ecacaca3663bab8376422fcb> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "9b26e8f7ecacaca3663bab8376422fcb" ;
+    generiek:lokaleIdentificator "0807042275" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/9dca92f055dcfb8fe69fc6f7031fd6c3> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "9dca92f055dcfb8fe69fc6f7031fd6c3" ;
+    generiek:lokaleIdentificator "0465810133" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/a0b11428ea20005fa979c798f0eb6a4a> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "a0b11428ea20005fa979c798f0eb6a4a" ;
+    generiek:lokaleIdentificator "0874267037" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/a65ffed30db25374b5f097368986b928> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "a65ffed30db25374b5f097368986b928" ;
+    generiek:lokaleIdentificator "0663810590" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/a6e555bc0f87fc5683d6e0c738162a27> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "a6e555bc0f87fc5683d6e0c738162a27" ;
+    generiek:lokaleIdentificator "0736364909" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/aa038c1ae756275f63897e35f2db55e9> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "aa038c1ae756275f63897e35f2db55e9" ;
+    generiek:lokaleIdentificator "0263545337" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/ac7a64739cbf28d1b2d1f1f5dfa40b26> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "ac7a64739cbf28d1b2d1f1f5dfa40b26" ;
+    generiek:lokaleIdentificator "0694597697" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/b1b8918e90ca03163eda95d7d4cdad33> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "b1b8918e90ca03163eda95d7d4cdad33" ;
+    generiek:lokaleIdentificator "0729523736" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/b5c1958b5d07230e725cefad81ce3473> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "b5c1958b5d07230e725cefad81ce3473" ;
+    generiek:lokaleIdentificator "0689553994" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/b6f172f2a085d74024ad781c0899b360> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "b6f172f2a085d74024ad781c0899b360" ;
+    generiek:lokaleIdentificator "0688812935" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/b7be29ca37d1f9049fa947f147e7a27f> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "b7be29ca37d1f9049fa947f147e7a27f" ;
+    generiek:lokaleIdentificator "0886485770" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/b92e90a1e068bf7472329d56b76b008a> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "b92e90a1e068bf7472329d56b76b008a" ;
+    generiek:lokaleIdentificator "0473908049" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/ba1693c9a9f214b692d3f3fdfbefa477> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "ba1693c9a9f214b692d3f3fdfbefa477" ;
+    generiek:lokaleIdentificator "0647949706" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/bc494c3a3ff4fe855a45bf8ef680bd7c> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "bc494c3a3ff4fe855a45bf8ef680bd7c" ;
+    generiek:lokaleIdentificator "0256543917" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/bdf5dc13a0894060adc26707de210b17> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "bdf5dc13a0894060adc26707de210b17" ;
+    generiek:lokaleIdentificator "0865506155" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/bfcc0356786a920d54ec65a2c6c5c917> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "bfcc0356786a920d54ec65a2c6c5c917" ;
+    generiek:lokaleIdentificator "0665553622" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/bfebcd8ea17e327c231cba0b83a3f11c> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "bfebcd8ea17e327c231cba0b83a3f11c" ;
+    generiek:lokaleIdentificator "0698817989" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/c22ac54797195c8d265cb822cfdb2c90> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "c22ac54797195c8d265cb822cfdb2c90" ;
+    generiek:lokaleIdentificator "0844179716" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/c474da69204109f7c904f998192e4dd5> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "c474da69204109f7c904f998192e4dd5" ;
+    generiek:lokaleIdentificator "0878405769" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/c59415a8e5453ebe212f3b4f29b65af3> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "c59415a8e5453ebe212f3b4f29b65af3" ;
+    generiek:lokaleIdentificator "0836906793" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/c87cc741911c91de42c548acfd95067c> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "c87cc741911c91de42c548acfd95067c" ;
+    generiek:lokaleIdentificator "0445508132" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/cb50ef50dd4d25ecba36f2c8ef76bcc7> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "cb50ef50dd4d25ecba36f2c8ef76bcc7" ;
+    generiek:lokaleIdentificator "0664681216" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/cc99a61437da01d4869308b96fb9dfd3> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "cc99a61437da01d4869308b96fb9dfd3" ;
+    generiek:lokaleIdentificator "0480589567" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/cedb4e5ee57f8f36ff3ee3e828aab673> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "cedb4e5ee57f8f36ff3ee3e828aab673" ;
+    generiek:lokaleIdentificator "0873440458" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/d0dcbb4a0eb152baa5dfc8badd21ddc0> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "d0dcbb4a0eb152baa5dfc8badd21ddc0" ;
+    generiek:lokaleIdentificator "0885714720" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/d1eb1692e141fb4196d8ff981ed1e5c3> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "d1eb1692e141fb4196d8ff981ed1e5c3" ;
+    generiek:lokaleIdentificator "0689674948" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/d566bbec679d415899d221039c094cd9> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "d566bbec679d415899d221039c094cd9" ;
+    generiek:lokaleIdentificator "0537951706" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/d7de4b7754a4efc86aa2df1696fb31c5> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "d7de4b7754a4efc86aa2df1696fb31c5" ;
+    generiek:lokaleIdentificator "0666615870" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/d9ce93b490c04bebbbb8b5e3b546f08b> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "d9ce93b490c04bebbbb8b5e3b546f08b" ;
+    generiek:lokaleIdentificator "0684613726" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/dd59bd033334ca1229695239bd236fe5> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "dd59bd033334ca1229695239bd236fe5" ;
+    generiek:lokaleIdentificator "0827396340" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/e3c1b1c4e02463b872484a9a46078497> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "e3c1b1c4e02463b872484a9a46078497" ;
+    generiek:lokaleIdentificator "0894999895" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/e3d7c5d6cd563b26aef3fea69daf8bf0> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "e3d7c5d6cd563b26aef3fea69daf8bf0" ;
+    generiek:lokaleIdentificator "0682844465" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/ea64bf7d8ff8ef115c727270ada8a0cc> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "ea64bf7d8ff8ef115c727270ada8a0cc" ;
+    generiek:lokaleIdentificator "0862943474" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/ee2482e1674479cd72f6d27e73573c4b> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "ee2482e1674479cd72f6d27e73573c4b" ;
+    generiek:lokaleIdentificator "0834358069" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/f001397ce87931d347a3b34f53bcd558> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "f001397ce87931d347a3b34f53bcd558" ;
+    generiek:lokaleIdentificator "0266559859" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/f2630d43f5663fe293058105db9c8c34> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "f2630d43f5663fe293058105db9c8c34" ;
+    generiek:lokaleIdentificator "0875376696" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/f6538291be4bf3b8273e226f617d2a3f> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "f6538291be4bf3b8273e226f617d2a3f" ;
+    generiek:lokaleIdentificator "0505849852" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/f7c3dd6042f9be0ea1ea284fc3df3beb> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "f7c3dd6042f9be0ea1ea284fc3df3beb" ;
+    generiek:lokaleIdentificator "0677764437" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/f930f2ef432f3af75cca4f67ad591b50> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "f930f2ef432f3af75cca4f67ad591b50" ;
+    generiek:lokaleIdentificator "0222947570" .
+
+<http://data.lblod.info/id/gestructureerdeIdentificator/fe1fe08d50219d8dbe6c08720ccaddc9> a generiek:GestructureerdeIdentificator ;
+    mu:uuid "fe1fe08d50219d8dbe6c08720ccaddc9" ;
+    generiek:lokaleIdentificator "0467270576" .
+
+<http://data.lblod.info/id/identificatoren/008a4617148b0c0434c0ad5753de809e> a adms:Identifier ;
+    mu:uuid "008a4617148b0c0434c0ad5753de809e" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/d1eb1692e141fb4196d8ff981ed1e5c3> .
+
+<http://data.lblod.info/id/identificatoren/0692dc708125281c625b3e02f97c3de6> a adms:Identifier ;
+    mu:uuid "0692dc708125281c625b3e02f97c3de6" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/8932ae77eb096f1edb5f51c8582549dd> .
+
+<http://data.lblod.info/id/identificatoren/080b54c8114aeed68eec44a74aa5ad2c> a adms:Identifier ;
+    mu:uuid "080b54c8114aeed68eec44a74aa5ad2c" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/f7c3dd6042f9be0ea1ea284fc3df3beb> .
+
+<http://data.lblod.info/id/identificatoren/081906c958c5b5c054a4bb4c417bd96a> a adms:Identifier ;
+    mu:uuid "081906c958c5b5c054a4bb4c417bd96a" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/f001397ce87931d347a3b34f53bcd558> .
+
+<http://data.lblod.info/id/identificatoren/109fb7ac680382457fe3b802f51a4a03> a adms:Identifier ;
+    mu:uuid "109fb7ac680382457fe3b802f51a4a03" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/bfebcd8ea17e327c231cba0b83a3f11c> .
+
+<http://data.lblod.info/id/identificatoren/11c2ecc132451625c80cdee64888fa72> a adms:Identifier ;
+    mu:uuid "11c2ecc132451625c80cdee64888fa72" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/aa038c1ae756275f63897e35f2db55e9> .
+
+<http://data.lblod.info/id/identificatoren/13caa4aeab09c3bd2209d25c99e7159b> a adms:Identifier ;
+    mu:uuid "13caa4aeab09c3bd2209d25c99e7159b" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/cb50ef50dd4d25ecba36f2c8ef76bcc7> .
+
+<http://data.lblod.info/id/identificatoren/183558c6aa91984d0f92996371f007c0> a adms:Identifier ;
+    mu:uuid "183558c6aa91984d0f92996371f007c0" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/75bddc0e7e073df97b49739d9fc8aec9> .
+
+<http://data.lblod.info/id/identificatoren/1a132fcb89bb3d9c93486e0575c3bb6e> a adms:Identifier ;
+    mu:uuid "1a132fcb89bb3d9c93486e0575c3bb6e" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/7abb0a6db1813e8fe3f5db9c88c685fc> .
+
+<http://data.lblod.info/id/identificatoren/1c240bc2762bc38274f838c8d069be30> a adms:Identifier ;
+    mu:uuid "1c240bc2762bc38274f838c8d069be30" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/d9ce93b490c04bebbbb8b5e3b546f08b> .
+
+<http://data.lblod.info/id/identificatoren/245292f26284ea2f451724715c52aced> a adms:Identifier ;
+    mu:uuid "245292f26284ea2f451724715c52aced" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/ea64bf7d8ff8ef115c727270ada8a0cc> .
+
+<http://data.lblod.info/id/identificatoren/260d3231d4a2e7488a7114ed8d18fde1> a adms:Identifier ;
+    mu:uuid "260d3231d4a2e7488a7114ed8d18fde1" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/a65ffed30db25374b5f097368986b928> .
+
+<http://data.lblod.info/id/identificatoren/2816c36b3ac92bd8c64e7ec233e870f3> a adms:Identifier ;
+    mu:uuid "2816c36b3ac92bd8c64e7ec233e870f3" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/bfcc0356786a920d54ec65a2c6c5c917> .
+
+<http://data.lblod.info/id/identificatoren/28ec55396860bdbcba539b30416884d7> a adms:Identifier ;
+    mu:uuid "28ec55396860bdbcba539b30416884d7" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/29995d585d449d07ab981a458d4d8a58> .
+
+<http://data.lblod.info/id/identificatoren/2f1f924fd83dc9a1099e829319164b07> a adms:Identifier ;
+    mu:uuid "2f1f924fd83dc9a1099e829319164b07" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/1ae0fd6d01729f259670566a702dcfee> .
+
+<http://data.lblod.info/id/identificatoren/302fe5d8d3e9f7d75fd98691c98c5275> a adms:Identifier ;
+    mu:uuid "302fe5d8d3e9f7d75fd98691c98c5275" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/ee2482e1674479cd72f6d27e73573c4b> .
+
+<http://data.lblod.info/id/identificatoren/37357fca0618c387ef3b42287f5477c2> a adms:Identifier ;
+    mu:uuid "37357fca0618c387ef3b42287f5477c2" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/b6f172f2a085d74024ad781c0899b360> .
+
+<http://data.lblod.info/id/identificatoren/3d00e5a4d42bedc89bd791158f8301aa> a adms:Identifier ;
+    mu:uuid "3d00e5a4d42bedc89bd791158f8301aa" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/2458dec3a9e64f3bdc758cfc74ea3f60> .
+
+<http://data.lblod.info/id/identificatoren/491638ffe41055c45dbc3a842227f24c> a adms:Identifier ;
+    mu:uuid "491638ffe41055c45dbc3a842227f24c" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/e3c1b1c4e02463b872484a9a46078497> .
+
+<http://data.lblod.info/id/identificatoren/49594b9a0e989073d54b415eb5fc2114> a adms:Identifier ;
+    mu:uuid "49594b9a0e989073d54b415eb5fc2114" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/d7de4b7754a4efc86aa2df1696fb31c5> .
+
+<http://data.lblod.info/id/identificatoren/4966a13b3126445e7f00086fa2bf1734> a adms:Identifier ;
+    mu:uuid "4966a13b3126445e7f00086fa2bf1734" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/a0b11428ea20005fa979c798f0eb6a4a> .
+
+<http://data.lblod.info/id/identificatoren/4afc4ebf5c212c6daf0ebbe89b14fe94> a adms:Identifier ;
+    mu:uuid "4afc4ebf5c212c6daf0ebbe89b14fe94" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/09fbd0da3ad86093de6086c15bc5a3c8> .
+
+<http://data.lblod.info/id/identificatoren/51dfae4afeb79f57b65475b4783f90fb> a adms:Identifier ;
+    mu:uuid "51dfae4afeb79f57b65475b4783f90fb" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/5f817d6d395145f5178c6dc232d80f57> .
+
+<http://data.lblod.info/id/identificatoren/52cb9863efc051cba49e82899d60269a> a adms:Identifier ;
+    mu:uuid "52cb9863efc051cba49e82899d60269a" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/f930f2ef432f3af75cca4f67ad591b50> .
+
+<http://data.lblod.info/id/identificatoren/549788e31d0fb0ee2ba60358ac7f3b05> a adms:Identifier ;
+    mu:uuid "549788e31d0fb0ee2ba60358ac7f3b05" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/3a66b0b9172f955e8862e274bfd11eee> .
+
+<http://data.lblod.info/id/identificatoren/6013e8499c7537614a7537d8caa3765e> a adms:Identifier ;
+    mu:uuid "6013e8499c7537614a7537d8caa3765e" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/cedb4e5ee57f8f36ff3ee3e828aab673> .
+
+<http://data.lblod.info/id/identificatoren/657ee86ef6c1c07b56ec65b641392426> a adms:Identifier ;
+    mu:uuid "657ee86ef6c1c07b56ec65b641392426" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/e3d7c5d6cd563b26aef3fea69daf8bf0> .
+
+<http://data.lblod.info/id/identificatoren/65e608a54e13d25b8a0b67ba73bac294> a adms:Identifier ;
+    mu:uuid "65e608a54e13d25b8a0b67ba73bac294" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/7e738b64675aafdeae9fc5c8bef794a4> .
+
+<http://data.lblod.info/id/identificatoren/663612e5fd331041198d890dd31313c9> a adms:Identifier ;
+    mu:uuid "663612e5fd331041198d890dd31313c9" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/bdf5dc13a0894060adc26707de210b17> .
+
+<http://data.lblod.info/id/identificatoren/66e09a522d53c8336e7a1672fce4ec5a> a adms:Identifier ;
+    mu:uuid "66e09a522d53c8336e7a1672fce4ec5a" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/ba1693c9a9f214b692d3f3fdfbefa477> .
+
+<http://data.lblod.info/id/identificatoren/69659efacb90d6bd9afb302324591704> a adms:Identifier ;
+    mu:uuid "69659efacb90d6bd9afb302324591704" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/2d1954c6ca57477886a14d59f42112ab> .
+
+<http://data.lblod.info/id/identificatoren/6ad98605de07ba25d161beb851ad61a7> a adms:Identifier ;
+    mu:uuid "6ad98605de07ba25d161beb851ad61a7" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/c59415a8e5453ebe212f3b4f29b65af3> .
+
+<http://data.lblod.info/id/identificatoren/71a700eba49d854ee1ce24de967df7bb> a adms:Identifier ;
+    mu:uuid "71a700eba49d854ee1ce24de967df7bb" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/c22ac54797195c8d265cb822cfdb2c90> .
+
+<http://data.lblod.info/id/identificatoren/7206f8f97fa779bb61915c00a164025b> a adms:Identifier ;
+    mu:uuid "7206f8f97fa779bb61915c00a164025b" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/59859b8b8b2fbc0c8674d6f14ec2c963> .
+
+<http://data.lblod.info/id/identificatoren/74793a50bbaeab5b80d55cc92365b2e0> a adms:Identifier ;
+    mu:uuid "74793a50bbaeab5b80d55cc92365b2e0" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/29a6c4b857f838c32f6ddd20c21571b3> .
+
+<http://data.lblod.info/id/identificatoren/76280332e646217e423f6017b570f85e> a adms:Identifier ;
+    mu:uuid "76280332e646217e423f6017b570f85e" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/50adadc59b491d50d909f41422c60695> .
+
+<http://data.lblod.info/id/identificatoren/77ae96baa745f5d010b1e1b07c371504> a adms:Identifier ;
+    mu:uuid "77ae96baa745f5d010b1e1b07c371504" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/d566bbec679d415899d221039c094cd9> .
+
+<http://data.lblod.info/id/identificatoren/80699fc69631bb1fa1f2ae0a49e29667> a adms:Identifier ;
+    mu:uuid "80699fc69631bb1fa1f2ae0a49e29667" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/5902e3caa1fc679e2cfbbce3dab7f009> .
+
+<http://data.lblod.info/id/identificatoren/813ea05b4d1c35e4d340f1d4677e4261> a adms:Identifier ;
+    mu:uuid "813ea05b4d1c35e4d340f1d4677e4261" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/81f82c3227284593a36cf9c2777eb3fc> .
+
+<http://data.lblod.info/id/identificatoren/8393fd5ed8fc510882a114acb72c42cd> a adms:Identifier ;
+    mu:uuid "8393fd5ed8fc510882a114acb72c42cd" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/9dca92f055dcfb8fe69fc6f7031fd6c3> .
+
+<http://data.lblod.info/id/identificatoren/86d62c516b583c212c3058c861883a4b> a adms:Identifier ;
+    mu:uuid "86d62c516b583c212c3058c861883a4b" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/4f657eb0bc32e92d8c98306a08924fcd> .
+
+<http://data.lblod.info/id/identificatoren/895ccf59af5d4140d39f9cd850158fd9> a adms:Identifier ;
+    mu:uuid "895ccf59af5d4140d39f9cd850158fd9" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/20210d5ae7cc37ff47d04174e96bb432> .
+
+<http://data.lblod.info/id/identificatoren/8bf63c43c4b12922f3586ddc72d38efb> a adms:Identifier ;
+    mu:uuid "8bf63c43c4b12922f3586ddc72d38efb" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/b92e90a1e068bf7472329d56b76b008a> .
+
+<http://data.lblod.info/id/identificatoren/8d36946716126257213da374823441a8> a adms:Identifier ;
+    mu:uuid "8d36946716126257213da374823441a8" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/0f9a600476a363e909c8634b234873c7> .
+
+<http://data.lblod.info/id/identificatoren/8ff944114b5d7d92d90e22e37efc7a74> a adms:Identifier ;
+    mu:uuid "8ff944114b5d7d92d90e22e37efc7a74" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/9b26e8f7ecacaca3663bab8376422fcb> .
+
+<http://data.lblod.info/id/identificatoren/92111b46c47db15a7a8619662533cc61> a adms:Identifier ;
+    mu:uuid "92111b46c47db15a7a8619662533cc61" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/07d580c59f081f6169366ea0413c3893> .
+
+<http://data.lblod.info/id/identificatoren/931d38f6c104bb11440c4eab30007071> a adms:Identifier ;
+    mu:uuid "931d38f6c104bb11440c4eab30007071" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/b1b8918e90ca03163eda95d7d4cdad33> .
+
+<http://data.lblod.info/id/identificatoren/938e54eea53e40dcc854f718891f9f3d> a adms:Identifier ;
+    mu:uuid "938e54eea53e40dcc854f718891f9f3d" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/61ebe3c6a3a26be349f2734339bb99b1> .
+
+<http://data.lblod.info/id/identificatoren/9a7ca2c2f3db6d12132cb7eb930ec910> a adms:Identifier ;
+    mu:uuid "9a7ca2c2f3db6d12132cb7eb930ec910" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/855f4680361085f8ab4d328524d15927> .
+
+<http://data.lblod.info/id/identificatoren/9b18aa32f510fb0d987da2fb82c3b674> a adms:Identifier ;
+    mu:uuid "9b18aa32f510fb0d987da2fb82c3b674" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/b7be29ca37d1f9049fa947f147e7a27f> .
+
+<http://data.lblod.info/id/identificatoren/9d925d3131d2daabc9dab95663f08568> a adms:Identifier ;
+    mu:uuid "9d925d3131d2daabc9dab95663f08568" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/0711bcdeb043fc972f8204b96d407744> .
+
+<http://data.lblod.info/id/identificatoren/a32606fbb8cb661a2ca800f1a56bfa57> a adms:Identifier ;
+    mu:uuid "a32606fbb8cb661a2ca800f1a56bfa57" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/742e6e58314bf60ee02ce6ee46c6c8f8> .
+
+<http://data.lblod.info/id/identificatoren/a4643bc2c41b09c70777c82be9ef346a> a adms:Identifier ;
+    mu:uuid "a4643bc2c41b09c70777c82be9ef346a" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/8275002a3c1b7aa1c4c8f6334b5ade5b> .
+
+<http://data.lblod.info/id/identificatoren/a5e2f8806a31dd9d1339d8cb2afcae41> a adms:Identifier ;
+    mu:uuid "a5e2f8806a31dd9d1339d8cb2afcae41" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/b5c1958b5d07230e725cefad81ce3473> .
+
+<http://data.lblod.info/id/identificatoren/a89d93787315012b417bf43a4be7eeae> a adms:Identifier ;
+    mu:uuid "a89d93787315012b417bf43a4be7eeae" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/19f115cd46774b14eefc37346b7f3be5> .
+
+<http://data.lblod.info/id/identificatoren/ad80002514640589dcb40ca3f14e9d56> a adms:Identifier ;
+    mu:uuid "ad80002514640589dcb40ca3f14e9d56" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/082dd38eb4240ed57f72fec7dd6d12d4> .
+
+<http://data.lblod.info/id/identificatoren/b11e9958142b8d5dd0ff465a65811d6e> a adms:Identifier ;
+    mu:uuid "b11e9958142b8d5dd0ff465a65811d6e" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/bc494c3a3ff4fe855a45bf8ef680bd7c> .
+
+<http://data.lblod.info/id/identificatoren/b2c9ac0e7e7532455e3d879ba4abe91d> a adms:Identifier ;
+    mu:uuid "b2c9ac0e7e7532455e3d879ba4abe91d" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/409d744fc0801aa7db322dc11105948c> .
+
+<http://data.lblod.info/id/identificatoren/bf7516d20ca8b51b527281c3d00e9d0b> a adms:Identifier ;
+    mu:uuid "bf7516d20ca8b51b527281c3d00e9d0b" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/1317fdd3f098049e6515c4edd287d86e> .
+
+<http://data.lblod.info/id/identificatoren/c23555055433ddbb57188e402415234f> a adms:Identifier ;
+    mu:uuid "c23555055433ddbb57188e402415234f" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/0f58c3dcca2cd7714f97fb31d8f4aca9> .
+
+<http://data.lblod.info/id/identificatoren/c2fe2fbd5ea7f54b1ae1710c332a8cb6> a adms:Identifier ;
+    mu:uuid "c2fe2fbd5ea7f54b1ae1710c332a8cb6" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/a6e555bc0f87fc5683d6e0c738162a27> .
+
+<http://data.lblod.info/id/identificatoren/c6368f30f34f029740675867ebac1c98> a adms:Identifier ;
+    mu:uuid "c6368f30f34f029740675867ebac1c98" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/40f324235706e17e9b358c275fd1850e> .
+
+<http://data.lblod.info/id/identificatoren/c6f0b81d94f5ecdf767389e5c7c4b89b> a adms:Identifier ;
+    mu:uuid "c6f0b81d94f5ecdf767389e5c7c4b89b" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/f6538291be4bf3b8273e226f617d2a3f> .
+
+<http://data.lblod.info/id/identificatoren/c8b806c8484b0cbb7a57fc5b55cbf767> a adms:Identifier ;
+    mu:uuid "c8b806c8484b0cbb7a57fc5b55cbf767" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/c474da69204109f7c904f998192e4dd5> .
+
+<http://data.lblod.info/id/identificatoren/cd324e60c5578e31e4a506b42f068722> a adms:Identifier ;
+    mu:uuid "cd324e60c5578e31e4a506b42f068722" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/7b49aa0f69b3279b9870edae294b669d> .
+
+<http://data.lblod.info/id/identificatoren/cd9e94b70986e2cdf001f594039bb3df> a adms:Identifier ;
+    mu:uuid "cd9e94b70986e2cdf001f594039bb3df" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/2fc3eb461b662e59f1765d6584e2abbc> .
+
+<http://data.lblod.info/id/identificatoren/cdfe6609e5ff309c85fc8ee8eaffa77c> a adms:Identifier ;
+    mu:uuid "cdfe6609e5ff309c85fc8ee8eaffa77c" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/3495511e394a2c0a38720788c8b2b3c7> .
+
+<http://data.lblod.info/id/identificatoren/cff81c2de30b1f9992999c25db8f1dcc> a adms:Identifier ;
+    mu:uuid "cff81c2de30b1f9992999c25db8f1dcc" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/5df43a5b255dda118a50cd42b95f4fc1> .
+
+<http://data.lblod.info/id/identificatoren/d077c2e9851dde12ac942b2c5d7d63f5> a adms:Identifier ;
+    mu:uuid "d077c2e9851dde12ac942b2c5d7d63f5" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/c87cc741911c91de42c548acfd95067c> .
+
+<http://data.lblod.info/id/identificatoren/d12f87a27815e45194decd1beac529fd> a adms:Identifier ;
+    mu:uuid "d12f87a27815e45194decd1beac529fd" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/dd59bd033334ca1229695239bd236fe5> .
+
+<http://data.lblod.info/id/identificatoren/d17f4158a18a28f8a2dfc81b2803d55b> a adms:Identifier ;
+    mu:uuid "d17f4158a18a28f8a2dfc81b2803d55b" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/5d3b0aecdd79a422fadf751af82e9401> .
+
+<http://data.lblod.info/id/identificatoren/d973f96f0da8a5bebb62d7bcbf59628a> a adms:Identifier ;
+    mu:uuid "d973f96f0da8a5bebb62d7bcbf59628a" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/1b329af236f0889037d69771f9055551> .
+
+<http://data.lblod.info/id/identificatoren/e19739bc074ad2d21e2d1555724fdb02> a adms:Identifier ;
+    mu:uuid "e19739bc074ad2d21e2d1555724fdb02" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/fe1fe08d50219d8dbe6c08720ccaddc9> .
+
+<http://data.lblod.info/id/identificatoren/e59658c3f6a8781272db2a6eee04960f> a adms:Identifier ;
+    mu:uuid "e59658c3f6a8781272db2a6eee04960f" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/1b660922750700f8e178746a5e03dfd9> .
+
+<http://data.lblod.info/id/identificatoren/e5abe417204aaa5abdc4ac018f2f132d> a adms:Identifier ;
+    mu:uuid "e5abe417204aaa5abdc4ac018f2f132d" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/5382221f85151892494e2940e79f5619> .
+
+<http://data.lblod.info/id/identificatoren/e664acfbae78c52769e24933fff50c08> a adms:Identifier ;
+    mu:uuid "e664acfbae78c52769e24933fff50c08" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/ac7a64739cbf28d1b2d1f1f5dfa40b26> .
+
+<http://data.lblod.info/id/identificatoren/ea178900b7854384a9a29f1e1490b088> a adms:Identifier ;
+    mu:uuid "ea178900b7854384a9a29f1e1490b088" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/f2630d43f5663fe293058105db9c8c34> .
+
+<http://data.lblod.info/id/identificatoren/f4831e272aaaadd0f067a1fd06c337de> a adms:Identifier ;
+    mu:uuid "f4831e272aaaadd0f067a1fd06c337de" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/2470541ce9caa4a3531d9ff49ad5cbe9> .
+
+<http://data.lblod.info/id/identificatoren/f859bce82bf3110e4697ead646df828f> a adms:Identifier ;
+    mu:uuid "f859bce82bf3110e4697ead646df828f" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/cc99a61437da01d4869308b96fb9dfd3> .
+
+<http://data.lblod.info/id/identificatoren/fd486f195e97f074fed578817b158bc0> a adms:Identifier ;
+    mu:uuid "fd486f195e97f074fed578817b158bc0" ;
+    skos:notation "KBO nummer" ;
+    generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificator/d0dcbb4a0eb152baa5dfc8badd21ddc0> .
+
+<http://data.lblod.info/id/bestuurseenheden/005f263d440315a440c47a34fddec33b7745836d64fe0b033fc82957285e838b> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/e1a7aa197d1fa117ad5fdc30dee57cf95974c149ed0f319237bb8fb1355d911e> ;
+    mu:uuid "005f263d440315a440c47a34fddec33b7745836d64fe0b033fc82957285e838b" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/657ee86ef6c1c07b56ec65b641392426> .
+
+<http://data.lblod.info/id/bestuurseenheden/0331f7d9259900c12c7cd16e081dca917d6b3ceda358cf69f12a1cdbb734b9ac> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/2c678dfde333c868587ced580e8079b9446ca2a55baeb6b79f7f75a6019ee45c> ;
+    mu:uuid "0331f7d9259900c12c7cd16e081dca917d6b3ceda358cf69f12a1cdbb734b9ac" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/302fe5d8d3e9f7d75fd98691c98c5275> .
+
+<http://data.lblod.info/id/bestuurseenheden/03df783df9b22fa5340f962d439c46048ba62f6b4f43bd2497eca20db7cd8617> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/e1a7aa197d1fa117ad5fdc30dee57cf95974c149ed0f319237bb8fb1355d911e> ;
+    mu:uuid "03df783df9b22fa5340f962d439c46048ba62f6b4f43bd2497eca20db7cd8617" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/c8b806c8484b0cbb7a57fc5b55cbf767> .
+
+<http://data.lblod.info/id/bestuurseenheden/079159c373e29e05221c4338a2440e4f58ddababa1d8f94dedf792b5414baf61> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/e1a7aa197d1fa117ad5fdc30dee57cf95974c149ed0f319237bb8fb1355d911e> ;
+    mu:uuid "079159c373e29e05221c4338a2440e4f58ddababa1d8f94dedf792b5414baf61" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/bf7516d20ca8b51b527281c3d00e9d0b> .
+
+<http://data.lblod.info/id/bestuurseenheden/0964427f9f2e113607681e5c25bf744a41bc412a94e1c0acc784a48d79441df6> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/909d039a1e2aae5fa681c0515d46c6adbfbe68e87e069a38c4a0f5dc07de7950> ;
+    mu:uuid "0964427f9f2e113607681e5c25bf744a41bc412a94e1c0acc784a48d79441df6" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/813ea05b4d1c35e4d340f1d4677e4261> .
+
+<http://data.lblod.info/id/bestuurseenheden/0d30036b943b9b9c3ef70c7c0e59a2325fbe2c455021ddb07bee427f73efcef8> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/2f0310c91de7b25f13cc488c18373925bfb1c443cda138d92f4f4a7d786df767> ;
+    mu:uuid "0d30036b943b9b9c3ef70c7c0e59a2325fbe2c455021ddb07bee427f73efcef8" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/d12f87a27815e45194decd1beac529fd> .
+
+<http://data.lblod.info/id/bestuurseenheden/10ce9d34-953b-4096-9c09-575426b12acc> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/38f8bb87f2a0c0f4ac1e39c846ba15f559843c81ecadddd0d0efbcb70334cef5> ;
+    mu:uuid "10ce9d34-953b-4096-9c09-575426b12acc" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/109fb7ac680382457fe3b802f51a4a03> .
+
+<http://data.lblod.info/id/bestuurseenheden/1165717c-1203-41cd-b434-b041cbe66782> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/d627c2dfdfc539a95a791916b85b5de4d2cc3ecf5c8dfa44e7c9bad8a7c69824> ;
+    mu:uuid "1165717c-1203-41cd-b434-b041cbe66782" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/65e608a54e13d25b8a0b67ba73bac294> .
+
+<http://data.lblod.info/id/bestuurseenheden/12b3670c672298b9f906f60433ab945a8c8cd2ef8e4b5f922d1fb284da18cd73> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/d6ae2524480ebf6900eda1f72dca25ba43139b6c0adbe2b7ae610365d59c2c34> ;
+    mu:uuid "12b3670c672298b9f906f60433ab945a8c8cd2ef8e4b5f922d1fb284da18cd73" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/d17f4158a18a28f8a2dfc81b2803d55b> .
+
+<http://data.lblod.info/id/bestuurseenheden/14cf807351ef2b7b20c8f481573b576f94cff8d7b8722190f137bc52a4d2e8c8> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/3a9b09cbccb798c8f9d5bad3fce1476bce1ee014165ba243488b0af690d0f464> ;
+    mu:uuid "14cf807351ef2b7b20c8f481573b576f94cff8d7b8722190f137bc52a4d2e8c8" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/cd9e94b70986e2cdf001f594039bb3df> .
+
+<http://data.lblod.info/id/bestuurseenheden/1bbd0f7a-664c-46bd-8ca0-891801b81962> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/6f382bd7c8e0bd81ffb83f0d13048dfd35525bde9fc0677a4a7a5780cc8e2614> ;
+    mu:uuid "1bbd0f7a-664c-46bd-8ca0-891801b81962" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/cdfe6609e5ff309c85fc8ee8eaffa77c> .
+
+<http://data.lblod.info/id/bestuurseenheden/2176cd7bde027a98b1d3c2f81862327cb8b3fa0df3757ed432371530e743ad5b> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/ce94eeae827cdc5c00f3f2f4276ff628580edefb3aa5861e4669b0c5d93adc57> ;
+    mu:uuid "2176cd7bde027a98b1d3c2f81862327cb8b3fa0df3757ed432371530e743ad5b" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/9a7ca2c2f3db6d12132cb7eb930ec910> .
+
+<http://data.lblod.info/id/bestuurseenheden/21a70e74dbb297ec42d5cc72ab810178b298d12fc8f679c742d2501f7ce5b6a3> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/aef3520d20282ff8782febfb42c5897fdd9dd902dde6f0c27b5c79a45a61d553> ;
+    mu:uuid "21a70e74dbb297ec42d5cc72ab810178b298d12fc8f679c742d2501f7ce5b6a3" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/260d3231d4a2e7488a7114ed8d18fde1> .
+
+<http://data.lblod.info/id/bestuurseenheden/251143c6-2094-4ad5-8b54-26cfded0082a> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/f7b72de90f98d11b9656ea8efe62d112dd0abc67e06236e6cb51bb776ff99068> ;
+    mu:uuid "251143c6-2094-4ad5-8b54-26cfded0082a" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/8bf63c43c4b12922f3586ddc72d38efb> .
+
+<http://data.lblod.info/id/bestuurseenheden/265f6bcddea9c9e994472376c40bd5591df678ab9fdba41d5d65933467d83f59> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/e1a7aa197d1fa117ad5fdc30dee57cf95974c149ed0f319237bb8fb1355d911e> ;
+    mu:uuid "265f6bcddea9c9e994472376c40bd5591df678ab9fdba41d5d65933467d83f59" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/76280332e646217e423f6017b570f85e> .
+
+<http://data.lblod.info/id/bestuurseenheden/27e7a364-fe11-4303-9a43-fc2e1a3510d7> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/7bbd72efc5f83ea1e22c75f707d613b2b4cca1617f9a7a9da42a2ab56ef7dfe4> ;
+    mu:uuid "27e7a364-fe11-4303-9a43-fc2e1a3510d7" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/e5abe417204aaa5abdc4ac018f2f132d> .
+
+<http://data.lblod.info/id/bestuurseenheden/2bf97f7faebd616265d004a80cce0319a110319197b657d5a0a1a16d81f34ca2> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/a31a308c01008e672f1cf8449dd571cfcad98af2d52a5fe8439bc247066f0aed> ;
+    mu:uuid "2bf97f7faebd616265d004a80cce0319a110319197b657d5a0a1a16d81f34ca2" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/52cb9863efc051cba49e82899d60269a> .
+
+<http://data.lblod.info/id/bestuurseenheden/31db97c9dab7ed09b591d2f3c567d47f70a5fa66c9ce3b4b2aea1e71f1dc8e76> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/3071908e96ecb2eed2d2572a46efc1a2826a42786d3676ffe8afdc16be3a3733> ;
+    mu:uuid "31db97c9dab7ed09b591d2f3c567d47f70a5fa66c9ce3b4b2aea1e71f1dc8e76" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/13caa4aeab09c3bd2209d25c99e7159b> .
+
+<http://data.lblod.info/id/bestuurseenheden/386f7c72-1c2b-49ea-b9fa-664abf86d15f> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/3b96bceb16ea9e38e76b97432e6f4c1b92f7183c09de31eacae995a211fd3f24> ;
+    mu:uuid "386f7c72-1c2b-49ea-b9fa-664abf86d15f" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/b11e9958142b8d5dd0ff465a65811d6e> .
+
+<http://data.lblod.info/id/bestuurseenheden/4141ab8d-b1e1-4b38-832a-76b4dba20dc7> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/e55336a3ecbae33f21e595458ba93eeeb0fa4390626622884d4d32523d0e0033> ;
+    mu:uuid "4141ab8d-b1e1-4b38-832a-76b4dba20dc7" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/c23555055433ddbb57188e402415234f> .
+
+<http://data.lblod.info/id/bestuurseenheden/47ac33b7-9321-432c-8ba8-1d284f04addf> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/ce94eeae827cdc5c00f3f2f4276ff628580edefb3aa5861e4669b0c5d93adc57> ;
+    mu:uuid "47ac33b7-9321-432c-8ba8-1d284f04addf" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/3d00e5a4d42bedc89bd791158f8301aa> .
+
+<http://data.lblod.info/id/bestuurseenheden/4b114b8e-11c5-4bc8-a3c2-4f5f05d7f430> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/1f31500c62ad5117b572c6f33a2131a6ae2e7231e31a6d97df5ab712719075fe> ;
+    mu:uuid "4b114b8e-11c5-4bc8-a3c2-4f5f05d7f430" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/938e54eea53e40dcc854f718891f9f3d> .
+
+<http://data.lblod.info/id/bestuurseenheden/4f452f5ad74a9cf4c6af447cb07157d8dad793abecff39729d7ab2eb582ec290> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/e1a7aa197d1fa117ad5fdc30dee57cf95974c149ed0f319237bb8fb1355d911e> ;
+    mu:uuid "4f452f5ad74a9cf4c6af447cb07157d8dad793abecff39729d7ab2eb582ec290" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/8ff944114b5d7d92d90e22e37efc7a74> .
+
+<http://data.lblod.info/id/bestuurseenheden/507182a9d6532733ac375988f8288bd1f5fdc2cfb1bee374bb6f5046bf307d4d> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/07a80fce7343279eab1f2113037031fafcc8b9a81202c214ef48f4feeac2e423> ;
+    mu:uuid "507182a9d6532733ac375988f8288bd1f5fdc2cfb1bee374bb6f5046bf307d4d" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/e19739bc074ad2d21e2d1555724fdb02> .
+
+<http://data.lblod.info/id/bestuurseenheden/5072fad918135764714007cea2f3573462199d6cbe7b96d6ac57d1c9b7bde399> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/141d487fe849fa900cb12f1e5904cc4c54e4c5af27c42fe1a216efec295e8254> ;
+    mu:uuid "5072fad918135764714007cea2f3573462199d6cbe7b96d6ac57d1c9b7bde399" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/895ccf59af5d4140d39f9cd850158fd9> .
+
+<http://data.lblod.info/id/bestuurseenheden/50ede269-5c49-41cd-be68-ac135314019c> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/c94533b210b8b1cb56bb69c4e7647238d39ce1a9c9096b83bc15bfcf5e1fcc36> ;
+    mu:uuid "50ede269-5c49-41cd-be68-ac135314019c" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/71a700eba49d854ee1ce24de967df7bb> .
+
+<http://data.lblod.info/id/bestuurseenheden/530dbb2c-a798-4cae-b42e-737b80b83b22> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/7ffc7f39fa2886fbd1011ae7f2af0c233b466a1622713654b33e958e5cea0861> ;
+    mu:uuid "530dbb2c-a798-4cae-b42e-737b80b83b22" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/92111b46c47db15a7a8619662533cc61> .
+
+<http://data.lblod.info/id/bestuurseenheden/531f08c0-65ac-4f47-ac15-066097ac5756> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/1fb92312354f3d900670e2b9cfbd80148910f1227e321f2c377f92957b071cb1> ;
+    mu:uuid "531f08c0-65ac-4f47-ac15-066097ac5756" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/0692dc708125281c625b3e02f97c3de6> .
+
+<http://data.lblod.info/id/bestuurseenheden/53fefc09ccb63625eda802c01cf32df7fe8a14a14f020a89a08e68dc49d43e31> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/01ae6047b61fc75a3944afeabd2c96c4b6c9aa48afdf6ebea95d9a3d5c1524aa> ;
+    mu:uuid "53fefc09ccb63625eda802c01cf32df7fe8a14a14f020a89a08e68dc49d43e31" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/c6368f30f34f029740675867ebac1c98> .
+
+<http://data.lblod.info/id/bestuurseenheden/5567394c206a8da9fe1e8ab4dc1d043eabdb5915ecf3d06a9495dc64cc3c691e> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/2761c3b5e85f62f5e2dc0e0d42519e97fdf8f265a1af7597c0694c51f0b34b7b> ;
+    mu:uuid "5567394c206a8da9fe1e8ab4dc1d043eabdb5915ecf3d06a9495dc64cc3c691e" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/080b54c8114aeed68eec44a74aa5ad2c> .
+
+<http://data.lblod.info/id/bestuurseenheden/559066ee63a3bbb4dbcaac93d9da15d9e81891e17e8a1d104a5ed356daa4aca4> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/cb88ad5637546b3555148dd0f3ed4f310a959b8f01212239e8bc37b790fcd4b3> ;
+    mu:uuid "559066ee63a3bbb4dbcaac93d9da15d9e81891e17e8a1d104a5ed356daa4aca4" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/51dfae4afeb79f57b65475b4783f90fb> .
+
+<http://data.lblod.info/id/bestuurseenheden/67d72f2e178c4adbd0567865d611248403aecae0e505fbb30d3c932a634c0d2a> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/5d33e9abb148af2e477a98d392d7fb9568749c00d0d5472a1e800a4e9dd3a618> ;
+    mu:uuid "67d72f2e178c4adbd0567865d611248403aecae0e505fbb30d3c932a634c0d2a" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/fd486f195e97f074fed578817b158bc0> .
+
+<http://data.lblod.info/id/bestuurseenheden/68cf1a248013d8921af92322a077e2c74988889defdfea0cc0d467eddf3baf1f> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/4efee7e615270a7ca325873546458d13e54609bd311b18d6b1724b130a3512bd> ;
+    mu:uuid "68cf1a248013d8921af92322a077e2c74988889defdfea0cc0d467eddf3baf1f" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/80699fc69631bb1fa1f2ae0a49e29667> .
+
+<http://data.lblod.info/id/bestuurseenheden/6af38a22fcba9d1701a77d9c869e0f06e11a3291a71a4118a7cd93629ba92c27> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/e1a7aa197d1fa117ad5fdc30dee57cf95974c149ed0f319237bb8fb1355d911e> ;
+    mu:uuid "6af38a22fcba9d1701a77d9c869e0f06e11a3291a71a4118a7cd93629ba92c27" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/491638ffe41055c45dbc3a842227f24c> .
+
+<http://data.lblod.info/id/bestuurseenheden/6c4179a4684d97c148da2e78ba99579e4145412c6431e1577713e5f095ff4f08> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/d1a7c48910cb2fc1ab3145d9a69e125d46c37dedf83d29d5f386697bc87892dd> ;
+    mu:uuid "6c4179a4684d97c148da2e78ba99579e4145412c6431e1577713e5f095ff4f08" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/2816c36b3ac92bd8c64e7ec233e870f3> .
+
+<http://data.lblod.info/id/bestuurseenheden/6cdf24341364ad76bcff1bc07f1ec33591bd8ae0f6814a3694f8a00b61d2fc67> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/ce80dff98a7d2ce0797a2626277b546c75d222a7262f14a41550f8f95df56161> ;
+    mu:uuid "6cdf24341364ad76bcff1bc07f1ec33591bd8ae0f6814a3694f8a00b61d2fc67" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/a4643bc2c41b09c70777c82be9ef346a> .
+
+<http://data.lblod.info/id/bestuurseenheden/6d1c55e517fd1fdcae81e9f07f0875aa9c452bed279e635b94fbe00630e7ae73> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/3b96bceb16ea9e38e76b97432e6f4c1b92f7183c09de31eacae995a211fd3f24> ;
+    mu:uuid "6d1c55e517fd1fdcae81e9f07f0875aa9c452bed279e635b94fbe00630e7ae73" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/c6f0b81d94f5ecdf767389e5c7c4b89b> .
+
+<http://data.lblod.info/id/bestuurseenheden/7152ffbc9f34208fdba63318b1d7e87980937c71cc36dfc24d5303567436f4b8> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/080c3058a571fbd71e2ab0cba985d228aa64a5ef00dda0eac517206d9e66f613> ;
+    mu:uuid "7152ffbc9f34208fdba63318b1d7e87980937c71cc36dfc24d5303567436f4b8" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/b2c9ac0e7e7532455e3d879ba4abe91d> .
+
+<http://data.lblod.info/id/bestuurseenheden/749bbdaf-dd7a-45e1-8f2e-98b8834bc295> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/a8040e566e7a22dfc6a83a7176d105abc68ab1bf1a89e94a1333c8f049131837> ;
+    mu:uuid "749bbdaf-dd7a-45e1-8f2e-98b8834bc295" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/28ec55396860bdbcba539b30416884d7> .
+
+<http://data.lblod.info/id/bestuurseenheden/77a07ee1348f6ef3b81ab685368d02c33812d92364e667f68fcdd073b050d949> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/80697b649ca5bc75c0d9a9c2f3a5a920c248b86aa062cd49118981c21b174d6b> ;
+    mu:uuid "77a07ee1348f6ef3b81ab685368d02c33812d92364e667f68fcdd073b050d949" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/cff81c2de30b1f9992999c25db8f1dcc> .
+
+<http://data.lblod.info/id/bestuurseenheden/7a26207c8531ac7c1dba8efd78870dd90d2ad64cb0cf3e666529e60e10e73a2d> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/76b98b973dad10a9df16433743f7721607dac9ea569fa43d1cc3e285ce54ef10> ;
+    mu:uuid "7a26207c8531ac7c1dba8efd78870dd90d2ad64cb0cf3e666529e60e10e73a2d" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/a89d93787315012b417bf43a4be7eeae> .
+
+<http://data.lblod.info/id/bestuurseenheden/7eff2130-5462-4569-8098-29ceec9e6a22> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/e60532b5e10070b48664b998e12af31cd4e612a0b8d089804d0bbed3d4ecc969> ;
+    mu:uuid "7eff2130-5462-4569-8098-29ceec9e6a22" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/11c2ecc132451625c80cdee64888fa72> .
+
+<http://data.lblod.info/id/bestuurseenheden/836436cd7bc957ec9eb24865c628c5707b4a1fbbae5cccebfaf1df0983f888be> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/60b70f3b49cc098224ba560fa597f0c0e9efa4d0e5a32eacd8e81ee89cef173e> ;
+    mu:uuid "836436cd7bc957ec9eb24865c628c5707b4a1fbbae5cccebfaf1df0983f888be" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/8d36946716126257213da374823441a8> .
+
+<http://data.lblod.info/id/bestuurseenheden/84ccc300d580fb3de6b36fab26524b43da45e7213d205b57b9db715dc24d35f3> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/e1a7aa197d1fa117ad5fdc30dee57cf95974c149ed0f319237bb8fb1355d911e> ;
+    mu:uuid "84ccc300d580fb3de6b36fab26524b43da45e7213d205b57b9db715dc24d35f3" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/f4831e272aaaadd0f067a1fd06c337de> .
+
+<http://data.lblod.info/id/bestuurseenheden/8a301cf9-6611-450c-aa95-b104803180db> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/2103a531e5e171f019a2f6a1c010d16d4cf7d5bdeee397b3ac8d35dd1b7bc38f> ;
+    mu:uuid "8a301cf9-6611-450c-aa95-b104803180db" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/2f1f924fd83dc9a1099e829319164b07> .
+
+<http://data.lblod.info/id/bestuurseenheden/8cfb6e37e4259b79bffd9027e38e2a10397edf45084122f3939dd19ff378fe9c> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/c0b4dbf6f9094005734ed39d822d593e23131a1905cacf06f062b85347bdb808> ;
+    mu:uuid "8cfb6e37e4259b79bffd9027e38e2a10397edf45084122f3939dd19ff378fe9c" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/66e09a522d53c8336e7a1672fce4ec5a> .
+
+<http://data.lblod.info/id/bestuurseenheden/8d71b78b3048c4062561b199811a6de7d49c8553c794b6cc62a565e683681ed4> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/05200c01bb94f80297204fa643dcdb5534283b9662ef46877662b4e6c0557e3f> ;
+    mu:uuid "8d71b78b3048c4062561b199811a6de7d49c8553c794b6cc62a565e683681ed4" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/37357fca0618c387ef3b42287f5477c2> .
+
+<http://data.lblod.info/id/bestuurseenheden/927c0e00-65db-4003-b3ef-715428141de8> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/c390151b9698fd323a7c021f36085f0e2e2ce84fd2aee26a70ed5553bb98c032> ;
+    mu:uuid "927c0e00-65db-4003-b3ef-715428141de8" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/4966a13b3126445e7f00086fa2bf1734> .
+
+<http://data.lblod.info/id/bestuurseenheden/94158248e8e9bd9a05012e06db794178caa74731b2dadcf84f5ad7373f13abcc> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/76b98b973dad10a9df16433743f7721607dac9ea569fa43d1cc3e285ce54ef10> ;
+    mu:uuid "94158248e8e9bd9a05012e06db794178caa74731b2dadcf84f5ad7373f13abcc" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/663612e5fd331041198d890dd31313c9> .
+
+<http://data.lblod.info/id/bestuurseenheden/96ceb4cf-ece3-417d-914b-3e6eff293e6a> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/94a2edbd38ede2a3385e46ec2d6b05e7b020782e435f4f761705142dd08e2978> ;
+    mu:uuid "96ceb4cf-ece3-417d-914b-3e6eff293e6a" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/8393fd5ed8fc510882a114acb72c42cd> .
+
+<http://data.lblod.info/id/bestuurseenheden/9f839b41d7dba917e53c483d35e693b2cefdb89a13a080faa762845af6a9a337> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/6121fba4f7e2b5da28882bcc51d2eb550489a18327a54c0e5e459aaee33f054e> ;
+    mu:uuid "9f839b41d7dba917e53c483d35e693b2cefdb89a13a080faa762845af6a9a337" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/549788e31d0fb0ee2ba60358ac7f3b05> .
+
+<http://data.lblod.info/id/bestuurseenheden/a79dd82a5e400056b3f233fc646850f57918b6173036efa1c3597971cdc6649f> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/3369513846214df5d8ab080574038269b6f88258266cbbcc89fca9837d5a50dd> ;
+    mu:uuid "a79dd82a5e400056b3f233fc646850f57918b6173036efa1c3597971cdc6649f" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/245292f26284ea2f451724715c52aced> .
+
+<http://data.lblod.info/id/bestuurseenheden/a9b3046e-331e-4668-b5cc-2da7bb09e354> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/f2bda6eb42c1ab85c4ef36588a043ac2bfeffa31bfb88bb7abc597f01efe270b> ;
+    mu:uuid "a9b3046e-331e-4668-b5cc-2da7bb09e354" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/d077c2e9851dde12ac942b2c5d7d63f5> .
+
+<http://data.lblod.info/id/bestuurseenheden/aabc8d18d6b42c555fc9061c1f756bae12c7ab722a4b4d6408e14785d5762500> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/91b5a93c37280c2436914d51e60baef7bb96a4621466a6037584946c0d491609> ;
+    mu:uuid "aabc8d18d6b42c555fc9061c1f756bae12c7ab722a4b4d6408e14785d5762500" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/cd324e60c5578e31e4a506b42f068722> .
+
+<http://data.lblod.info/id/bestuurseenheden/b54baac8-fcbf-426b-8407-542cdc009fee> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/07550a135c689629e5ea5214ca1c4630c1180110ca9b2f81debbe4d4bffa1058> ;
+    mu:uuid "b54baac8-fcbf-426b-8407-542cdc009fee" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/a5e2f8806a31dd9d1339d8cb2afcae41> .
+
+<http://data.lblod.info/id/bestuurseenheden/b7abada470cd56a64d67b5450b35c3e96c07ce5d752d6207d4886ccc8f4852ff> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/f7b72de90f98d11b9656ea8efe62d112dd0abc67e06236e6cb51bb776ff99068> ;
+    mu:uuid "b7abada470cd56a64d67b5450b35c3e96c07ce5d752d6207d4886ccc8f4852ff" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/081906c958c5b5c054a4bb4c417bd96a> .
+
+<http://data.lblod.info/id/bestuurseenheden/c0a096f256810f9d51c21456d5ee5bc9a5a471f78c8c699cc58c60730d5b0dbe> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/3369513846214df5d8ab080574038269b6f88258266cbbcc89fca9837d5a50dd> ;
+    mu:uuid "c0a096f256810f9d51c21456d5ee5bc9a5a471f78c8c699cc58c60730d5b0dbe" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/7206f8f97fa779bb61915c00a164025b> .
+
+<http://data.lblod.info/id/bestuurseenheden/c11ca390da51a65c5e328cd219eb91f5a657bba3d0f47cf995039dbfb1c64105> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/d73149af21c454de13ed7f7a4b51be415e5b98738486f0d2a86536947949132c> ;
+    mu:uuid "c11ca390da51a65c5e328cd219eb91f5a657bba3d0f47cf995039dbfb1c64105" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/d973f96f0da8a5bebb62d7bcbf59628a> .
+
+<http://data.lblod.info/id/bestuurseenheden/c4486571e2cf6a0656e29a47a3f210cf9bf732876320953c5759aef27b639842> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/83820048fc0a1e0c219f91a14d86b6ccaa38b9f3eb8ff8c3b4704fcedca264f7> ;
+    mu:uuid "c4486571e2cf6a0656e29a47a3f210cf9bf732876320953c5759aef27b639842" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/86d62c516b583c212c3058c861883a4b> .
+
+<http://data.lblod.info/id/bestuurseenheden/c83586e7-9818-4be5-ab24-5e9dcd9b21fd> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/fabec9e745fc9efa32afadd8b7268938805b9679dcf3b032c9b9a9a3530d6b59> ;
+    mu:uuid "c83586e7-9818-4be5-ab24-5e9dcd9b21fd" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/e59658c3f6a8781272db2a6eee04960f> .
+
+<http://data.lblod.info/id/bestuurseenheden/cce1926b-51ff-4b66-a702-ea985f1d250b> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/e60532b5e10070b48664b998e12af31cd4e612a0b8d089804d0bbed3d4ecc969> ;
+    mu:uuid "cce1926b-51ff-4b66-a702-ea985f1d250b" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/931d38f6c104bb11440c4eab30007071> .
+
+<http://data.lblod.info/id/bestuurseenheden/d0ec3d07-a15c-4e04-bcbb-b05083262544> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/40e6ed8a858ceca76bf9bdf1fefcfc989cf48c5251c814ff728521ef798d75b3> ;
+    mu:uuid "d0ec3d07-a15c-4e04-bcbb-b05083262544" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/69659efacb90d6bd9afb302324591704> .
+
+<http://data.lblod.info/id/bestuurseenheden/d9196423b3657e5484236c769737573e4574e223eaccde6a7b7207d632a6a669> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/a1433dde05ab69812cdc7b95f0e8c42468dfa165777030cad3f5e21014be8220> ;
+    mu:uuid "d9196423b3657e5484236c769737573e4574e223eaccde6a7b7207d632a6a669" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/6013e8499c7537614a7537d8caa3765e> .
+
+<http://data.lblod.info/id/bestuurseenheden/d9c35f09-2a47-4ecf-b078-4cbe86ad8527> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/bestuurseenheden/81a6c688-9d4e-4905-b5af-c8b2386516e5> ;
+    mu:uuid "d9c35f09-2a47-4ecf-b078-4cbe86ad8527" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/6ad98605de07ba25d161beb851ad61a7> .
+
+<http://data.lblod.info/id/bestuurseenheden/dbb530bd-a765-49e6-8c3e-4fed14d44c4e> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/31b63d953c84130d22cdac7258ab5845634078ca415e379322a4a045d3495bdc> ;
+    mu:uuid "dbb530bd-a765-49e6-8c3e-4fed14d44c4e" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/c2fe2fbd5ea7f54b1ae1710c332a8cb6> .
+
+<http://data.lblod.info/id/bestuurseenheden/e10b5c6c27e642c4f6ae8b1aa623b1a696318483629e5edbea343ba20038d94c> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/99ba8a5c13dff0e6fb58996653274a8755e29d03baa241535b5230fc3c4d1e60> ;
+    mu:uuid "e10b5c6c27e642c4f6ae8b1aa623b1a696318483629e5edbea343ba20038d94c" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/a32606fbb8cb661a2ca800f1a56bfa57> .
+
+<http://data.lblod.info/id/bestuurseenheden/e23cb5929d99c7633348f71af1bf11ab5b8fa3649e34d4e0967a429ee6437bd1> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/2546a39800c91088ed65bbe14a35d514db3e55359042462741c743a8ff18bda2> ;
+    mu:uuid "e23cb5929d99c7633348f71af1bf11ab5b8fa3649e34d4e0967a429ee6437bd1" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/ea178900b7854384a9a29f1e1490b088> .
+
+<http://data.lblod.info/id/bestuurseenheden/e2bf9406-8c70-4dda-bb88-5771480d9155> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/f2bda6eb42c1ab85c4ef36588a043ac2bfeffa31bfb88bb7abc597f01efe270b> ;
+    mu:uuid "e2bf9406-8c70-4dda-bb88-5771480d9155" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/e664acfbae78c52769e24933fff50c08> .
+
+<http://data.lblod.info/id/bestuurseenheden/e2dfbd3a56dd87414968d7454dcfde193145e331ddcfc86fb48a9c79b5c0cef3> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/e1a7aa197d1fa117ad5fdc30dee57cf95974c149ed0f319237bb8fb1355d911e> ;
+    mu:uuid "e2dfbd3a56dd87414968d7454dcfde193145e331ddcfc86fb48a9c79b5c0cef3" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/9d925d3131d2daabc9dab95663f08568> .
+
+<http://data.lblod.info/id/bestuurseenheden/e452e23b-95cb-4b75-8825-503288ede636> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/99937d077273c7dc90a57c475c5c5465edb3d792e024a0be0be37baa0e1b5938> ;
+    mu:uuid "e452e23b-95cb-4b75-8825-503288ede636" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/1a132fcb89bb3d9c93486e0575c3bb6e> .
+
+<http://data.lblod.info/id/bestuurseenheden/e7ff93ecd6ec0ad906e179e3ccb1cea698e30013e888fa28c725b272beef3b99> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/e1a7aa197d1fa117ad5fdc30dee57cf95974c149ed0f319237bb8fb1355d911e> ;
+    mu:uuid "e7ff93ecd6ec0ad906e179e3ccb1cea698e30013e888fa28c725b272beef3b99" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/4afc4ebf5c212c6daf0ebbe89b14fe94> .
+
+<http://data.lblod.info/id/bestuurseenheden/e9612bfd21b5b805074e751d03224dae38f8c4c91a89fd34f1f4007c3978ba91> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/d74618571b5d5b6406f37dbd2be19bfa0becfa3dfffc2d887ebbcd550870192d> ;
+    mu:uuid "e9612bfd21b5b805074e751d03224dae38f8c4c91a89fd34f1f4007c3978ba91" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/ad80002514640589dcb40ca3f14e9d56> .
+
+<http://data.lblod.info/id/bestuurseenheden/eb31eb0b167e34e43a47ba63cc7bfbbf8e13ce818ede2e7af7bd513b857c8751> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/4b55855dc112b7fa4c37e0b39326fbca2661320ddd964bb8e0d2674394698997> ;
+    mu:uuid "eb31eb0b167e34e43a47ba63cc7bfbbf8e13ce818ede2e7af7bd513b857c8751" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/9b18aa32f510fb0d987da2fb82c3b674> .
+
+<http://data.lblod.info/id/bestuurseenheden/ef67ec9cdeb835268fd4a6f554db25f1bbb081009fa136b597785853076ea937> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/ae494f69be10f82afa1d7b0937abd22f490e09d268c743ea7b8e6a66c516d4fc> ;
+    mu:uuid "ef67ec9cdeb835268fd4a6f554db25f1bbb081009fa136b597785853076ea937" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/f859bce82bf3110e4697ead646df828f> .
+
+<http://data.lblod.info/id/bestuurseenheden/f3f1598c1a9fb9e3666a3001004e4bfdb028da702bb8755655c0946597bb8ea4> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/3a9b09cbccb798c8f9d5bad3fce1476bce1ee014165ba243488b0af690d0f464> ;
+    mu:uuid "f3f1598c1a9fb9e3666a3001004e4bfdb028da702bb8755655c0946597bb8ea4" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/74793a50bbaeab5b80d55cc92365b2e0> .
+
+<http://data.lblod.info/id/bestuurseenheden/f490a5f5-5f21-4c01-b70e-80d76ad8c256> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/a0cc5b5e5fa2ff41dfe70066f4e4e579b39c8876c6772e81e0ddfd407d236f16> ;
+    mu:uuid "f490a5f5-5f21-4c01-b70e-80d76ad8c256" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/008a4617148b0c0434c0ad5753de809e> .
+
+<http://data.lblod.info/id/bestuurseenheden/f7ec3b8b3f74b7656c1769b7b1ec7641e12fe8fcf64564ce0a204e30df498907> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/b7919ff33e8f2bd022b53e6c9c1562422599c0cbb75f5d1ebf6f290d91458cb9> ;
+    mu:uuid "f7ec3b8b3f74b7656c1769b7b1ec7641e12fe8fcf64564ce0a204e30df498907" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/49594b9a0e989073d54b415eb5fc2114> .
+
+<http://data.lblod.info/id/bestuurseenheden/fd620aa85d002529d17747ee2a7350d97633144386c273a53a2ac742367b2b09> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/3a763f4d473ad2803f9299a1854130eca8351f1923074ee9e8f18fe5ed9d14ef> ;
+    mu:uuid "fd620aa85d002529d17747ee2a7350d97633144386c273a53a2ac742367b2b09" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/77ae96baa745f5d010b1e1b07c371504> .
+
+<http://data.lblod.info/id/bestuurseenheden/fd9abc2a-e346-4bf4-bbfa-e1bba880e2b9> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/4afbdfef4de7314c2637a9f950b13bb9b0b4eaaf3413c0bd5d0600852a9d7cb3> ;
+    mu:uuid "fd9abc2a-e346-4bf4-bbfa-e1bba880e2b9" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/183558c6aa91984d0f92996371f007c0> .
+
+<http://data.lblod.info/id/bestuurseenheden/ffec0b97d60ac685f8e95209fdbdee3ba0171511609d109d4252a34fc5bf4160> a besluit:Bestuurseenheid ;
+    besluit:werkingsgebied <http://data.lblod.info/id/werkingsgebieden/97dde102c11a0abb02f6b6a8a19ef6b4b42f2f575dd566162bd7abaa6c0c8eca> ;
+    mu:uuid "ffec0b97d60ac685f8e95209fdbdee3ba0171511609d109d4252a34fc5bf4160" ;
+    adms:identifier <http://data.lblod.info/id/identificatoren/1c240bc2762bc38274f838c8d069be30> .
+

--- a/config/migrations/2024/20240212141020-onboarding-public-ocmw-associations/20240215140142-import-public-ocmw-associations.graph
+++ b/config/migrations/2024/20240212141020-onboarding-public-ocmw-associations/20240215140142-import-public-ocmw-associations.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/administrative-unit

--- a/config/migrations/2024/20240212141020-onboarding-public-ocmw-associations/20240215140142-import-public-ocmw-associations.ttl
+++ b/config/migrations/2024/20240212141020-onboarding-public-ocmw-associations/20240215140142-import-public-ocmw-associations.ttl
@@ -1,0 +1,3072 @@
+
+          @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+          @prefix mu: <http://mu.semte.ch/vocabularies/core/> .
+          @prefix persoon: <https://data.vlaanderen.be/ns/persoon#> .
+          @prefix ext: <http://mu.semte.ch/vocabularies/ext/>.
+          @prefix person: <http://www.w3.org/ns/person#>.
+          @prefix session: <http://mu.semte.ch/vocabularies/session/>.
+          @prefix foaf: <http://xmlns.com/foaf/0.1/>.
+          @prefix besluit: <http://data.vlaanderen.be/ns/besluit#>.
+          @prefix ere: <http://data.lblod.info/vocabularies/erediensten/>.
+          @prefix mandaat: <http://data.vlaanderen.be/ns/mandaat#>.
+          @prefix org: <http://www.w3.org/ns/org#>.
+          @prefix dcterms: <http://purl.org/dc/terms/>.
+          @prefix generiek: <https://data.vlaanderen.be/ns/generiek#>.
+          @prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+          @prefix dc_terms: <http://purl.org/dc/terms/>.
+        
+      <http://data.lblod.info/id/identificatoren/640921d4-129d-44b7-933b-6f492f4cd55c> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "640921d4-129d-44b7-933b-6f492f4cd55c" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/21b97213-2b4a-4200-9518-bd24c2760942> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/21b97213-2b4a-4200-9518-bd24c2760942> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "21b97213-2b4a-4200-9518-bd24c2760942" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/21b97213-2b4a-4200-9518-bd24c2760942> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1038" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/43090584-90f9-4c1d-a6c0-57233d2f407f> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "43090584-90f9-4c1d-a6c0-57233d2f407f";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/aee4d5a1-e790-4212-affb-3fb35447f747>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/12fb7eeb-72ac-40e8-a53e-4e900ac0ab75>,
+                        <http://data.lblod.info/id/contact-punten/bd4ffdeb-30da-4a7e-ab32-febe03266b3a>.
+
+      <http://data.lblod.info/id/contact-punten/12fb7eeb-72ac-40e8-a53e-4e900ac0ab75> a <http://schema.org/ContactPoint>;
+        mu:uuid "12fb7eeb-72ac-40e8-a53e-4e900ac0ab75";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/bd4ffdeb-30da-4a7e-ab32-febe03266b3a> a <http://schema.org/ContactPoint>;
+        mu:uuid "bd4ffdeb-30da-4a7e-ab32-febe03266b3a";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/aee4d5a1-e790-4212-affb-3fb35447f747> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "aee4d5a1-e790-4212-affb-3fb35447f747".
+
+      <http://data.lblod.info/id/bestuurseenheden/7152ffbc9f34208fdba63318b1d7e87980937c71cc36dfc24d5303567436f4b8> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "7152ffbc9f34208fdba63318b1d7e87980937c71cc36dfc24d5303567436f4b8" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "Woonzorgnetwerk Edegem" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/640921d4-129d-44b7-933b-6f492f4cd55c> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/43090584-90f9-4c1d-a6c0-57233d2f407f> .
+
+      <http://data.lblod.info/id/identificatoren/a01516ea-b4e8-4e8a-b3c6-8f5642d9c280> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "a01516ea-b4e8-4e8a-b3c6-8f5642d9c280" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/90c5e7a0-b5d3-448d-a545-dbb736c6539c> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/90c5e7a0-b5d3-448d-a545-dbb736c6539c> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "90c5e7a0-b5d3-448d-a545-dbb736c6539c" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/90c5e7a0-b5d3-448d-a545-dbb736c6539c> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "820" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/f1d4bdd5-3e5b-4f2d-b96c-cff945e694c4> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "f1d4bdd5-3e5b-4f2d-b96c-cff945e694c4";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/1fc527c4-9e64-49b8-8778-fb0f3188de68>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/3f62afb2-8d7d-45fe-9d8f-298bc4c0018d>,
+                        <http://data.lblod.info/id/contact-punten/a4cd7f8d-378e-4d42-b883-7020dcad175c>.
+
+      <http://data.lblod.info/id/contact-punten/3f62afb2-8d7d-45fe-9d8f-298bc4c0018d> a <http://schema.org/ContactPoint>;
+        mu:uuid "3f62afb2-8d7d-45fe-9d8f-298bc4c0018d";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/a4cd7f8d-378e-4d42-b883-7020dcad175c> a <http://schema.org/ContactPoint>;
+        mu:uuid "a4cd7f8d-378e-4d42-b883-7020dcad175c";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/1fc527c4-9e64-49b8-8778-fb0f3188de68> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "1fc527c4-9e64-49b8-8778-fb0f3188de68".
+
+      <http://data.lblod.info/id/bestuurseenheden/14cf807351ef2b7b20c8f481573b576f94cff8d7b8722190f137bc52a4d2e8c8> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "14cf807351ef2b7b20c8f481573b576f94cff8d7b8722190f137bc52a4d2e8c8" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "Zorgbedrijf Antwerpen" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/a01516ea-b4e8-4e8a-b3c6-8f5642d9c280> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/f1d4bdd5-3e5b-4f2d-b96c-cff945e694c4> .
+
+      <http://data.lblod.info/id/identificatoren/779cb6ab-04b9-446d-8cac-1f3a6a738d0e> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "779cb6ab-04b9-446d-8cac-1f3a6a738d0e" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/1aee2076-d120-4b5d-8313-96e593236ca0> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/1aee2076-d120-4b5d-8313-96e593236ca0> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "1aee2076-d120-4b5d-8313-96e593236ca0" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/1aee2076-d120-4b5d-8313-96e593236ca0> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1042" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/f9ea94a8-b754-4c38-8e80-7b5b5ab756fa> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "f9ea94a8-b754-4c38-8e80-7b5b5ab756fa";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/7d8dfd0a-ec65-4a99-ac25-2fc9b1d07467>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/2e093c40-a72d-4509-861b-60fe11047cfc>,
+                        <http://data.lblod.info/id/contact-punten/59659e20-fb8b-4f4f-b488-c6c5b900f86b>.
+
+      <http://data.lblod.info/id/contact-punten/2e093c40-a72d-4509-861b-60fe11047cfc> a <http://schema.org/ContactPoint>;
+        mu:uuid "2e093c40-a72d-4509-861b-60fe11047cfc";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/59659e20-fb8b-4f4f-b488-c6c5b900f86b> a <http://schema.org/ContactPoint>;
+        mu:uuid "59659e20-fb8b-4f4f-b488-c6c5b900f86b";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/7d8dfd0a-ec65-4a99-ac25-2fc9b1d07467> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "7d8dfd0a-ec65-4a99-ac25-2fc9b1d07467".
+
+      <http://data.lblod.info/id/bestuurseenheden/b54baac8-fcbf-426b-8407-542cdc009fee> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "b54baac8-fcbf-426b-8407-542cdc009fee" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "ZorgGroep Lommel" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/779cb6ab-04b9-446d-8cac-1f3a6a738d0e> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/f9ea94a8-b754-4c38-8e80-7b5b5ab756fa> .
+
+      <http://data.lblod.info/id/identificatoren/1cdc8369-a344-43bf-9576-b68f215e7045> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "1cdc8369-a344-43bf-9576-b68f215e7045" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/cfcbe316-4a97-4e47-ba84-74111fc4fab0> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/cfcbe316-4a97-4e47-ba84-74111fc4fab0> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "cfcbe316-4a97-4e47-ba84-74111fc4fab0" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/cfcbe316-4a97-4e47-ba84-74111fc4fab0> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1036" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/c82f9da8-6db6-496a-b4ae-79db9a29c4b2> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "c82f9da8-6db6-496a-b4ae-79db9a29c4b2";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/25d5fdb9-41ae-4aea-8e6e-9087c1373dfb>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/7fc3e166-5b8d-4dea-b5fd-21c427b94b9d>,
+                        <http://data.lblod.info/id/contact-punten/4d4c0ed9-ef66-4531-87b3-ff0d66ec2317>.
+
+      <http://data.lblod.info/id/contact-punten/7fc3e166-5b8d-4dea-b5fd-21c427b94b9d> a <http://schema.org/ContactPoint>;
+        mu:uuid "7fc3e166-5b8d-4dea-b5fd-21c427b94b9d";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/4d4c0ed9-ef66-4531-87b3-ff0d66ec2317> a <http://schema.org/ContactPoint>;
+        mu:uuid "4d4c0ed9-ef66-4531-87b3-ff0d66ec2317";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/25d5fdb9-41ae-4aea-8e6e-9087c1373dfb> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "25d5fdb9-41ae-4aea-8e6e-9087c1373dfb".
+
+      <http://data.lblod.info/id/bestuurseenheden/aabc8d18d6b42c555fc9061c1f756bae12c7ab722a4b4d6408e14785d5762500> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "aabc8d18d6b42c555fc9061c1f756bae12c7ab722a4b4d6408e14785d5762500" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "Woon- en Zorgbedrijf Wervik" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/1cdc8369-a344-43bf-9576-b68f215e7045> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/c82f9da8-6db6-496a-b4ae-79db9a29c4b2> .
+
+      <http://data.lblod.info/id/identificatoren/f6e5eaeb-6d42-4685-a9c3-ea45b2e78f16> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "f6e5eaeb-6d42-4685-a9c3-ea45b2e78f16" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/fcb61143-b449-470a-8ca5-33f253a122bf> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/fcb61143-b449-470a-8ca5-33f253a122bf> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "fcb61143-b449-470a-8ca5-33f253a122bf" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/fcb61143-b449-470a-8ca5-33f253a122bf> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "859" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/f230f777-a957-4075-9011-e48910f76c6b> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "f230f777-a957-4075-9011-e48910f76c6b";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/7f32ef9b-e87c-4982-9770-b50cc419b249>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/878addba-5766-410e-b010-b4796bb589f6>,
+                        <http://data.lblod.info/id/contact-punten/7c260646-94e3-4b9f-b390-4ff8611cf315>.
+
+      <http://data.lblod.info/id/contact-punten/878addba-5766-410e-b010-b4796bb589f6> a <http://schema.org/ContactPoint>;
+        mu:uuid "878addba-5766-410e-b010-b4796bb589f6";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/7c260646-94e3-4b9f-b390-4ff8611cf315> a <http://schema.org/ContactPoint>;
+        mu:uuid "7c260646-94e3-4b9f-b390-4ff8611cf315";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/7f32ef9b-e87c-4982-9770-b50cc419b249> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "7f32ef9b-e87c-4982-9770-b50cc419b249".
+
+      <http://data.lblod.info/id/bestuurseenheden/e23cb5929d99c7633348f71af1bf11ab5b8fa3649e34d4e0967a429ee6437bd1> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "e23cb5929d99c7633348f71af1bf11ab5b8fa3649e34d4e0967a429ee6437bd1" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "Intergemeentelijke Dienst voor Schuldbemiddeling Bodukap" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/f6e5eaeb-6d42-4685-a9c3-ea45b2e78f16> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/f230f777-a957-4075-9011-e48910f76c6b> .
+
+      <http://data.lblod.info/id/identificatoren/9eed5499-15a2-4c2c-aa08-4e20c4767814> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "9eed5499-15a2-4c2c-aa08-4e20c4767814" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/3194f844-9ffa-4e07-ae08-c86e63eee617> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/3194f844-9ffa-4e07-ae08-c86e63eee617> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "3194f844-9ffa-4e07-ae08-c86e63eee617" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/3194f844-9ffa-4e07-ae08-c86e63eee617> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "830" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/ea097438-b057-4b00-af1e-3ca4ad61624c> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "ea097438-b057-4b00-af1e-3ca4ad61624c";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/a0706d21-7dd0-426d-9718-f2fb0e5a4216>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/60b3f2d9-11f8-4472-a2ec-d49f172d4a05>,
+                        <http://data.lblod.info/id/contact-punten/111c5564-dc5b-4237-b4ec-deb5833aa66b>.
+
+      <http://data.lblod.info/id/contact-punten/60b3f2d9-11f8-4472-a2ec-d49f172d4a05> a <http://schema.org/ContactPoint>;
+        mu:uuid "60b3f2d9-11f8-4472-a2ec-d49f172d4a05";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/111c5564-dc5b-4237-b4ec-deb5833aa66b> a <http://schema.org/ContactPoint>;
+        mu:uuid "111c5564-dc5b-4237-b4ec-deb5833aa66b";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/a0706d21-7dd0-426d-9718-f2fb0e5a4216> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "a0706d21-7dd0-426d-9718-f2fb0e5a4216".
+
+      <http://data.lblod.info/id/bestuurseenheden/6cdf24341364ad76bcff1bc07f1ec33591bd8ae0f6814a3694f8a00b61d2fc67> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "6cdf24341364ad76bcff1bc07f1ec33591bd8ae0f6814a3694f8a00b61d2fc67" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "Welzijnsregio Noord-Limburg" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/9eed5499-15a2-4c2c-aa08-4e20c4767814> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/ea097438-b057-4b00-af1e-3ca4ad61624c> .
+
+      <http://data.lblod.info/id/identificatoren/1a395d32-9471-4250-b681-e61f9fbfc2ea> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "1a395d32-9471-4250-b681-e61f9fbfc2ea" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/16961d99-ef99-4b28-b9de-04fdd64fa45e> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/16961d99-ef99-4b28-b9de-04fdd64fa45e> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "16961d99-ef99-4b28-b9de-04fdd64fa45e" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/16961d99-ef99-4b28-b9de-04fdd64fa45e> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1053" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/126a3952-2d85-476a-91ae-53103d77c33f> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "126a3952-2d85-476a-91ae-53103d77c33f";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/2f547a05-2c7c-48bb-b8c9-325102f7cd7b>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/ce2893be-147b-420b-b3ba-fb040f98a82a>,
+                        <http://data.lblod.info/id/contact-punten/b65244b1-d582-4658-9aa7-1fe3a6ed3349>.
+
+      <http://data.lblod.info/id/contact-punten/ce2893be-147b-420b-b3ba-fb040f98a82a> a <http://schema.org/ContactPoint>;
+        mu:uuid "ce2893be-147b-420b-b3ba-fb040f98a82a";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/b65244b1-d582-4658-9aa7-1fe3a6ed3349> a <http://schema.org/ContactPoint>;
+        mu:uuid "b65244b1-d582-4658-9aa7-1fe3a6ed3349";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/2f547a05-2c7c-48bb-b8c9-325102f7cd7b> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "2f547a05-2c7c-48bb-b8c9-325102f7cd7b".
+
+      <http://data.lblod.info/id/bestuurseenheden/e2bf9406-8c70-4dda-bb88-5771480d9155> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "e2bf9406-8c70-4dda-bb88-5771480d9155" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "Woonzorggroep Voorkempen" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/1a395d32-9471-4250-b681-e61f9fbfc2ea> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/126a3952-2d85-476a-91ae-53103d77c33f> .
+
+      <http://data.lblod.info/id/identificatoren/98ebb4c2-8a68-4241-8f50-065ca99a2068> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "98ebb4c2-8a68-4241-8f50-065ca99a2068" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/fafe2bd2-2f3c-448c-926b-b14edb90a00a> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/fafe2bd2-2f3c-448c-926b-b14edb90a00a> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "fafe2bd2-2f3c-448c-926b-b14edb90a00a" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/fafe2bd2-2f3c-448c-926b-b14edb90a00a> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1153" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/164a410f-d98c-4cc8-90a8-17b8293a9aa1> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "164a410f-d98c-4cc8-90a8-17b8293a9aa1";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/1d4ec2cc-5710-4d09-9199-50f2a3bfd656>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/eabc9fa8-5ea3-44e6-bd0e-6c938f1c9c3e>,
+                        <http://data.lblod.info/id/contact-punten/8debca0e-9861-47f2-888e-cd72ead66f8f>.
+
+      <http://data.lblod.info/id/contact-punten/eabc9fa8-5ea3-44e6-bd0e-6c938f1c9c3e> a <http://schema.org/ContactPoint>;
+        mu:uuid "eabc9fa8-5ea3-44e6-bd0e-6c938f1c9c3e";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/8debca0e-9861-47f2-888e-cd72ead66f8f> a <http://schema.org/ContactPoint>;
+        mu:uuid "8debca0e-9861-47f2-888e-cd72ead66f8f";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/1d4ec2cc-5710-4d09-9199-50f2a3bfd656> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "1d4ec2cc-5710-4d09-9199-50f2a3bfd656".
+
+      <http://data.lblod.info/id/bestuurseenheden/531f08c0-65ac-4f47-ac15-066097ac5756> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "531f08c0-65ac-4f47-ac15-066097ac5756" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "Zorg Tielt" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/98ebb4c2-8a68-4241-8f50-065ca99a2068> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/164a410f-d98c-4cc8-90a8-17b8293a9aa1> .
+
+      <http://data.lblod.info/id/identificatoren/3869d1ff-00d6-42a9-92c0-0ae101f5b189> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "3869d1ff-00d6-42a9-92c0-0ae101f5b189" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/09c2cf62-aab3-465f-aa55-3f6b7841ad2b> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/09c2cf62-aab3-465f-aa55-3f6b7841ad2b> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "09c2cf62-aab3-465f-aa55-3f6b7841ad2b" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/09c2cf62-aab3-465f-aa55-3f6b7841ad2b> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1044" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/f769940a-6007-4770-8634-1b853d33b2b3> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "f769940a-6007-4770-8634-1b853d33b2b3";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/80a5ae40-1322-4700-9fc8-e435acdb19fd>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/267643e8-0296-449a-986a-191c787712f4>,
+                        <http://data.lblod.info/id/contact-punten/c43b8cf9-12f9-4d1d-9394-f99a9e5fc1aa>.
+
+      <http://data.lblod.info/id/contact-punten/267643e8-0296-449a-986a-191c787712f4> a <http://schema.org/ContactPoint>;
+        mu:uuid "267643e8-0296-449a-986a-191c787712f4";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/c43b8cf9-12f9-4d1d-9394-f99a9e5fc1aa> a <http://schema.org/ContactPoint>;
+        mu:uuid "c43b8cf9-12f9-4d1d-9394-f99a9e5fc1aa";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/80a5ae40-1322-4700-9fc8-e435acdb19fd> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "80a5ae40-1322-4700-9fc8-e435acdb19fd".
+
+      <http://data.lblod.info/id/bestuurseenheden/e9612bfd21b5b805074e751d03224dae38f8c4c91a89fd34f1f4007c3978ba91> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "e9612bfd21b5b805074e751d03224dae38f8c4c91a89fd34f1f4007c3978ba91" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "Zorgbedrijf Harelbeke" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/3869d1ff-00d6-42a9-92c0-0ae101f5b189> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/f769940a-6007-4770-8634-1b853d33b2b3> .
+
+      <http://data.lblod.info/id/identificatoren/5bb7ca67-2d30-4e4d-8a24-ca9b7ff29f17> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "5bb7ca67-2d30-4e4d-8a24-ca9b7ff29f17" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/b23f935a-3fda-45a7-85a0-410d5ff34d7f> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/b23f935a-3fda-45a7-85a0-410d5ff34d7f> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "b23f935a-3fda-45a7-85a0-410d5ff34d7f" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/b23f935a-3fda-45a7-85a0-410d5ff34d7f> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1154" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/9c1dcb9a-41e0-4e6c-a867-cc3f74d77862> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "9c1dcb9a-41e0-4e6c-a867-cc3f74d77862";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/7deaab1b-fd9e-4faf-8ebe-e2e5499139f8>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/21c7c5ab-8de0-4f14-8127-15c9e70d65b4>,
+                        <http://data.lblod.info/id/contact-punten/4d14800a-3de4-492f-8072-81120f21ac49>.
+
+      <http://data.lblod.info/id/contact-punten/21c7c5ab-8de0-4f14-8127-15c9e70d65b4> a <http://schema.org/ContactPoint>;
+        mu:uuid "21c7c5ab-8de0-4f14-8127-15c9e70d65b4";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/4d14800a-3de4-492f-8072-81120f21ac49> a <http://schema.org/ContactPoint>;
+        mu:uuid "4d14800a-3de4-492f-8072-81120f21ac49";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/7deaab1b-fd9e-4faf-8ebe-e2e5499139f8> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "7deaab1b-fd9e-4faf-8ebe-e2e5499139f8".
+
+      <http://data.lblod.info/id/bestuurseenheden/1bbd0f7a-664c-46bd-8ca0-891801b81962> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "1bbd0f7a-664c-46bd-8ca0-891801b81962" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "Zorgbedrijf Sint-Truiden" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/5bb7ca67-2d30-4e4d-8a24-ca9b7ff29f17> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/9c1dcb9a-41e0-4e6c-a867-cc3f74d77862> .
+
+      <http://data.lblod.info/id/identificatoren/552a1fd8-214c-43c0-9d11-33718772ec05> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "552a1fd8-214c-43c0-9d11-33718772ec05" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/7d12d16a-6954-4748-8ed7-c975e1f53878> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/7d12d16a-6954-4748-8ed7-c975e1f53878> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "7d12d16a-6954-4748-8ed7-c975e1f53878" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/7d12d16a-6954-4748-8ed7-c975e1f53878> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1043" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/d00dc86b-28fa-4472-b17d-6239e8eb5600> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "d00dc86b-28fa-4472-b17d-6239e8eb5600";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/b0683ef2-828c-489a-b2cb-eac42c601628>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/1c231309-534d-43df-adcb-8c34fb02ab5f>,
+                        <http://data.lblod.info/id/contact-punten/2c2c2199-36e0-4c4f-85ce-3c5d9f794c50>.
+
+      <http://data.lblod.info/id/contact-punten/1c231309-534d-43df-adcb-8c34fb02ab5f> a <http://schema.org/ContactPoint>;
+        mu:uuid "1c231309-534d-43df-adcb-8c34fb02ab5f";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/2c2c2199-36e0-4c4f-85ce-3c5d9f794c50> a <http://schema.org/ContactPoint>;
+        mu:uuid "2c2c2199-36e0-4c4f-85ce-3c5d9f794c50";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/b0683ef2-828c-489a-b2cb-eac42c601628> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "b0683ef2-828c-489a-b2cb-eac42c601628".
+
+      <http://data.lblod.info/id/bestuurseenheden/559066ee63a3bbb4dbcaac93d9da15d9e81891e17e8a1d104a5ed356daa4aca4> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "559066ee63a3bbb4dbcaac93d9da15d9e81891e17e8a1d104a5ed356daa4aca4" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "Zorgvereniging OPcura" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/552a1fd8-214c-43c0-9d11-33718772ec05> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/d00dc86b-28fa-4472-b17d-6239e8eb5600> .
+
+      <http://data.lblod.info/id/identificatoren/3f46e4f7-6e5e-496f-aca9-23186abe0efa> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "3f46e4f7-6e5e-496f-aca9-23186abe0efa" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/4990d869-be6f-4227-bf11-b03a5afac268> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/4990d869-be6f-4227-bf11-b03a5afac268> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "4990d869-be6f-4227-bf11-b03a5afac268" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/4990d869-be6f-4227-bf11-b03a5afac268> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1045" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/50073e7a-ba02-486d-880b-8913af004c9f> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "50073e7a-ba02-486d-880b-8913af004c9f";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/8831322e-b68b-4588-8a66-a0760746cd8f>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/874a17ac-4d14-4065-b38f-8140e91518c3>,
+                        <http://data.lblod.info/id/contact-punten/35f02526-a8b0-4b55-b2df-77dcd7a2b68c>.
+
+      <http://data.lblod.info/id/contact-punten/874a17ac-4d14-4065-b38f-8140e91518c3> a <http://schema.org/ContactPoint>;
+        mu:uuid "874a17ac-4d14-4065-b38f-8140e91518c3";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/35f02526-a8b0-4b55-b2df-77dcd7a2b68c> a <http://schema.org/ContactPoint>;
+        mu:uuid "35f02526-a8b0-4b55-b2df-77dcd7a2b68c";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/8831322e-b68b-4588-8a66-a0760746cd8f> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "8831322e-b68b-4588-8a66-a0760746cd8f".
+
+      <http://data.lblod.info/id/bestuurseenheden/8d71b78b3048c4062561b199811a6de7d49c8553c794b6cc62a565e683681ed4> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "8d71b78b3048c4062561b199811a6de7d49c8553c794b6cc62a565e683681ed4" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "Zorg Houthalen-Helchteren" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/3f46e4f7-6e5e-496f-aca9-23186abe0efa> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/50073e7a-ba02-486d-880b-8913af004c9f> .
+
+      <http://data.lblod.info/id/identificatoren/6e62c312-f20f-45dd-ae5c-c9730d68b38d> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "6e62c312-f20f-45dd-ae5c-c9730d68b38d" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/d53b0de5-4fd7-4914-8ed9-cf1a6748f1ad> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/d53b0de5-4fd7-4914-8ed9-cf1a6748f1ad> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "d53b0de5-4fd7-4914-8ed9-cf1a6748f1ad" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/d53b0de5-4fd7-4914-8ed9-cf1a6748f1ad> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "854" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/d3ed7991-d213-43a6-8f1a-68d380e3e178> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "d3ed7991-d213-43a6-8f1a-68d380e3e178";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/9258ab7b-e7c8-4014-a9fa-e0c661b151b2>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/8fc93d00-5739-4a5a-8cb2-ac5c0c1b388f>,
+                        <http://data.lblod.info/id/contact-punten/1754c0eb-bec1-478b-95a9-6396cc3ccaa6>.
+
+      <http://data.lblod.info/id/contact-punten/8fc93d00-5739-4a5a-8cb2-ac5c0c1b388f> a <http://schema.org/ContactPoint>;
+        mu:uuid "8fc93d00-5739-4a5a-8cb2-ac5c0c1b388f";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/1754c0eb-bec1-478b-95a9-6396cc3ccaa6> a <http://schema.org/ContactPoint>;
+        mu:uuid "1754c0eb-bec1-478b-95a9-6396cc3ccaa6";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/9258ab7b-e7c8-4014-a9fa-e0c661b151b2> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "9258ab7b-e7c8-4014-a9fa-e0c661b151b2".
+
+      <http://data.lblod.info/id/bestuurseenheden/c11ca390da51a65c5e328cd219eb91f5a657bba3d0f47cf995039dbfb1c64105> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "c11ca390da51a65c5e328cd219eb91f5a657bba3d0f47cf995039dbfb1c64105" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "W13" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/6e62c312-f20f-45dd-ae5c-c9730d68b38d> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/d3ed7991-d213-43a6-8f1a-68d380e3e178> .
+
+      <http://data.lblod.info/id/identificatoren/1387bf46-921d-4ce9-9439-41477f62629c> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "1387bf46-921d-4ce9-9439-41477f62629c" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/fb44d755-0b15-4afa-98e4-09887e0cf6d5> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/fb44d755-0b15-4afa-98e4-09887e0cf6d5> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "fb44d755-0b15-4afa-98e4-09887e0cf6d5" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/fb44d755-0b15-4afa-98e4-09887e0cf6d5> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "832" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/6c2734bc-fc7a-407e-ad10-ea2869f79352> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "6c2734bc-fc7a-407e-ad10-ea2869f79352";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/7beb70dd-9c0d-468e-9165-0203f8aadac6>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/c59010fc-1ec7-429f-8dd8-f30c880a8900>,
+                        <http://data.lblod.info/id/contact-punten/9cf7cc20-5406-48aa-a174-8bb403e1ed76>.
+
+      <http://data.lblod.info/id/contact-punten/c59010fc-1ec7-429f-8dd8-f30c880a8900> a <http://schema.org/ContactPoint>;
+        mu:uuid "c59010fc-1ec7-429f-8dd8-f30c880a8900";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/9cf7cc20-5406-48aa-a174-8bb403e1ed76> a <http://schema.org/ContactPoint>;
+        mu:uuid "9cf7cc20-5406-48aa-a174-8bb403e1ed76";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/7beb70dd-9c0d-468e-9165-0203f8aadac6> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "7beb70dd-9c0d-468e-9165-0203f8aadac6".
+
+      <http://data.lblod.info/id/bestuurseenheden/68cf1a248013d8921af92322a077e2c74988889defdfea0cc0d467eddf3baf1f> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "68cf1a248013d8921af92322a077e2c74988889defdfea0cc0d467eddf3baf1f" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "Welzijnsband Meetjesland" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/1387bf46-921d-4ce9-9439-41477f62629c> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/6c2734bc-fc7a-407e-ad10-ea2869f79352> .
+
+      <http://data.lblod.info/id/identificatoren/f43c3cd6-b80c-4a27-8086-9075f23e6e3e> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "f43c3cd6-b80c-4a27-8086-9075f23e6e3e" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/1bfce8a9-22cd-48af-9eac-04582984fabf> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/1bfce8a9-22cd-48af-9eac-04582984fabf> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "1bfce8a9-22cd-48af-9eac-04582984fabf" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/1bfce8a9-22cd-48af-9eac-04582984fabf> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1030" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/b66c2dfd-92aa-4e23-b1b0-67e74f48c036> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "b66c2dfd-92aa-4e23-b1b0-67e74f48c036";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/ea81a09c-40f4-4225-99e8-9e21be3f2f4e>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/996ff725-9db2-4092-b5d7-1cc192248ce6>,
+                        <http://data.lblod.info/id/contact-punten/12fec191-d4bc-4223-8aef-67c0c9c85fb5>.
+
+      <http://data.lblod.info/id/contact-punten/996ff725-9db2-4092-b5d7-1cc192248ce6> a <http://schema.org/ContactPoint>;
+        mu:uuid "996ff725-9db2-4092-b5d7-1cc192248ce6";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/12fec191-d4bc-4223-8aef-67c0c9c85fb5> a <http://schema.org/ContactPoint>;
+        mu:uuid "12fec191-d4bc-4223-8aef-67c0c9c85fb5";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/ea81a09c-40f4-4225-99e8-9e21be3f2f4e> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "ea81a09c-40f4-4225-99e8-9e21be3f2f4e".
+
+      <http://data.lblod.info/id/bestuurseenheden/12b3670c672298b9f906f60433ab945a8c8cd2ef8e4b5f922d1fb284da18cd73> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "12b3670c672298b9f906f60433ab945a8c8cd2ef8e4b5f922d1fb284da18cd73" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "Zorgbedrijf Rivierenland" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/f43c3cd6-b80c-4a27-8086-9075f23e6e3e> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/b66c2dfd-92aa-4e23-b1b0-67e74f48c036> .
+
+      <http://data.lblod.info/id/identificatoren/3ff756f2-dec7-4353-98ba-e5b2f6caf4a8> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "3ff756f2-dec7-4353-98ba-e5b2f6caf4a8" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/1732a958-a4cd-44a3-a115-bcbace65fa49> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/1732a958-a4cd-44a3-a115-bcbace65fa49> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "1732a958-a4cd-44a3-a115-bcbace65fa49" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/1732a958-a4cd-44a3-a115-bcbace65fa49> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1173" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/357df00b-9583-4864-9e3f-fa8e2e45aa38> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "357df00b-9583-4864-9e3f-fa8e2e45aa38";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/fe20051b-4ade-404a-a4fd-905d70203b9c>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/cf4d8d27-9cdf-46c6-81d1-9e6a8d1a58b4>,
+                        <http://data.lblod.info/id/contact-punten/e0af4998-ee00-4782-ad42-e38377ff25ff>.
+
+      <http://data.lblod.info/id/contact-punten/cf4d8d27-9cdf-46c6-81d1-9e6a8d1a58b4> a <http://schema.org/ContactPoint>;
+        mu:uuid "cf4d8d27-9cdf-46c6-81d1-9e6a8d1a58b4";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/e0af4998-ee00-4782-ad42-e38377ff25ff> a <http://schema.org/ContactPoint>;
+        mu:uuid "e0af4998-ee00-4782-ad42-e38377ff25ff";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/fe20051b-4ade-404a-a4fd-905d70203b9c> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "fe20051b-4ade-404a-a4fd-905d70203b9c".
+
+      <http://data.lblod.info/id/bestuurseenheden/10ce9d34-953b-4096-9c09-575426b12acc> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "10ce9d34-953b-4096-9c09-575426b12acc" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "Zorgband Leie en Schelde" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/3ff756f2-dec7-4353-98ba-e5b2f6caf4a8> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/357df00b-9583-4864-9e3f-fa8e2e45aa38> .
+
+      <http://data.lblod.info/id/identificatoren/3937b345-be6f-48fc-b561-5134976e1f01> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "3937b345-be6f-48fc-b561-5134976e1f01" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/bbbcf104-6d4a-420f-ae99-188e636e76f7> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/bbbcf104-6d4a-420f-ae99-188e636e76f7> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "bbbcf104-6d4a-420f-ae99-188e636e76f7" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/bbbcf104-6d4a-420f-ae99-188e636e76f7> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1052" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/f7c39b40-6f37-45e1-91ae-1c9e9aa538a4> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "f7c39b40-6f37-45e1-91ae-1c9e9aa538a4";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/bbffb985-6d60-450d-b3dd-f3add187fd5b>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/b37bb034-c381-4850-bdf1-aa921fb67b86>,
+                        <http://data.lblod.info/id/contact-punten/9e90d715-6de4-4e4a-af12-c6a5011a3a85>.
+
+      <http://data.lblod.info/id/contact-punten/b37bb034-c381-4850-bdf1-aa921fb67b86> a <http://schema.org/ContactPoint>;
+        mu:uuid "b37bb034-c381-4850-bdf1-aa921fb67b86";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/9e90d715-6de4-4e4a-af12-c6a5011a3a85> a <http://schema.org/ContactPoint>;
+        mu:uuid "9e90d715-6de4-4e4a-af12-c6a5011a3a85";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/bbffb985-6d60-450d-b3dd-f3add187fd5b> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "bbffb985-6d60-450d-b3dd-f3add187fd5b".
+
+      <http://data.lblod.info/id/bestuurseenheden/4b114b8e-11c5-4bc8-a3c2-4f5f05d7f430> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "4b114b8e-11c5-4bc8-a3c2-4f5f05d7f430" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "Zorgbedrijf Vilvoorde" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/3937b345-be6f-48fc-b561-5134976e1f01> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/f7c39b40-6f37-45e1-91ae-1c9e9aa538a4> .
+
+      <http://data.lblod.info/id/identificatoren/aca5035f-27b9-400c-894b-7a963255a6c4> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "aca5035f-27b9-400c-894b-7a963255a6c4" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/2fe4ff2c-282e-4ef2-8816-2809618857b1> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/2fe4ff2c-282e-4ef2-8816-2809618857b1> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "2fe4ff2c-282e-4ef2-8816-2809618857b1" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/2fe4ff2c-282e-4ef2-8816-2809618857b1> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1379" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/d9610229-8b0b-4949-b93b-50547a0c6d06> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "d9610229-8b0b-4949-b93b-50547a0c6d06";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/47357c21-ae30-4dbd-8edc-0484ad732186>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/dd05ba71-6519-412c-b33e-e308f501e41b>,
+                        <http://data.lblod.info/id/contact-punten/ac4a3a9c-1957-4f5f-aaf4-8b3002f3470b>.
+
+      <http://data.lblod.info/id/contact-punten/dd05ba71-6519-412c-b33e-e308f501e41b> a <http://schema.org/ContactPoint>;
+        mu:uuid "dd05ba71-6519-412c-b33e-e308f501e41b";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/ac4a3a9c-1957-4f5f-aaf4-8b3002f3470b> a <http://schema.org/ContactPoint>;
+        mu:uuid "ac4a3a9c-1957-4f5f-aaf4-8b3002f3470b";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/47357c21-ae30-4dbd-8edc-0484ad732186> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "47357c21-ae30-4dbd-8edc-0484ad732186".
+
+      <http://data.lblod.info/id/bestuurseenheden/cce1926b-51ff-4b66-a702-ea985f1d250b> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "cce1926b-51ff-4b66-a702-ea985f1d250b" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/34b5af85-dc9f-468f-9e03-ef89b174c267> ;
+        skos:prefLabel  "A.S.Z. Autonome Verzorgingsinstelling" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/aca5035f-27b9-400c-894b-7a963255a6c4> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/d9610229-8b0b-4949-b93b-50547a0c6d06> .
+
+      <http://data.lblod.info/id/identificatoren/84e6ba2e-fd32-4b8c-a93c-6dd038c3c5b5> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "84e6ba2e-fd32-4b8c-a93c-6dd038c3c5b5" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/e2e866af-7626-4816-85d5-8b06105b2adc> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/e2e866af-7626-4816-85d5-8b06105b2adc> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "e2e866af-7626-4816-85d5-8b06105b2adc" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/e2e866af-7626-4816-85d5-8b06105b2adc> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1381" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/fc791a58-b974-4a09-896b-025fe3d2f620> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "fc791a58-b974-4a09-896b-025fe3d2f620";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/ad8006cc-75f3-4b0d-885c-a150ceb4e03e>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/5daff073-ed67-4288-b0e1-4e19c88592ec>,
+                        <http://data.lblod.info/id/contact-punten/210ebd0e-b921-4e79-964f-b5f433216ded>.
+
+      <http://data.lblod.info/id/contact-punten/5daff073-ed67-4288-b0e1-4e19c88592ec> a <http://schema.org/ContactPoint>;
+        mu:uuid "5daff073-ed67-4288-b0e1-4e19c88592ec";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/210ebd0e-b921-4e79-964f-b5f433216ded> a <http://schema.org/ContactPoint>;
+        mu:uuid "210ebd0e-b921-4e79-964f-b5f433216ded";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/ad8006cc-75f3-4b0d-885c-a150ceb4e03e> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "ad8006cc-75f3-4b0d-885c-a150ceb4e03e".
+
+      <http://data.lblod.info/id/bestuurseenheden/fd9abc2a-e346-4bf4-bbfa-e1bba880e2b9> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "fd9abc2a-e346-4bf4-bbfa-e1bba880e2b9" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/34b5af85-dc9f-468f-9e03-ef89b174c267> ;
+        skos:prefLabel  "AZ Lokeren AV" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/84e6ba2e-fd32-4b8c-a93c-6dd038c3c5b5> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/fc791a58-b974-4a09-896b-025fe3d2f620> .
+
+      <http://data.lblod.info/id/identificatoren/392b9c7e-df28-4b54-bb8c-80532234a1e7> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "392b9c7e-df28-4b54-bb8c-80532234a1e7" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/b14fee42-38e1-48af-ac9b-cbe3c488062c> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/b14fee42-38e1-48af-ac9b-cbe3c488062c> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "b14fee42-38e1-48af-ac9b-cbe3c488062c" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/b14fee42-38e1-48af-ac9b-cbe3c488062c> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1368" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/526aed69-7e2e-42a2-9c5f-0dccc3b076b0> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "526aed69-7e2e-42a2-9c5f-0dccc3b076b0";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/f064247b-b44c-41af-9f7c-20ed412ef52c>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/c96c69ce-58b5-46c6-ad0a-545b45850fe1>,
+                        <http://data.lblod.info/id/contact-punten/587a2416-d8e9-421e-97d7-8b67047d84b4>.
+
+      <http://data.lblod.info/id/contact-punten/c96c69ce-58b5-46c6-ad0a-545b45850fe1> a <http://schema.org/ContactPoint>;
+        mu:uuid "c96c69ce-58b5-46c6-ad0a-545b45850fe1";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/587a2416-d8e9-421e-97d7-8b67047d84b4> a <http://schema.org/ContactPoint>;
+        mu:uuid "587a2416-d8e9-421e-97d7-8b67047d84b4";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/f064247b-b44c-41af-9f7c-20ed412ef52c> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "f064247b-b44c-41af-9f7c-20ed412ef52c".
+
+      <http://data.lblod.info/id/bestuurseenheden/c83586e7-9818-4be5-ab24-5e9dcd9b21fd> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "c83586e7-9818-4be5-ab24-5e9dcd9b21fd" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/34b5af85-dc9f-468f-9e03-ef89b174c267> ;
+        skos:prefLabel  "Algemeen Ziekenhuis Vesalius" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/392b9c7e-df28-4b54-bb8c-80532234a1e7> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/526aed69-7e2e-42a2-9c5f-0dccc3b076b0> .
+
+      <http://data.lblod.info/id/identificatoren/f4202aec-a81e-4cc7-9b3f-c7561b4a02ca> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "f4202aec-a81e-4cc7-9b3f-c7561b4a02ca" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/8d94f796-ec04-4c02-b900-0399f67ba9bd> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/8d94f796-ec04-4c02-b900-0399f67ba9bd> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "8d94f796-ec04-4c02-b900-0399f67ba9bd" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/8d94f796-ec04-4c02-b900-0399f67ba9bd> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1374" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/420ed363-ac87-4c50-84ce-bba2d50c0ee8> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "420ed363-ac87-4c50-84ce-bba2d50c0ee8";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/a02964c4-a48e-4a30-8548-0f24fc0fc2d2>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/152a8e31-b1b2-4639-9a6c-d5ccdab1c8f9>,
+                        <http://data.lblod.info/id/contact-punten/37cf08ec-54b6-42fc-b975-1d5dddbe73e6>.
+
+      <http://data.lblod.info/id/contact-punten/152a8e31-b1b2-4639-9a6c-d5ccdab1c8f9> a <http://schema.org/ContactPoint>;
+        mu:uuid "152a8e31-b1b2-4639-9a6c-d5ccdab1c8f9";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/37cf08ec-54b6-42fc-b975-1d5dddbe73e6> a <http://schema.org/ContactPoint>;
+        mu:uuid "37cf08ec-54b6-42fc-b975-1d5dddbe73e6";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/a02964c4-a48e-4a30-8548-0f24fc0fc2d2> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "a02964c4-a48e-4a30-8548-0f24fc0fc2d2".
+
+      <http://data.lblod.info/id/bestuurseenheden/b7abada470cd56a64d67b5450b35c3e96c07ce5d752d6207d4886ccc8f4852ff> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "b7abada470cd56a64d67b5450b35c3e96c07ce5d752d6207d4886ccc8f4852ff" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/34b5af85-dc9f-468f-9e03-ef89b174c267> ;
+        skos:prefLabel  "AZ Sint-Jan Brugge - Oostende A.V." ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/f4202aec-a81e-4cc7-9b3f-c7561b4a02ca> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/420ed363-ac87-4c50-84ce-bba2d50c0ee8> .
+
+      <http://data.lblod.info/id/identificatoren/9ceab27e-d5c0-4656-9c2e-8dcdfbe31400> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "9ceab27e-d5c0-4656-9c2e-8dcdfbe31400" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/83b57a04-9e10-490c-bec0-3d52c209f3bb> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/83b57a04-9e10-490c-bec0-3d52c209f3bb> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "83b57a04-9e10-490c-bec0-3d52c209f3bb" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/83b57a04-9e10-490c-bec0-3d52c209f3bb> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1378" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/644a2aa8-edec-4a29-b7c4-2b19f018d8fa> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "644a2aa8-edec-4a29-b7c4-2b19f018d8fa";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/9f00f24b-7090-42e6-bf48-0b96f8475c66>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/01a26584-96bc-4e9c-b485-750d3744f547>,
+                        <http://data.lblod.info/id/contact-punten/d2e27199-2e44-42ac-8385-a0ab87b13146>.
+
+      <http://data.lblod.info/id/contact-punten/01a26584-96bc-4e9c-b485-750d3744f547> a <http://schema.org/ContactPoint>;
+        mu:uuid "01a26584-96bc-4e9c-b485-750d3744f547";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/d2e27199-2e44-42ac-8385-a0ab87b13146> a <http://schema.org/ContactPoint>;
+        mu:uuid "d2e27199-2e44-42ac-8385-a0ab87b13146";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/9f00f24b-7090-42e6-bf48-0b96f8475c66> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "9f00f24b-7090-42e6-bf48-0b96f8475c66".
+
+      <http://data.lblod.info/id/bestuurseenheden/251143c6-2094-4ad5-8b54-26cfded0082a> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "251143c6-2094-4ad5-8b54-26cfded0082a" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/34b5af85-dc9f-468f-9e03-ef89b174c267> ;
+        skos:prefLabel  "AV Henri Serruysziekenhuis" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/9ceab27e-d5c0-4656-9c2e-8dcdfbe31400> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/644a2aa8-edec-4a29-b7c4-2b19f018d8fa> .
+
+      <http://data.lblod.info/id/identificatoren/a35ed698-a6f5-4dda-90a9-0e5435694e0c> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "a35ed698-a6f5-4dda-90a9-0e5435694e0c" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/b3a0e9ab-36ee-4cd3-a85a-6a68d3fa7fb5> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/b3a0e9ab-36ee-4cd3-a85a-6a68d3fa7fb5> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "b3a0e9ab-36ee-4cd3-a85a-6a68d3fa7fb5" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/b3a0e9ab-36ee-4cd3-a85a-6a68d3fa7fb5> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "834" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/64eac79d-7663-4eec-bfdc-755284c3c050> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "64eac79d-7663-4eec-bfdc-755284c3c050";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/dab6c686-87cd-4371-b170-b77f7f4127fc>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/7fbe31b9-27d9-4c02-b0ac-3cfa06e77fda>,
+                        <http://data.lblod.info/id/contact-punten/0f5518e9-08e3-4064-be70-4e1f0ded5f0d>.
+
+      <http://data.lblod.info/id/contact-punten/7fbe31b9-27d9-4c02-b0ac-3cfa06e77fda> a <http://schema.org/ContactPoint>;
+        mu:uuid "7fbe31b9-27d9-4c02-b0ac-3cfa06e77fda";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/0f5518e9-08e3-4064-be70-4e1f0ded5f0d> a <http://schema.org/ContactPoint>;
+        mu:uuid "0f5518e9-08e3-4064-be70-4e1f0ded5f0d";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/dab6c686-87cd-4371-b170-b77f7f4127fc> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "dab6c686-87cd-4371-b170-b77f7f4127fc".
+
+      <http://data.lblod.info/id/bestuurseenheden/67d72f2e178c4adbd0567865d611248403aecae0e505fbb30d3c932a634c0d2a> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "67d72f2e178c4adbd0567865d611248403aecae0e505fbb30d3c932a634c0d2a" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "SVK Leie en Schelde" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/a35ed698-a6f5-4dda-90a9-0e5435694e0c> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/64eac79d-7663-4eec-bfdc-755284c3c050> .
+
+      <http://data.lblod.info/id/identificatoren/4e13ea20-3121-4299-b3f8-2d2a589b8bb3> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "4e13ea20-3121-4299-b3f8-2d2a589b8bb3" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/898115a9-8f00-45d7-9cf2-5d82fc9ab449> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/898115a9-8f00-45d7-9cf2-5d82fc9ab449> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "898115a9-8f00-45d7-9cf2-5d82fc9ab449" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/898115a9-8f00-45d7-9cf2-5d82fc9ab449> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "833" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/679e1724-f858-4875-bac2-e5b1b5eb5e28> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "679e1724-f858-4875-bac2-e5b1b5eb5e28";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/76eece1a-f06b-4997-9af1-8f4f4ad48e3d>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/10177f1a-9f7c-4f3c-8fea-8ff8f00fd901>,
+                        <http://data.lblod.info/id/contact-punten/733fca61-557d-4afd-b772-fcf81310122f>.
+
+      <http://data.lblod.info/id/contact-punten/10177f1a-9f7c-4f3c-8fea-8ff8f00fd901> a <http://schema.org/ContactPoint>;
+        mu:uuid "10177f1a-9f7c-4f3c-8fea-8ff8f00fd901";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/733fca61-557d-4afd-b772-fcf81310122f> a <http://schema.org/ContactPoint>;
+        mu:uuid "733fca61-557d-4afd-b772-fcf81310122f";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/76eece1a-f06b-4997-9af1-8f4f4ad48e3d> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "76eece1a-f06b-4997-9af1-8f4f4ad48e3d".
+
+      <http://data.lblod.info/id/bestuurseenheden/f7ec3b8b3f74b7656c1769b7b1ec7641e12fe8fcf64564ce0a204e30df498907> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "f7ec3b8b3f74b7656c1769b7b1ec7641e12fe8fcf64564ce0a204e30df498907" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "Zorgbedrijf Meetjesland" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/4e13ea20-3121-4299-b3f8-2d2a589b8bb3> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/679e1724-f858-4875-bac2-e5b1b5eb5e28> .
+
+      <http://data.lblod.info/id/identificatoren/8d393777-b962-44dd-a0bc-643e9d701880> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "8d393777-b962-44dd-a0bc-643e9d701880" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/acb378c8-f954-43f8-9acc-f0e82856e88b> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/acb378c8-f954-43f8-9acc-f0e82856e88b> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "acb378c8-f954-43f8-9acc-f0e82856e88b" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/acb378c8-f954-43f8-9acc-f0e82856e88b> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1383" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/3e702bcd-1080-4391-9af1-8cf6d6431a83> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "3e702bcd-1080-4391-9af1-8cf6d6431a83";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/7fe3fa23-943c-436c-90f8-9edccafa1c67>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/e984b3ce-8d06-4841-9c8d-0738ec1c458a>,
+                        <http://data.lblod.info/id/contact-punten/b02bd7f8-6797-400a-ab76-0ae425208080>.
+
+      <http://data.lblod.info/id/contact-punten/e984b3ce-8d06-4841-9c8d-0738ec1c458a> a <http://schema.org/ContactPoint>;
+        mu:uuid "e984b3ce-8d06-4841-9c8d-0738ec1c458a";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/b02bd7f8-6797-400a-ab76-0ae425208080> a <http://schema.org/ContactPoint>;
+        mu:uuid "b02bd7f8-6797-400a-ab76-0ae425208080";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/7fe3fa23-943c-436c-90f8-9edccafa1c67> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "7fe3fa23-943c-436c-90f8-9edccafa1c67".
+
+      <http://data.lblod.info/id/bestuurseenheden/749bbdaf-dd7a-45e1-8f2e-98b8834bc295> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "749bbdaf-dd7a-45e1-8f2e-98b8834bc295" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "Vereniging Onze-Lieve-Vrouweziekenhuis (afgekort WV OLV-ZH)" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/8d393777-b962-44dd-a0bc-643e9d701880> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/3e702bcd-1080-4391-9af1-8cf6d6431a83> .
+
+      <http://data.lblod.info/id/identificatoren/6f842792-f904-4aac-8a68-bf496403198d> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "6f842792-f904-4aac-8a68-bf496403198d" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/3f508a8a-0131-4340-9015-0519de1982f8> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/3f508a8a-0131-4340-9015-0519de1982f8> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "3f508a8a-0131-4340-9015-0519de1982f8" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/3f508a8a-0131-4340-9015-0519de1982f8> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "858" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/3428471c-ff94-493e-8228-0196b4b28c70> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "3428471c-ff94-493e-8228-0196b4b28c70";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/8b0b0a66-6bbb-457c-9f55-03e6a178934a>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/05b4670a-4670-4b44-905b-42c9c7d280b2>,
+                        <http://data.lblod.info/id/contact-punten/15d6d098-6e03-4d18-8a35-e6f9a3a8e966>.
+
+      <http://data.lblod.info/id/contact-punten/05b4670a-4670-4b44-905b-42c9c7d280b2> a <http://schema.org/ContactPoint>;
+        mu:uuid "05b4670a-4670-4b44-905b-42c9c7d280b2";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/15d6d098-6e03-4d18-8a35-e6f9a3a8e966> a <http://schema.org/ContactPoint>;
+        mu:uuid "15d6d098-6e03-4d18-8a35-e6f9a3a8e966";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/8b0b0a66-6bbb-457c-9f55-03e6a178934a> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "8b0b0a66-6bbb-457c-9f55-03e6a178934a".
+
+      <http://data.lblod.info/id/bestuurseenheden/fd620aa85d002529d17747ee2a7350d97633144386c273a53a2ac742367b2b09> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "fd620aa85d002529d17747ee2a7350d97633144386c273a53a2ac742367b2b09" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "Motena" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/6f842792-f904-4aac-8a68-bf496403198d> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/3428471c-ff94-493e-8228-0196b4b28c70> .
+
+      <http://data.lblod.info/id/identificatoren/2cba48dc-c9c2-4a72-b5ea-f82465673476> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "2cba48dc-c9c2-4a72-b5ea-f82465673476" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/c8b57ef7-62bf-42d4-8b2e-d759c5366236> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/c8b57ef7-62bf-42d4-8b2e-d759c5366236> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "c8b57ef7-62bf-42d4-8b2e-d759c5366236" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/c8b57ef7-62bf-42d4-8b2e-d759c5366236> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1372" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/3bfbc6c4-64fd-4006-8ade-8f16b1ef09ca> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "3bfbc6c4-64fd-4006-8ade-8f16b1ef09ca";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/ddec4243-da50-4c7b-a4cd-457899ca4b95>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/fdc32173-5634-4f64-841b-f1b31a8deb53>,
+                        <http://data.lblod.info/id/contact-punten/7774d6cb-e41f-4c92-a53d-957861157c3e>.
+
+      <http://data.lblod.info/id/contact-punten/fdc32173-5634-4f64-841b-f1b31a8deb53> a <http://schema.org/ContactPoint>;
+        mu:uuid "fdc32173-5634-4f64-841b-f1b31a8deb53";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/7774d6cb-e41f-4c92-a53d-957861157c3e> a <http://schema.org/ContactPoint>;
+        mu:uuid "7774d6cb-e41f-4c92-a53d-957861157c3e";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/ddec4243-da50-4c7b-a4cd-457899ca4b95> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "ddec4243-da50-4c7b-a4cd-457899ca4b95".
+
+      <http://data.lblod.info/id/bestuurseenheden/47ac33b7-9321-432c-8ba8-1d284f04addf> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "47ac33b7-9321-432c-8ba8-1d284f04addf" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/34b5af85-dc9f-468f-9e03-ef89b174c267> ;
+        skos:prefLabel  "Algemeen Ziekenhuis Jan Palfijn Gent" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/2cba48dc-c9c2-4a72-b5ea-f82465673476> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/3bfbc6c4-64fd-4006-8ade-8f16b1ef09ca> .
+
+      <http://data.lblod.info/id/identificatoren/b866524d-ae95-4ef4-9b72-eb64a28e1713> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "b866524d-ae95-4ef4-9b72-eb64a28e1713" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/44ecaa43-5007-45b1-874d-44e245145f65> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/44ecaa43-5007-45b1-874d-44e245145f65> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "44ecaa43-5007-45b1-874d-44e245145f65" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/44ecaa43-5007-45b1-874d-44e245145f65> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1033" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/5d6349af-74fb-4a1f-a35b-be9e2b9d6b94> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "5d6349af-74fb-4a1f-a35b-be9e2b9d6b94";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/0a99799b-8c4a-4f57-aebe-e6376207aeb2>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/ee707118-57f3-4853-b200-29552355b961>,
+                        <http://data.lblod.info/id/contact-punten/5db103d0-ede8-499d-8e9d-f4cb1f4fd933>.
+
+      <http://data.lblod.info/id/contact-punten/ee707118-57f3-4853-b200-29552355b961> a <http://schema.org/ContactPoint>;
+        mu:uuid "ee707118-57f3-4853-b200-29552355b961";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/5db103d0-ede8-499d-8e9d-f4cb1f4fd933> a <http://schema.org/ContactPoint>;
+        mu:uuid "5db103d0-ede8-499d-8e9d-f4cb1f4fd933";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/0a99799b-8c4a-4f57-aebe-e6376207aeb2> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "0a99799b-8c4a-4f57-aebe-e6376207aeb2".
+
+      <http://data.lblod.info/id/bestuurseenheden/005f263d440315a440c47a34fddec33b7745836d64fe0b033fc82957285e838b> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "005f263d440315a440c47a34fddec33b7745836d64fe0b033fc82957285e838b" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "Mintus (Zorgvereniging Brugge)" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/b866524d-ae95-4ef4-9b72-eb64a28e1713> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/5d6349af-74fb-4a1f-a35b-be9e2b9d6b94> .
+
+      <http://data.lblod.info/id/identificatoren/28a7bd19-b171-4fbc-8b83-499868767190> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "28a7bd19-b171-4fbc-8b83-499868767190" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/f70d8213-8330-4231-9e48-bacf1928e38f> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/f70d8213-8330-4231-9e48-bacf1928e38f> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "f70d8213-8330-4231-9e48-bacf1928e38f" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/f70d8213-8330-4231-9e48-bacf1928e38f> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "824" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/6b462edb-3e31-4e48-bc3c-f321e7e264d0> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "6b462edb-3e31-4e48-bc3c-f321e7e264d0";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/1351cf27-2e2e-404b-a940-0506fcbc89f9>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/afd14b76-7b8a-4f81-a7ef-05a3aae06ffa>,
+                        <http://data.lblod.info/id/contact-punten/6330638a-a5db-4137-8185-57a70bcc6431>.
+
+      <http://data.lblod.info/id/contact-punten/afd14b76-7b8a-4f81-a7ef-05a3aae06ffa> a <http://schema.org/ContactPoint>;
+        mu:uuid "afd14b76-7b8a-4f81-a7ef-05a3aae06ffa";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/6330638a-a5db-4137-8185-57a70bcc6431> a <http://schema.org/ContactPoint>;
+        mu:uuid "6330638a-a5db-4137-8185-57a70bcc6431";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/1351cf27-2e2e-404b-a940-0506fcbc89f9> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "1351cf27-2e2e-404b-a940-0506fcbc89f9".
+
+      <http://data.lblod.info/id/bestuurseenheden/a9b3046e-331e-4668-b5cc-2da7bb09e354> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "a9b3046e-331e-4668-b5cc-2da7bb09e354" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "KINA (Regionaal Instituut voor Dringende Hulpverlening Krisisinfo-Netwerk-Antwerpen)" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/28a7bd19-b171-4fbc-8b83-499868767190> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/6b462edb-3e31-4e48-bc3c-f321e7e264d0> .
+
+      <http://data.lblod.info/id/identificatoren/e2b9bfba-78b6-46e7-8bd7-302e066a210b> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "e2b9bfba-78b6-46e7-8bd7-302e066a210b" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/e4468d66-e3a4-4332-b3b2-35ccda23402e> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/e4468d66-e3a4-4332-b3b2-35ccda23402e> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "e4468d66-e3a4-4332-b3b2-35ccda23402e" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/e4468d66-e3a4-4332-b3b2-35ccda23402e> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "827" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/aaaacaa5-2384-4570-a9db-6ddc7a16a9ed> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "aaaacaa5-2384-4570-a9db-6ddc7a16a9ed";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/b40c17c3-a709-4e4e-aaac-9d5d064f762b>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/9c09e431-bc7f-4e00-b27c-4ecf78a4de3d>,
+                        <http://data.lblod.info/id/contact-punten/171fefde-ecd4-4ef1-8aa4-5a2ec18cf194>.
+
+      <http://data.lblod.info/id/contact-punten/9c09e431-bc7f-4e00-b27c-4ecf78a4de3d> a <http://schema.org/ContactPoint>;
+        mu:uuid "9c09e431-bc7f-4e00-b27c-4ecf78a4de3d";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/171fefde-ecd4-4ef1-8aa4-5a2ec18cf194> a <http://schema.org/ContactPoint>;
+        mu:uuid "171fefde-ecd4-4ef1-8aa4-5a2ec18cf194";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/b40c17c3-a709-4e4e-aaac-9d5d064f762b> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "b40c17c3-a709-4e4e-aaac-9d5d064f762b".
+
+      <http://data.lblod.info/id/bestuurseenheden/6c4179a4684d97c148da2e78ba99579e4145412c6431e1577713e5f095ff4f08> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "6c4179a4684d97c148da2e78ba99579e4145412c6431e1577713e5f095ff4f08" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "Zorggroep Orion" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/e2b9bfba-78b6-46e7-8bd7-302e066a210b> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/aaaacaa5-2384-4570-a9db-6ddc7a16a9ed> .
+
+      <http://data.lblod.info/id/identificatoren/81d731ce-5956-46e8-841b-cc1a6533f435> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "81d731ce-5956-46e8-841b-cc1a6533f435" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/105ffb45-165d-4475-80b2-0c2bc9d11a72> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/105ffb45-165d-4475-80b2-0c2bc9d11a72> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "105ffb45-165d-4475-80b2-0c2bc9d11a72" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/105ffb45-165d-4475-80b2-0c2bc9d11a72> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "835" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/a8608787-b5f2-47ac-a6c9-91aa08ffd7c8> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "a8608787-b5f2-47ac-a6c9-91aa08ffd7c8";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/0f537145-dfe8-4c57-8376-a0b8dd986617>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/c2b49c41-a344-43b4-8e28-471770a9d3af>,
+                        <http://data.lblod.info/id/contact-punten/5f8d18a1-96f7-4b3f-9a3e-9447ea690fab>.
+
+      <http://data.lblod.info/id/contact-punten/c2b49c41-a344-43b4-8e28-471770a9d3af> a <http://schema.org/ContactPoint>;
+        mu:uuid "c2b49c41-a344-43b4-8e28-471770a9d3af";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/5f8d18a1-96f7-4b3f-9a3e-9447ea690fab> a <http://schema.org/ContactPoint>;
+        mu:uuid "5f8d18a1-96f7-4b3f-9a3e-9447ea690fab";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/0f537145-dfe8-4c57-8376-a0b8dd986617> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "0f537145-dfe8-4c57-8376-a0b8dd986617".
+
+      <http://data.lblod.info/id/bestuurseenheden/2176cd7bde027a98b1d3c2f81862327cb8b3fa0df3757ed432371530e743ad5b> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "2176cd7bde027a98b1d3c2f81862327cb8b3fa0df3757ed432371530e743ad5b" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "Sociaal Verhuurkantoor Gent" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/81d731ce-5956-46e8-841b-cc1a6533f435> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/a8608787-b5f2-47ac-a6c9-91aa08ffd7c8> .
+
+      <http://data.lblod.info/id/identificatoren/ee9fbca6-c52d-4d61-a233-1ba88e6ee6dd> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "ee9fbca6-c52d-4d61-a233-1ba88e6ee6dd" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/e6d5ab1f-ed7e-4dff-819d-5c50d3f967bf> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/e6d5ab1f-ed7e-4dff-819d-5c50d3f967bf> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "e6d5ab1f-ed7e-4dff-819d-5c50d3f967bf" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/e6d5ab1f-ed7e-4dff-819d-5c50d3f967bf> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1380" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/5f31f547-bcbe-4fdc-b9c2-71fc12cc13c1> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "5f31f547-bcbe-4fdc-b9c2-71fc12cc13c1";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/4b0a814a-a0d4-4dd8-95a3-1121371928f2>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/bc82224a-02e8-4611-91ad-236644047e8d>,
+                        <http://data.lblod.info/id/contact-punten/b842d15e-579d-4b11-9144-f1d0e57c0fb5>.
+
+      <http://data.lblod.info/id/contact-punten/bc82224a-02e8-4611-91ad-236644047e8d> a <http://schema.org/ContactPoint>;
+        mu:uuid "bc82224a-02e8-4611-91ad-236644047e8d";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/b842d15e-579d-4b11-9144-f1d0e57c0fb5> a <http://schema.org/ContactPoint>;
+        mu:uuid "b842d15e-579d-4b11-9144-f1d0e57c0fb5";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/4b0a814a-a0d4-4dd8-95a3-1121371928f2> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "4b0a814a-a0d4-4dd8-95a3-1121371928f2".
+
+      <http://data.lblod.info/id/bestuurseenheden/50ede269-5c49-41cd-be68-ac135314019c> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "50ede269-5c49-41cd-be68-ac135314019c" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/34b5af85-dc9f-468f-9e03-ef89b174c267> ;
+        skos:prefLabel  "Algemeen Ziekenhuis Sint-Dimpna" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/ee9fbca6-c52d-4d61-a233-1ba88e6ee6dd> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/5f31f547-bcbe-4fdc-b9c2-71fc12cc13c1> .
+
+      <http://data.lblod.info/id/identificatoren/c2f40a7c-cd4e-40a4-92a8-539e1477f686> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "c2f40a7c-cd4e-40a4-92a8-539e1477f686" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/7e3b7f3b-f359-4016-b205-f94cf576ef9e> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/7e3b7f3b-f359-4016-b205-f94cf576ef9e> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "7e3b7f3b-f359-4016-b205-f94cf576ef9e" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/7e3b7f3b-f359-4016-b205-f94cf576ef9e> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "848" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/9ed7881d-873c-41c8-90d4-e92471609095> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "9ed7881d-873c-41c8-90d4-e92471609095";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/62d70c0c-2974-46d0-a17c-5fc83036e859>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/a6dc8891-aec4-4d42-812e-d8aa85ceb096>,
+                        <http://data.lblod.info/id/contact-punten/bea0027d-8bd2-4a8e-9941-0e64a108f4bd>.
+
+      <http://data.lblod.info/id/contact-punten/a6dc8891-aec4-4d42-812e-d8aa85ceb096> a <http://schema.org/ContactPoint>;
+        mu:uuid "a6dc8891-aec4-4d42-812e-d8aa85ceb096";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/bea0027d-8bd2-4a8e-9941-0e64a108f4bd> a <http://schema.org/ContactPoint>;
+        mu:uuid "bea0027d-8bd2-4a8e-9941-0e64a108f4bd";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/62d70c0c-2974-46d0-a17c-5fc83036e859> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "62d70c0c-2974-46d0-a17c-5fc83036e859".
+
+      <http://data.lblod.info/id/bestuurseenheden/84ccc300d580fb3de6b36fab26524b43da45e7213d205b57b9db715dc24d35f3> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "84ccc300d580fb3de6b36fab26524b43da45e7213d205b57b9db715dc24d35f3" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "Vereniging 't Sas" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/c2f40a7c-cd4e-40a4-92a8-539e1477f686> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/9ed7881d-873c-41c8-90d4-e92471609095> .
+
+      <http://data.lblod.info/id/identificatoren/79e66de1-5fae-4054-bf7a-c931c3b5a6f5> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "79e66de1-5fae-4054-bf7a-c931c3b5a6f5" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/d3461742-87ed-40de-80b5-22f328a9e166> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/d3461742-87ed-40de-80b5-22f328a9e166> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "d3461742-87ed-40de-80b5-22f328a9e166" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/d3461742-87ed-40de-80b5-22f328a9e166> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "842" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/f32f2da7-cacf-4002-b2ca-4f522ebb9f57> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "f32f2da7-cacf-4002-b2ca-4f522ebb9f57";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/eef9aebf-3311-43f8-aa04-3c2c259c5071>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/2e3a9ef0-48ea-4043-ab6c-debb472f88b9>,
+                        <http://data.lblod.info/id/contact-punten/af935b66-dfc9-46e2-9cd7-cf3f2cab3637>.
+
+      <http://data.lblod.info/id/contact-punten/2e3a9ef0-48ea-4043-ab6c-debb472f88b9> a <http://schema.org/ContactPoint>;
+        mu:uuid "2e3a9ef0-48ea-4043-ab6c-debb472f88b9";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/af935b66-dfc9-46e2-9cd7-cf3f2cab3637> a <http://schema.org/ContactPoint>;
+        mu:uuid "af935b66-dfc9-46e2-9cd7-cf3f2cab3637";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/eef9aebf-3311-43f8-aa04-3c2c259c5071> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "eef9aebf-3311-43f8-aa04-3c2c259c5071".
+
+      <http://data.lblod.info/id/bestuurseenheden/4f452f5ad74a9cf4c6af447cb07157d8dad793abecff39729d7ab2eb582ec290> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "4f452f5ad74a9cf4c6af447cb07157d8dad793abecff39729d7ab2eb582ec290" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "vereniging voor Samenwerking rond Preventie in het kader van Opvoeding en Onderwijs Regio Brugge (SPOOR)" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/79e66de1-5fae-4054-bf7a-c931c3b5a6f5> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/f32f2da7-cacf-4002-b2ca-4f522ebb9f57> .
+
+      <http://data.lblod.info/id/identificatoren/9a7e0329-0ea4-4e08-a21f-eeb2bc257d71> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "9a7e0329-0ea4-4e08-a21f-eeb2bc257d71" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/5cce5ce2-cbfd-4485-b4da-b6e58817963b> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/5cce5ce2-cbfd-4485-b4da-b6e58817963b> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "5cce5ce2-cbfd-4485-b4da-b6e58817963b" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/5cce5ce2-cbfd-4485-b4da-b6e58817963b> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "828" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/65e0dd26-4a6e-45bf-8cd2-b9024cba5271> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "65e0dd26-4a6e-45bf-8cd2-b9024cba5271";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/75cb0db8-3010-4761-b9da-7cbbebe6b73b>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/827fe69a-a437-452c-b21e-f955d9acadae>,
+                        <http://data.lblod.info/id/contact-punten/8ec537f7-34ae-4c44-a76e-cd6f2e3a3037>.
+
+      <http://data.lblod.info/id/contact-punten/827fe69a-a437-452c-b21e-f955d9acadae> a <http://schema.org/ContactPoint>;
+        mu:uuid "827fe69a-a437-452c-b21e-f955d9acadae";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/8ec537f7-34ae-4c44-a76e-cd6f2e3a3037> a <http://schema.org/ContactPoint>;
+        mu:uuid "8ec537f7-34ae-4c44-a76e-cd6f2e3a3037";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/75cb0db8-3010-4761-b9da-7cbbebe6b73b> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "75cb0db8-3010-4761-b9da-7cbbebe6b73b".
+
+      <http://data.lblod.info/id/bestuurseenheden/2bf97f7faebd616265d004a80cce0319a110319197b657d5a0a1a16d81f34ca2> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "2bf97f7faebd616265d004a80cce0319a110319197b657d5a0a1a16d81f34ca2" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "Welzijnszorg Kempen" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/9a7e0329-0ea4-4e08-a21f-eeb2bc257d71> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/65e0dd26-4a6e-45bf-8cd2-b9024cba5271> .
+
+      <http://data.lblod.info/id/identificatoren/05fc35fa-c5af-4361-a27e-ac32128ea05f> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "05fc35fa-c5af-4361-a27e-ac32128ea05f" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/b934f18d-d177-4e45-b0fd-5a20e1a2c182> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/b934f18d-d177-4e45-b0fd-5a20e1a2c182> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "b934f18d-d177-4e45-b0fd-5a20e1a2c182" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/b934f18d-d177-4e45-b0fd-5a20e1a2c182> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "846" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/3957dc82-ade6-40ec-8476-24241825190c> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "3957dc82-ade6-40ec-8476-24241825190c";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/a52e2d15-8a41-45db-8c88-fed36d0d2234>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/ab6c5db7-04e7-4e10-b3b3-8ed1f128d3a9>,
+                        <http://data.lblod.info/id/contact-punten/235406e9-5aa7-4f63-b156-bd54c49010b7>.
+
+      <http://data.lblod.info/id/contact-punten/ab6c5db7-04e7-4e10-b3b3-8ed1f128d3a9> a <http://schema.org/ContactPoint>;
+        mu:uuid "ab6c5db7-04e7-4e10-b3b3-8ed1f128d3a9";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/235406e9-5aa7-4f63-b156-bd54c49010b7> a <http://schema.org/ContactPoint>;
+        mu:uuid "235406e9-5aa7-4f63-b156-bd54c49010b7";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/a52e2d15-8a41-45db-8c88-fed36d0d2234> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "a52e2d15-8a41-45db-8c88-fed36d0d2234".
+
+      <http://data.lblod.info/id/bestuurseenheden/6af38a22fcba9d1701a77d9c869e0f06e11a3291a71a4118a7cd93629ba92c27> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "6af38a22fcba9d1701a77d9c869e0f06e11a3291a71a4118a7cd93629ba92c27" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "Ruddersstove" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/05fc35fa-c5af-4361-a27e-ac32128ea05f> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/3957dc82-ade6-40ec-8476-24241825190c> .
+
+      <http://data.lblod.info/id/identificatoren/652a188b-a565-4a84-bfc4-5484b2f77195> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "652a188b-a565-4a84-bfc4-5484b2f77195" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/51dd47fc-e803-426b-81ba-e44ca7fcabb7> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/51dd47fc-e803-426b-81ba-e44ca7fcabb7> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "51dd47fc-e803-426b-81ba-e44ca7fcabb7" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/51dd47fc-e803-426b-81ba-e44ca7fcabb7> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "844" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/03e7f945-46bb-4a09-a975-f850f6ccf4e1> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "03e7f945-46bb-4a09-a975-f850f6ccf4e1";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/ebb3ab0a-aaa4-47c4-8fbf-0c9449e1ba68>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/fe213a68-adaa-4595-9061-f2016acc18d1>,
+                        <http://data.lblod.info/id/contact-punten/f855d748-4471-41bc-bc01-fcac6c12e188>.
+
+      <http://data.lblod.info/id/contact-punten/fe213a68-adaa-4595-9061-f2016acc18d1> a <http://schema.org/ContactPoint>;
+        mu:uuid "fe213a68-adaa-4595-9061-f2016acc18d1";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/f855d748-4471-41bc-bc01-fcac6c12e188> a <http://schema.org/ContactPoint>;
+        mu:uuid "f855d748-4471-41bc-bc01-fcac6c12e188";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/ebb3ab0a-aaa4-47c4-8fbf-0c9449e1ba68> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "ebb3ab0a-aaa4-47c4-8fbf-0c9449e1ba68".
+
+      <http://data.lblod.info/id/bestuurseenheden/079159c373e29e05221c4338a2440e4f58ddababa1d8f94dedf792b5414baf61> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "079159c373e29e05221c4338a2440e4f58ddababa1d8f94dedf792b5414baf61" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "De Blauwe Lelie" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/652a188b-a565-4a84-bfc4-5484b2f77195> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/03e7f945-46bb-4a09-a975-f850f6ccf4e1> .
+
+      <http://data.lblod.info/id/identificatoren/0604b23a-766e-4234-aece-81d06aad7960> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "0604b23a-766e-4234-aece-81d06aad7960" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/b26f0039-9adc-43fa-823b-679f937c49eb> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/b26f0039-9adc-43fa-823b-679f937c49eb> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "b26f0039-9adc-43fa-823b-679f937c49eb" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/b26f0039-9adc-43fa-823b-679f937c49eb> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "841" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/c82b1018-0c31-4be7-8414-af3d19d3d1aa> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "c82b1018-0c31-4be7-8414-af3d19d3d1aa";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/6f91b88d-68c6-40c8-9770-8257e63334a8>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/df6e14f9-7101-4937-b17b-9f321a5474ae>,
+                        <http://data.lblod.info/id/contact-punten/2f0de614-0690-450e-a260-8f71017d41a7>.
+
+      <http://data.lblod.info/id/contact-punten/df6e14f9-7101-4937-b17b-9f321a5474ae> a <http://schema.org/ContactPoint>;
+        mu:uuid "df6e14f9-7101-4937-b17b-9f321a5474ae";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/2f0de614-0690-450e-a260-8f71017d41a7> a <http://schema.org/ContactPoint>;
+        mu:uuid "2f0de614-0690-450e-a260-8f71017d41a7";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/6f91b88d-68c6-40c8-9770-8257e63334a8> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "6f91b88d-68c6-40c8-9770-8257e63334a8".
+
+      <http://data.lblod.info/id/bestuurseenheden/265f6bcddea9c9e994472376c40bd5591df678ab9fdba41d5d65933467d83f59> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "265f6bcddea9c9e994472376c40bd5591df678ab9fdba41d5d65933467d83f59" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "De Schakelaar" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/0604b23a-766e-4234-aece-81d06aad7960> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/c82b1018-0c31-4be7-8414-af3d19d3d1aa> .
+
+      <http://data.lblod.info/id/identificatoren/0846feb8-a414-4eaa-b5b3-53cc7c092899> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "0846feb8-a414-4eaa-b5b3-53cc7c092899" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/8f0d2800-0733-4141-a216-f95d6447871a> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/8f0d2800-0733-4141-a216-f95d6447871a> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "8f0d2800-0733-4141-a216-f95d6447871a" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/8f0d2800-0733-4141-a216-f95d6447871a> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "849" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/53363afc-7acf-4f64-b642-6ff4045a66e2> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "53363afc-7acf-4f64-b642-6ff4045a66e2";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/8f19c558-93bb-4776-89f2-590ddac2c170>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/713758a5-1ddb-4773-aece-ed43a816a6fd>,
+                        <http://data.lblod.info/id/contact-punten/394f2195-23e8-4d68-b2b5-603fab920144>.
+
+      <http://data.lblod.info/id/contact-punten/713758a5-1ddb-4773-aece-ed43a816a6fd> a <http://schema.org/ContactPoint>;
+        mu:uuid "713758a5-1ddb-4773-aece-ed43a816a6fd";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/394f2195-23e8-4d68-b2b5-603fab920144> a <http://schema.org/ContactPoint>;
+        mu:uuid "394f2195-23e8-4d68-b2b5-603fab920144";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/8f19c558-93bb-4776-89f2-590ddac2c170> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "8f19c558-93bb-4776-89f2-590ddac2c170".
+
+      <http://data.lblod.info/id/bestuurseenheden/e2dfbd3a56dd87414968d7454dcfde193145e331ddcfc86fb48a9c79b5c0cef3> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "e2dfbd3a56dd87414968d7454dcfde193145e331ddcfc86fb48a9c79b5c0cef3" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "Vereniging Wok Brugge" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/0846feb8-a414-4eaa-b5b3-53cc7c092899> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/53363afc-7acf-4f64-b642-6ff4045a66e2> .
+
+      <http://data.lblod.info/id/identificatoren/9526495f-5977-472a-9331-ae48369e72fd> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "9526495f-5977-472a-9331-ae48369e72fd" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/d50c72f3-bc99-42fb-9220-5d6b328d1266> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/d50c72f3-bc99-42fb-9220-5d6b328d1266> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "d50c72f3-bc99-42fb-9220-5d6b328d1266" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/d50c72f3-bc99-42fb-9220-5d6b328d1266> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "847" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/5ab828f6-bf1c-4a34-a2a8-92d5c30069c4> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "5ab828f6-bf1c-4a34-a2a8-92d5c30069c4";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/186264dd-36c4-4150-be13-b784f8cf07e5>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/d038d369-775c-45cc-8cbe-70e3d4b0ddd4>,
+                        <http://data.lblod.info/id/contact-punten/6e27b942-45bb-4180-bf9e-18875f5134be>.
+
+      <http://data.lblod.info/id/contact-punten/d038d369-775c-45cc-8cbe-70e3d4b0ddd4> a <http://schema.org/ContactPoint>;
+        mu:uuid "d038d369-775c-45cc-8cbe-70e3d4b0ddd4";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/6e27b942-45bb-4180-bf9e-18875f5134be> a <http://schema.org/ContactPoint>;
+        mu:uuid "6e27b942-45bb-4180-bf9e-18875f5134be";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/186264dd-36c4-4150-be13-b784f8cf07e5> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "186264dd-36c4-4150-be13-b784f8cf07e5".
+
+      <http://data.lblod.info/id/bestuurseenheden/e7ff93ecd6ec0ad906e179e3ccb1cea698e30013e888fa28c725b272beef3b99> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "e7ff93ecd6ec0ad906e179e3ccb1cea698e30013e888fa28c725b272beef3b99" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "SVK Brugge" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/9526495f-5977-472a-9331-ae48369e72fd> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/5ab828f6-bf1c-4a34-a2a8-92d5c30069c4> .
+
+      <http://data.lblod.info/id/identificatoren/322583e9-ff14-4852-a1c2-1bdf3d6111d0> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "322583e9-ff14-4852-a1c2-1bdf3d6111d0" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/c020513b-b825-4318-b702-e9e70d18cfe3> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/c020513b-b825-4318-b702-e9e70d18cfe3> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "c020513b-b825-4318-b702-e9e70d18cfe3" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/c020513b-b825-4318-b702-e9e70d18cfe3> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1015" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/941c855b-e2be-4368-a936-3eaa997021ba> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "941c855b-e2be-4368-a936-3eaa997021ba";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/fede82ce-06dc-40d2-b648-78ca8388bd03>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/80fe54f5-29d2-431a-85a1-653c22c34725>,
+                        <http://data.lblod.info/id/contact-punten/cbdb7cf5-ee71-46b9-b27e-6c133625e73b>.
+
+      <http://data.lblod.info/id/contact-punten/80fe54f5-29d2-431a-85a1-653c22c34725> a <http://schema.org/ContactPoint>;
+        mu:uuid "80fe54f5-29d2-431a-85a1-653c22c34725";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/cbdb7cf5-ee71-46b9-b27e-6c133625e73b> a <http://schema.org/ContactPoint>;
+        mu:uuid "cbdb7cf5-ee71-46b9-b27e-6c133625e73b";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/fede82ce-06dc-40d2-b648-78ca8388bd03> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "fede82ce-06dc-40d2-b648-78ca8388bd03".
+
+      <http://data.lblod.info/id/bestuurseenheden/5567394c206a8da9fe1e8ab4dc1d043eabdb5915ecf3d06a9495dc64cc3c691e> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "5567394c206a8da9fe1e8ab4dc1d043eabdb5915ecf3d06a9495dc64cc3c691e" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "Welzijnsvereniging Weldenderend" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/322583e9-ff14-4852-a1c2-1bdf3d6111d0> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/941c855b-e2be-4368-a936-3eaa997021ba> .
+
+      <http://data.lblod.info/id/identificatoren/9a17737e-15eb-46b6-8fc0-66f68f6be88d> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "9a17737e-15eb-46b6-8fc0-66f68f6be88d" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/9865fc81-e448-448d-ab83-0e2e01b5cea7> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/9865fc81-e448-448d-ab83-0e2e01b5cea7> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "9865fc81-e448-448d-ab83-0e2e01b5cea7" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/9865fc81-e448-448d-ab83-0e2e01b5cea7> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "852" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/49641d8a-4283-4558-b6e6-c797cbbc778a> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "49641d8a-4283-4558-b6e6-c797cbbc778a";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/9d38f818-aabc-474a-9183-4393f36b2fed>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/73ccd06c-7fdd-4cb2-8892-310d1b524a0b>,
+                        <http://data.lblod.info/id/contact-punten/9343db4a-d8f5-4cb9-bb55-128a485018f4>.
+
+      <http://data.lblod.info/id/contact-punten/73ccd06c-7fdd-4cb2-8892-310d1b524a0b> a <http://schema.org/ContactPoint>;
+        mu:uuid "73ccd06c-7fdd-4cb2-8892-310d1b524a0b";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/9343db4a-d8f5-4cb9-bb55-128a485018f4> a <http://schema.org/ContactPoint>;
+        mu:uuid "9343db4a-d8f5-4cb9-bb55-128a485018f4";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/9d38f818-aabc-474a-9183-4393f36b2fed> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "9d38f818-aabc-474a-9183-4393f36b2fed".
+
+      <http://data.lblod.info/id/bestuurseenheden/c4486571e2cf6a0656e29a47a3f210cf9bf732876320953c5759aef27b639842> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "c4486571e2cf6a0656e29a47a3f210cf9bf732876320953c5759aef27b639842" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "Vereniging Ons Tehuis voor Zuid-West-Vlaanderen" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/9a17737e-15eb-46b6-8fc0-66f68f6be88d> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/49641d8a-4283-4558-b6e6-c797cbbc778a> .
+
+      <http://data.lblod.info/id/identificatoren/e4eaa981-a672-4c6a-b9d0-f1fbe4395fbd> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "e4eaa981-a672-4c6a-b9d0-f1fbe4395fbd" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/e1112705-3722-434a-81ef-686f9cf0391f> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/e1112705-3722-434a-81ef-686f9cf0391f> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "e1112705-3722-434a-81ef-686f9cf0391f" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/e1112705-3722-434a-81ef-686f9cf0391f> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1375" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/bd1a05b2-7b51-4654-b09b-a5054d2397fe> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "bd1a05b2-7b51-4654-b09b-a5054d2397fe";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/7b6dff2b-cbed-4da5-ae56-abe2a29b8101>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/d377fd35-bbd5-4206-8ccf-cb224021753b>,
+                        <http://data.lblod.info/id/contact-punten/de9c28ea-8bc0-49be-b98f-86558c92075e>.
+
+      <http://data.lblod.info/id/contact-punten/d377fd35-bbd5-4206-8ccf-cb224021753b> a <http://schema.org/ContactPoint>;
+        mu:uuid "d377fd35-bbd5-4206-8ccf-cb224021753b";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/de9c28ea-8bc0-49be-b98f-86558c92075e> a <http://schema.org/ContactPoint>;
+        mu:uuid "de9c28ea-8bc0-49be-b98f-86558c92075e";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/7b6dff2b-cbed-4da5-ae56-abe2a29b8101> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "7b6dff2b-cbed-4da5-ae56-abe2a29b8101".
+
+      <http://data.lblod.info/id/bestuurseenheden/4141ab8d-b1e1-4b38-832a-76b4dba20dc7> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "4141ab8d-b1e1-4b38-832a-76b4dba20dc7" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/34b5af85-dc9f-468f-9e03-ef89b174c267> ;
+        skos:prefLabel  "Autonome Verzorgingsinstelling Virga Jesseziekenhuis" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/e4eaa981-a672-4c6a-b9d0-f1fbe4395fbd> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/bd1a05b2-7b51-4654-b09b-a5054d2397fe> .
+
+      <http://data.lblod.info/id/identificatoren/d102dbe3-586d-46fa-93b1-96ed0d490acd> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "d102dbe3-586d-46fa-93b1-96ed0d490acd" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/1f5fd316-4448-40c1-bc1e-d5bdceee3071> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/1f5fd316-4448-40c1-bc1e-d5bdceee3071> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "1f5fd316-4448-40c1-bc1e-d5bdceee3071" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/1f5fd316-4448-40c1-bc1e-d5bdceee3071> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "822" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/ee7545fb-6deb-427a-b5a4-a312f5801312> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "ee7545fb-6deb-427a-b5a4-a312f5801312";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/abe69811-dd3a-4bad-ba44-7ec172a518b5>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/0568637e-70c1-4efc-ae13-0aeec33b4c4c>,
+                        <http://data.lblod.info/id/contact-punten/3a4b35fc-305f-462f-8ad8-44dc372ea3b1>.
+
+      <http://data.lblod.info/id/contact-punten/0568637e-70c1-4efc-ae13-0aeec33b4c4c> a <http://schema.org/ContactPoint>;
+        mu:uuid "0568637e-70c1-4efc-ae13-0aeec33b4c4c";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/3a4b35fc-305f-462f-8ad8-44dc372ea3b1> a <http://schema.org/ContactPoint>;
+        mu:uuid "3a4b35fc-305f-462f-8ad8-44dc372ea3b1";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/abe69811-dd3a-4bad-ba44-7ec172a518b5> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "abe69811-dd3a-4bad-ba44-7ec172a518b5".
+
+      <http://data.lblod.info/id/bestuurseenheden/0d30036b943b9b9c3ef70c7c0e59a2325fbe2c455021ddb07bee427f73efcef8> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "0d30036b943b9b9c3ef70c7c0e59a2325fbe2c455021ddb07bee427f73efcef8" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "Audio" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/d102dbe3-586d-46fa-93b1-96ed0d490acd> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/ee7545fb-6deb-427a-b5a4-a312f5801312> .
+
+      <http://data.lblod.info/id/identificatoren/e8ae01f1-3ef4-4a71-bff0-a5c0b704767c> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "e8ae01f1-3ef4-4a71-bff0-a5c0b704767c" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/648275d1-20bf-46cd-aa46-192f0ec86be9> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/648275d1-20bf-46cd-aa46-192f0ec86be9> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "648275d1-20bf-46cd-aa46-192f0ec86be9" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/648275d1-20bf-46cd-aa46-192f0ec86be9> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "819" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/b28af14a-7fea-4bfb-8c32-1470bc84989b> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "b28af14a-7fea-4bfb-8c32-1470bc84989b";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/b7c12552-4ad8-46b5-92a8-4c716488511b>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/33c98e05-7234-4117-9b95-83f8cc13949a>,
+                        <http://data.lblod.info/id/contact-punten/1fee47c3-05ac-461d-9b54-b1bfd92396e2>.
+
+      <http://data.lblod.info/id/contact-punten/33c98e05-7234-4117-9b95-83f8cc13949a> a <http://schema.org/ContactPoint>;
+        mu:uuid "33c98e05-7234-4117-9b95-83f8cc13949a";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/1fee47c3-05ac-461d-9b54-b1bfd92396e2> a <http://schema.org/ContactPoint>;
+        mu:uuid "1fee47c3-05ac-461d-9b54-b1bfd92396e2";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/b7c12552-4ad8-46b5-92a8-4c716488511b> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "b7c12552-4ad8-46b5-92a8-4c716488511b".
+
+      <http://data.lblod.info/id/bestuurseenheden/f3f1598c1a9fb9e3666a3001004e4bfdb028da702bb8755655c0946597bb8ea4> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "f3f1598c1a9fb9e3666a3001004e4bfdb028da702bb8755655c0946597bb8ea4" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "Beschut Wonen Antwerpen" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/e8ae01f1-3ef4-4a71-bff0-a5c0b704767c> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/b28af14a-7fea-4bfb-8c32-1470bc84989b> .
+
+      <http://data.lblod.info/id/identificatoren/5ed8216e-8778-488b-86f7-e36c329e391a> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "5ed8216e-8778-488b-86f7-e36c329e391a" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/7536e2c9-2b75-4c12-9c50-5334b2945b45> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/7536e2c9-2b75-4c12-9c50-5334b2945b45> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "7536e2c9-2b75-4c12-9c50-5334b2945b45" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/7536e2c9-2b75-4c12-9c50-5334b2945b45> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "823" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/b3008e75-6dc2-4ebf-ae25-b1ca619736de> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "b3008e75-6dc2-4ebf-ae25-b1ca619736de";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/d72edcde-8813-4951-ae11-3974a6ed538f>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/fe1cd62a-a9e0-459d-ac1b-55693255bee7>,
+                        <http://data.lblod.info/id/contact-punten/9c169574-e784-4535-bc5e-fff0c9d2e029>.
+
+      <http://data.lblod.info/id/contact-punten/fe1cd62a-a9e0-459d-ac1b-55693255bee7> a <http://schema.org/ContactPoint>;
+        mu:uuid "fe1cd62a-a9e0-459d-ac1b-55693255bee7";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/9c169574-e784-4535-bc5e-fff0c9d2e029> a <http://schema.org/ContactPoint>;
+        mu:uuid "9c169574-e784-4535-bc5e-fff0c9d2e029";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/d72edcde-8813-4951-ae11-3974a6ed538f> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "d72edcde-8813-4951-ae11-3974a6ed538f".
+
+      <http://data.lblod.info/id/bestuurseenheden/9f839b41d7dba917e53c483d35e693b2cefdb89a13a080faa762845af6a9a337> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "9f839b41d7dba917e53c483d35e693b2cefdb89a13a080faa762845af6a9a337" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "Het Eepos (Wonen voor volwassen personen met een handicap)" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/5ed8216e-8778-488b-86f7-e36c329e391a> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/b3008e75-6dc2-4ebf-ae25-b1ca619736de> .
+
+      <http://data.lblod.info/id/identificatoren/1cf29c4a-ab50-4502-9145-3782e344fa2a> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "1cf29c4a-ab50-4502-9145-3782e344fa2a" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/8ded69ca-7e39-44a1-95d2-3244567c9d51> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/8ded69ca-7e39-44a1-95d2-3244567c9d51> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "8ded69ca-7e39-44a1-95d2-3244567c9d51" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/8ded69ca-7e39-44a1-95d2-3244567c9d51> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "825" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/f9301713-5ded-425c-a648-da4cd6eb6bd4> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "f9301713-5ded-425c-a648-da4cd6eb6bd4";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/60fc606f-c7d7-466e-88ee-042231e9bfc1>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/f2250cee-f8cf-4c3b-8b68-0e5b6d0c3cb0>,
+                        <http://data.lblod.info/id/contact-punten/d38583b0-7014-4bd0-964f-26ff4614023c>.
+
+      <http://data.lblod.info/id/contact-punten/f2250cee-f8cf-4c3b-8b68-0e5b6d0c3cb0> a <http://schema.org/ContactPoint>;
+        mu:uuid "f2250cee-f8cf-4c3b-8b68-0e5b6d0c3cb0";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/d38583b0-7014-4bd0-964f-26ff4614023c> a <http://schema.org/ContactPoint>;
+        mu:uuid "d38583b0-7014-4bd0-964f-26ff4614023c";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/60fc606f-c7d7-466e-88ee-042231e9bfc1> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "60fc606f-c7d7-466e-88ee-042231e9bfc1".
+
+      <http://data.lblod.info/id/bestuurseenheden/5072fad918135764714007cea2f3573462199d6cbe7b96d6ac57d1c9b7bde399> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "5072fad918135764714007cea2f3573462199d6cbe7b96d6ac57d1c9b7bde399" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "DODOENS" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/1cf29c4a-ab50-4502-9145-3782e344fa2a> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/f9301713-5ded-425c-a648-da4cd6eb6bd4> .
+
+      <http://data.lblod.info/id/identificatoren/a0b26f05-6cb9-4cc8-bc3b-0d07707a1ae0> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "a0b26f05-6cb9-4cc8-bc3b-0d07707a1ae0" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/1bcc44b4-8b40-43cb-a299-54b59d9467ea> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/1bcc44b4-8b40-43cb-a299-54b59d9467ea> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "1bcc44b4-8b40-43cb-a299-54b59d9467ea" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/1bcc44b4-8b40-43cb-a299-54b59d9467ea> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "821" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/f6bb6398-ec25-4505-8313-84b77ba52dc5> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "f6bb6398-ec25-4505-8313-84b77ba52dc5";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/74f5f200-860a-45bd-8206-6ec132c362e2>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/177a6112-85cd-460e-b0b3-8e743ea7a0cc>,
+                        <http://data.lblod.info/id/contact-punten/90f35dea-e38f-4bba-9176-d464fe47616f>.
+
+      <http://data.lblod.info/id/contact-punten/177a6112-85cd-460e-b0b3-8e743ea7a0cc> a <http://schema.org/ContactPoint>;
+        mu:uuid "177a6112-85cd-460e-b0b3-8e743ea7a0cc";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/90f35dea-e38f-4bba-9176-d464fe47616f> a <http://schema.org/ContactPoint>;
+        mu:uuid "90f35dea-e38f-4bba-9176-d464fe47616f";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/74f5f200-860a-45bd-8206-6ec132c362e2> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "74f5f200-860a-45bd-8206-6ec132c362e2".
+
+      <http://data.lblod.info/id/bestuurseenheden/8cfb6e37e4259b79bffd9027e38e2a10397edf45084122f3939dd19ff378fe9c> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "8cfb6e37e4259b79bffd9027e38e2a10397edf45084122f3939dd19ff378fe9c" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "Zorgbedrijf Brasschaat" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/a0b26f05-6cb9-4cc8-bc3b-0d07707a1ae0> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/f6bb6398-ec25-4505-8313-84b77ba52dc5> .
+
+      <http://data.lblod.info/id/identificatoren/b4ebc9ba-57f7-41cc-8073-1aa981e0c4a9> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "b4ebc9ba-57f7-41cc-8073-1aa981e0c4a9" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/442bf2da-61da-416d-bfef-790132f384bc> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/442bf2da-61da-416d-bfef-790132f384bc> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "442bf2da-61da-416d-bfef-790132f384bc" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/442bf2da-61da-416d-bfef-790132f384bc> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "826" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/2d2eba20-8928-4f68-9eb2-a7d0fc051e5e> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "2d2eba20-8928-4f68-9eb2-a7d0fc051e5e";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/54081a5f-b6f5-4683-918f-bc85920d5c0d>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/c3acf561-68d4-46aa-89a9-d467bebc04d7>,
+                        <http://data.lblod.info/id/contact-punten/70f3744f-1218-4a9c-a06d-e67d82767da4>.
+
+      <http://data.lblod.info/id/contact-punten/c3acf561-68d4-46aa-89a9-d467bebc04d7> a <http://schema.org/ContactPoint>;
+        mu:uuid "c3acf561-68d4-46aa-89a9-d467bebc04d7";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/70f3744f-1218-4a9c-a06d-e67d82767da4> a <http://schema.org/ContactPoint>;
+        mu:uuid "70f3744f-1218-4a9c-a06d-e67d82767da4";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/54081a5f-b6f5-4683-918f-bc85920d5c0d> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "54081a5f-b6f5-4683-918f-bc85920d5c0d".
+
+      <http://data.lblod.info/id/bestuurseenheden/31db97c9dab7ed09b591d2f3c567d47f70a5fa66c9ce3b4b2aea1e71f1dc8e76> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "31db97c9dab7ed09b591d2f3c567d47f70a5fa66c9ce3b4b2aea1e71f1dc8e76" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "Zorgbedrijf Klein-Brabant" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/b4ebc9ba-57f7-41cc-8073-1aa981e0c4a9> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/2d2eba20-8928-4f68-9eb2-a7d0fc051e5e> .
+
+      <http://data.lblod.info/id/identificatoren/4a032d4f-3957-443d-980b-338018039887> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "4a032d4f-3957-443d-980b-338018039887" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/4bb5652e-9ab5-47e6-87cb-635adb95a30f> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/4bb5652e-9ab5-47e6-87cb-635adb95a30f> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "4bb5652e-9ab5-47e6-87cb-635adb95a30f" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/4bb5652e-9ab5-47e6-87cb-635adb95a30f> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "836" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/e882059c-f4a5-47b6-999c-3e616eff7e19> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "e882059c-f4a5-47b6-999c-3e616eff7e19";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/3e7d5097-be3c-4451-b0ea-a2c99d961aa3>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/ccfc1762-53ec-48a0-b8a4-ca6a7760a222>,
+                        <http://data.lblod.info/id/contact-punten/3fc9f34c-e254-428b-b712-f470e33c6915>.
+
+      <http://data.lblod.info/id/contact-punten/ccfc1762-53ec-48a0-b8a4-ca6a7760a222> a <http://schema.org/ContactPoint>;
+        mu:uuid "ccfc1762-53ec-48a0-b8a4-ca6a7760a222";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/3fc9f34c-e254-428b-b712-f470e33c6915> a <http://schema.org/ContactPoint>;
+        mu:uuid "3fc9f34c-e254-428b-b712-f470e33c6915";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/3e7d5097-be3c-4451-b0ea-a2c99d961aa3> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "3e7d5097-be3c-4451-b0ea-a2c99d961aa3".
+
+      <http://data.lblod.info/id/bestuurseenheden/ef67ec9cdeb835268fd4a6f554db25f1bbb081009fa136b597785853076ea937> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "ef67ec9cdeb835268fd4a6f554db25f1bbb081009fa136b597785853076ea937" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "OVERO Openbare Vereniging Ronse" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/4a032d4f-3957-443d-980b-338018039887> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/e882059c-f4a5-47b6-999c-3e616eff7e19> .
+
+      <http://data.lblod.info/id/identificatoren/01d22460-6ce2-4db7-aff8-e827ecdab52c> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "01d22460-6ce2-4db7-aff8-e827ecdab52c" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/c157e8b4-fde9-4222-aac8-e040e118d2c7> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/c157e8b4-fde9-4222-aac8-e040e118d2c7> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "c157e8b4-fde9-4222-aac8-e040e118d2c7" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/c157e8b4-fde9-4222-aac8-e040e118d2c7> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "831" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/c5b386e2-02ad-4fe5-ad09-85e6b69da348> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "c5b386e2-02ad-4fe5-ad09-85e6b69da348";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/babb8efd-e3ab-413d-b846-dc92e00911ca>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/d61cb257-bf9a-424d-9d99-9a389b16b505>,
+                        <http://data.lblod.info/id/contact-punten/545b73bd-ed73-4d9b-a778-b8691e5101aa>.
+
+      <http://data.lblod.info/id/contact-punten/d61cb257-bf9a-424d-9d99-9a389b16b505> a <http://schema.org/ContactPoint>;
+        mu:uuid "d61cb257-bf9a-424d-9d99-9a389b16b505";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/545b73bd-ed73-4d9b-a778-b8691e5101aa> a <http://schema.org/ContactPoint>;
+        mu:uuid "545b73bd-ed73-4d9b-a778-b8691e5101aa";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/babb8efd-e3ab-413d-b846-dc92e00911ca> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "babb8efd-e3ab-413d-b846-dc92e00911ca".
+
+      <http://data.lblod.info/id/bestuurseenheden/eb31eb0b167e34e43a47ba63cc7bfbbf8e13ce818ede2e7af7bd513b857c8751> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "eb31eb0b167e34e43a47ba63cc7bfbbf8e13ce818ede2e7af7bd513b857c8751" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "RVT Rusthuis Najaarszon" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/01d22460-6ce2-4db7-aff8-e827ecdab52c> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/c5b386e2-02ad-4fe5-ad09-85e6b69da348> .
+
+      <http://data.lblod.info/id/identificatoren/3cad9a6f-8ecc-4575-b2ed-e4d496891c8e> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "3cad9a6f-8ecc-4575-b2ed-e4d496891c8e" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/e62479e4-e276-4353-bf31-7a627ab76867> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/e62479e4-e276-4353-bf31-7a627ab76867> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "e62479e4-e276-4353-bf31-7a627ab76867" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/e62479e4-e276-4353-bf31-7a627ab76867> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "838" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/6da90278-7493-49fd-ae08-df5ba22106f2> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "6da90278-7493-49fd-ae08-df5ba22106f2";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/3366e670-7d1b-4a6d-8bf4-b09412a9dfc5>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/872bdfad-592b-43b5-bd95-a1201c8a37e8>,
+                        <http://data.lblod.info/id/contact-punten/f2e55ccc-eb86-4a26-83f4-4e6aa4e70765>.
+
+      <http://data.lblod.info/id/contact-punten/872bdfad-592b-43b5-bd95-a1201c8a37e8> a <http://schema.org/ContactPoint>;
+        mu:uuid "872bdfad-592b-43b5-bd95-a1201c8a37e8";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/f2e55ccc-eb86-4a26-83f4-4e6aa4e70765> a <http://schema.org/ContactPoint>;
+        mu:uuid "f2e55ccc-eb86-4a26-83f4-4e6aa4e70765";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/3366e670-7d1b-4a6d-8bf4-b09412a9dfc5> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "3366e670-7d1b-4a6d-8bf4-b09412a9dfc5".
+
+      <http://data.lblod.info/id/bestuurseenheden/c0a096f256810f9d51c21456d5ee5bc9a5a471f78c8c699cc58c60730d5b0dbe> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "c0a096f256810f9d51c21456d5ee5bc9a5a471f78c8c699cc58c60730d5b0dbe" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "Sociaal Verhuurkantoor Waasland" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/3cad9a6f-8ecc-4575-b2ed-e4d496891c8e> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/6da90278-7493-49fd-ae08-df5ba22106f2> .
+
+      <http://data.lblod.info/id/identificatoren/a47132c2-d012-4ce4-97d1-c791cf803f4e> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "a47132c2-d012-4ce4-97d1-c791cf803f4e" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/ec9b21d3-92f1-4eef-b9b7-06de614755a6> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/ec9b21d3-92f1-4eef-b9b7-06de614755a6> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "ec9b21d3-92f1-4eef-b9b7-06de614755a6" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/ec9b21d3-92f1-4eef-b9b7-06de614755a6> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1040" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/39ab21b2-49af-4c4d-8ff8-22a0a1c42f53> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "39ab21b2-49af-4c4d-8ff8-22a0a1c42f53";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/0a77e88d-9b3e-4329-a69c-420d12608916>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/a47ae453-571e-4777-af85-23a7a7d7e782>,
+                        <http://data.lblod.info/id/contact-punten/c6c4b3f1-e00e-4b4a-bb0f-4b23abfd0e24>.
+
+      <http://data.lblod.info/id/contact-punten/a47ae453-571e-4777-af85-23a7a7d7e782> a <http://schema.org/ContactPoint>;
+        mu:uuid "a47ae453-571e-4777-af85-23a7a7d7e782";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/c6c4b3f1-e00e-4b4a-bb0f-4b23abfd0e24> a <http://schema.org/ContactPoint>;
+        mu:uuid "c6c4b3f1-e00e-4b4a-bb0f-4b23abfd0e24";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/0a77e88d-9b3e-4329-a69c-420d12608916> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "0a77e88d-9b3e-4329-a69c-420d12608916".
+
+      <http://data.lblod.info/id/bestuurseenheden/27e7a364-fe11-4303-9a43-fc2e1a3510d7> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "27e7a364-fe11-4303-9a43-fc2e1a3510d7" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "Welzijnsvereniging Sint-Gillis-Waas" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/a47132c2-d012-4ce4-97d1-c791cf803f4e> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/39ab21b2-49af-4c4d-8ff8-22a0a1c42f53> .
+
+      <http://data.lblod.info/id/identificatoren/79ddd43d-1ae4-4d31-b965-2c40ef542a0c> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "79ddd43d-1ae4-4d31-b965-2c40ef542a0c" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/974197ef-bf59-4ab0-aadd-99495c698249> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/974197ef-bf59-4ab0-aadd-99495c698249> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "974197ef-bf59-4ab0-aadd-99495c698249" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/974197ef-bf59-4ab0-aadd-99495c698249> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1039" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/ced402e1-6fc5-4639-8aed-b7e78eb50fbe> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "ced402e1-6fc5-4639-8aed-b7e78eb50fbe";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/de07d8ff-e051-4aef-8099-679dad433cf2>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/adc4ed88-dc7e-451e-b8f3-8175f7f5850f>,
+                        <http://data.lblod.info/id/contact-punten/a30f073c-d032-48e4-81db-48b15191d639>.
+
+      <http://data.lblod.info/id/contact-punten/adc4ed88-dc7e-451e-b8f3-8175f7f5850f> a <http://schema.org/ContactPoint>;
+        mu:uuid "adc4ed88-dc7e-451e-b8f3-8175f7f5850f";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/a30f073c-d032-48e4-81db-48b15191d639> a <http://schema.org/ContactPoint>;
+        mu:uuid "a30f073c-d032-48e4-81db-48b15191d639";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/de07d8ff-e051-4aef-8099-679dad433cf2> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "de07d8ff-e051-4aef-8099-679dad433cf2".
+
+      <http://data.lblod.info/id/bestuurseenheden/ffec0b97d60ac685f8e95209fdbdee3ba0171511609d109d4252a34fc5bf4160> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "ffec0b97d60ac685f8e95209fdbdee3ba0171511609d109d4252a34fc5bf4160" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "Sakura" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/79ddd43d-1ae4-4d31-b965-2c40ef542a0c> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/ced402e1-6fc5-4639-8aed-b7e78eb50fbe> .
+
+      <http://data.lblod.info/id/identificatoren/646ba17b-b40c-4663-9410-2b9a6ea445e7> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "646ba17b-b40c-4663-9410-2b9a6ea445e7" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/fc2f0bde-639c-404f-a5e2-9acc6c20c9e7> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/fc2f0bde-639c-404f-a5e2-9acc6c20c9e7> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "fc2f0bde-639c-404f-a5e2-9acc6c20c9e7" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/fc2f0bde-639c-404f-a5e2-9acc6c20c9e7> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1051" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/a952fdf4-201a-41cc-ab1e-5286fc09c4b8> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "a952fdf4-201a-41cc-ab1e-5286fc09c4b8";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/7c9e815f-ba7a-4afa-b6e7-84f851dad7a2>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/dbec7872-1b03-4d19-af2d-5205396c8f78>,
+                        <http://data.lblod.info/id/contact-punten/e2ffda54-1c27-47c3-a496-b5f25863f8ed>.
+
+      <http://data.lblod.info/id/contact-punten/dbec7872-1b03-4d19-af2d-5205396c8f78> a <http://schema.org/ContactPoint>;
+        mu:uuid "dbec7872-1b03-4d19-af2d-5205396c8f78";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/e2ffda54-1c27-47c3-a496-b5f25863f8ed> a <http://schema.org/ContactPoint>;
+        mu:uuid "e2ffda54-1c27-47c3-a496-b5f25863f8ed";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/7c9e815f-ba7a-4afa-b6e7-84f851dad7a2> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "7c9e815f-ba7a-4afa-b6e7-84f851dad7a2".
+
+      <http://data.lblod.info/id/bestuurseenheden/d0ec3d07-a15c-4e04-bcbb-b05083262544> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "d0ec3d07-a15c-4e04-bcbb-b05083262544" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "Zorgpunt Waasland" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/646ba17b-b40c-4663-9410-2b9a6ea445e7> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/a952fdf4-201a-41cc-ab1e-5286fc09c4b8> .
+
+      <http://data.lblod.info/id/identificatoren/cda31585-d946-4942-aa32-a53afd084d5b> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "cda31585-d946-4942-aa32-a53afd084d5b" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/b6692f5f-e23e-4667-98fc-479b81679d3b> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/b6692f5f-e23e-4667-98fc-479b81679d3b> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "b6692f5f-e23e-4667-98fc-479b81679d3b" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/b6692f5f-e23e-4667-98fc-479b81679d3b> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1333" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/af3cb6e9-a970-4e11-9e46-0343319423f3> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "af3cb6e9-a970-4e11-9e46-0343319423f3";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/57d01e48-8e76-4e37-bc78-bc19dcbcaa9a>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/a8bb5eab-9c72-42b5-96c7-e593592c7700>,
+                        <http://data.lblod.info/id/contact-punten/25aa1f11-be57-46bc-b144-22b6336d347f>.
+
+      <http://data.lblod.info/id/contact-punten/a8bb5eab-9c72-42b5-96c7-e593592c7700> a <http://schema.org/ContactPoint>;
+        mu:uuid "a8bb5eab-9c72-42b5-96c7-e593592c7700";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/25aa1f11-be57-46bc-b144-22b6336d347f> a <http://schema.org/ContactPoint>;
+        mu:uuid "25aa1f11-be57-46bc-b144-22b6336d347f";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/57d01e48-8e76-4e37-bc78-bc19dcbcaa9a> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "57d01e48-8e76-4e37-bc78-bc19dcbcaa9a".
+
+      <http://data.lblod.info/id/bestuurseenheden/386f7c72-1c2b-49ea-b9fa-664abf86d15f> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "386f7c72-1c2b-49ea-b9fa-664abf86d15f" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/34b5af85-dc9f-468f-9e03-ef89b174c267> ;
+        skos:prefLabel  "A.V. Ziekenhuis Oost-Limburg ZOL" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/cda31585-d946-4942-aa32-a53afd084d5b> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/af3cb6e9-a970-4e11-9e46-0343319423f3> .
+
+      <http://data.lblod.info/id/identificatoren/9fe304ec-e732-4aed-88fc-767c51f52615> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "9fe304ec-e732-4aed-88fc-767c51f52615" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/8c4f6153-135a-4567-bdb9-294bf1ccffe3> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/8c4f6153-135a-4567-bdb9-294bf1ccffe3> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "8c4f6153-135a-4567-bdb9-294bf1ccffe3" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/8c4f6153-135a-4567-bdb9-294bf1ccffe3> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "829" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/e3b5d4cf-cd63-49d8-b58f-aa9fae5ab85d> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "e3b5d4cf-cd63-49d8-b58f-aa9fae5ab85d";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/d4ca5a19-f1f7-4552-9004-261b88f0480a>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/ac4df232-61a5-4b58-acde-cfd5642884ec>,
+                        <http://data.lblod.info/id/contact-punten/ea9555aa-090e-4408-89c1-24c8705f05aa>.
+
+      <http://data.lblod.info/id/contact-punten/ac4df232-61a5-4b58-acde-cfd5642884ec> a <http://schema.org/ContactPoint>;
+        mu:uuid "ac4df232-61a5-4b58-acde-cfd5642884ec";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/ea9555aa-090e-4408-89c1-24c8705f05aa> a <http://schema.org/ContactPoint>;
+        mu:uuid "ea9555aa-090e-4408-89c1-24c8705f05aa";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/d4ca5a19-f1f7-4552-9004-261b88f0480a> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "d4ca5a19-f1f7-4552-9004-261b88f0480a".
+
+      <http://data.lblod.info/id/bestuurseenheden/6d1c55e517fd1fdcae81e9f07f0875aa9c452bed279e635b94fbe00630e7ae73> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "6d1c55e517fd1fdcae81e9f07f0875aa9c452bed279e635b94fbe00630e7ae73" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "Zorgbedrijf Ouderenzorg Genk" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/9fe304ec-e732-4aed-88fc-767c51f52615> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/e3b5d4cf-cd63-49d8-b58f-aa9fae5ab85d> .
+
+      <http://data.lblod.info/id/identificatoren/63d10463-667a-4bed-9ee2-026a3f8a096a> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "63d10463-667a-4bed-9ee2-026a3f8a096a" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/f167cfa1-c042-499a-8f81-bd99363d2c7e> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/f167cfa1-c042-499a-8f81-bd99363d2c7e> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "f167cfa1-c042-499a-8f81-bd99363d2c7e" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/f167cfa1-c042-499a-8f81-bd99363d2c7e> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "840" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/d8338964-bbee-4839-a269-d04a5b6ea737> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "d8338964-bbee-4839-a269-d04a5b6ea737";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/16d7ebb5-6343-4f32-b21c-bcc3dd2bed68>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/7d6bc1f5-214a-44ec-a5e8-8384af70ebd4>,
+                        <http://data.lblod.info/id/contact-punten/18c4ceb0-ab0d-4e79-bae1-e023a7a6b177>.
+
+      <http://data.lblod.info/id/contact-punten/7d6bc1f5-214a-44ec-a5e8-8384af70ebd4> a <http://schema.org/ContactPoint>;
+        mu:uuid "7d6bc1f5-214a-44ec-a5e8-8384af70ebd4";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/18c4ceb0-ab0d-4e79-bae1-e023a7a6b177> a <http://schema.org/ContactPoint>;
+        mu:uuid "18c4ceb0-ab0d-4e79-bae1-e023a7a6b177";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/16d7ebb5-6343-4f32-b21c-bcc3dd2bed68> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "16d7ebb5-6343-4f32-b21c-bcc3dd2bed68".
+
+      <http://data.lblod.info/id/bestuurseenheden/507182a9d6532733ac375988f8288bd1f5fdc2cfb1bee374bb6f5046bf307d4d> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "507182a9d6532733ac375988f8288bd1f5fdc2cfb1bee374bb6f5046bf307d4d" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "Welzijnskoepel West-Brabant" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/63d10463-667a-4bed-9ee2-026a3f8a096a> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/d8338964-bbee-4839-a269-d04a5b6ea737> .
+
+      <http://data.lblod.info/id/identificatoren/927e05e1-1a22-4bdc-9916-24bcb895f620> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "927e05e1-1a22-4bdc-9916-24bcb895f620" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/9fe3e993-5097-44fa-aeef-30a12adac169> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/9fe3e993-5097-44fa-aeef-30a12adac169> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "9fe3e993-5097-44fa-aeef-30a12adac169" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/9fe3e993-5097-44fa-aeef-30a12adac169> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1330" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/d70222ab-f5a9-41be-b5be-0dd2aeba3d43> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "d70222ab-f5a9-41be-b5be-0dd2aeba3d43";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/7bb7b354-5319-4462-ac91-561cf540c10e>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/bf181d19-3b53-424d-9846-06cd8ec1f5b8>,
+                        <http://data.lblod.info/id/contact-punten/d9a18c2f-24ca-4de3-bbc5-6873d19abd40>.
+
+      <http://data.lblod.info/id/contact-punten/bf181d19-3b53-424d-9846-06cd8ec1f5b8> a <http://schema.org/ContactPoint>;
+        mu:uuid "bf181d19-3b53-424d-9846-06cd8ec1f5b8";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/d9a18c2f-24ca-4de3-bbc5-6873d19abd40> a <http://schema.org/ContactPoint>;
+        mu:uuid "d9a18c2f-24ca-4de3-bbc5-6873d19abd40";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/7bb7b354-5319-4462-ac91-561cf540c10e> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "7bb7b354-5319-4462-ac91-561cf540c10e".
+
+      <http://data.lblod.info/id/bestuurseenheden/dbb530bd-a765-49e6-8c3e-4fed14d44c4e> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "dbb530bd-a765-49e6-8c3e-4fed14d44c4e" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "Welzijnsvereniging Sleutelzorg" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/927e05e1-1a22-4bdc-9916-24bcb895f620> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/d70222ab-f5a9-41be-b5be-0dd2aeba3d43> .
+
+      <http://data.lblod.info/id/identificatoren/5b632f5b-0607-4997-af0f-9342fab9cf39> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "5b632f5b-0607-4997-af0f-9342fab9cf39" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/ceb89003-82b8-4367-bbe6-a32c58ee5f40> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/ceb89003-82b8-4367-bbe6-a32c58ee5f40> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "ceb89003-82b8-4367-bbe6-a32c58ee5f40" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/ceb89003-82b8-4367-bbe6-a32c58ee5f40> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1047" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/53eb2101-95f5-442d-a89c-9e06f57d1218> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "53eb2101-95f5-442d-a89c-9e06f57d1218";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/71697b49-10be-4b7d-90d4-c07476f06dfb>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/fc43f8c8-7381-49c7-bcf8-f5f2d1414161>,
+                        <http://data.lblod.info/id/contact-punten/9d585020-a5b0-461d-b831-da32f0716153>.
+
+      <http://data.lblod.info/id/contact-punten/fc43f8c8-7381-49c7-bcf8-f5f2d1414161> a <http://schema.org/ContactPoint>;
+        mu:uuid "fc43f8c8-7381-49c7-bcf8-f5f2d1414161";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/9d585020-a5b0-461d-b831-da32f0716153> a <http://schema.org/ContactPoint>;
+        mu:uuid "9d585020-a5b0-461d-b831-da32f0716153";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/71697b49-10be-4b7d-90d4-c07476f06dfb> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "71697b49-10be-4b7d-90d4-c07476f06dfb".
+
+      <http://data.lblod.info/id/bestuurseenheden/f490a5f5-5f21-4c01-b70e-80d76ad8c256> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "f490a5f5-5f21-4c01-b70e-80d76ad8c256" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "Zorg Stekene" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/5b632f5b-0607-4997-af0f-9342fab9cf39> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/53eb2101-95f5-442d-a89c-9e06f57d1218> .
+
+      <http://data.lblod.info/id/identificatoren/c228ed37-3898-47b4-b3c5-2391ba9b1765> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "c228ed37-3898-47b4-b3c5-2391ba9b1765" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/69178935-6fc1-4663-9c70-ca1b014910b7> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/69178935-6fc1-4663-9c70-ca1b014910b7> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "69178935-6fc1-4663-9c70-ca1b014910b7" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/69178935-6fc1-4663-9c70-ca1b014910b7> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1037" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/8432c421-032e-4ce3-ba4f-88cb3c0caf45> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "8432c421-032e-4ce3-ba4f-88cb3c0caf45";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/dbeed088-8027-4b93-91e7-1439d2bca4eb>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/42a12f22-2840-4334-8571-db5e6caa5d4a>,
+                        <http://data.lblod.info/id/contact-punten/8e5eeb62-d7cc-4806-a7ef-4eb225bc88fc>.
+
+      <http://data.lblod.info/id/contact-punten/42a12f22-2840-4334-8571-db5e6caa5d4a> a <http://schema.org/ContactPoint>;
+        mu:uuid "42a12f22-2840-4334-8571-db5e6caa5d4a";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/8e5eeb62-d7cc-4806-a7ef-4eb225bc88fc> a <http://schema.org/ContactPoint>;
+        mu:uuid "8e5eeb62-d7cc-4806-a7ef-4eb225bc88fc";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/dbeed088-8027-4b93-91e7-1439d2bca4eb> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "dbeed088-8027-4b93-91e7-1439d2bca4eb".
+
+      <http://data.lblod.info/id/bestuurseenheden/836436cd7bc957ec9eb24865c628c5707b4a1fbbae5cccebfaf1df0983f888be> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "836436cd7bc957ec9eb24865c628c5707b4a1fbbae5cccebfaf1df0983f888be" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "Zorg Izegem" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/c228ed37-3898-47b4-b3c5-2391ba9b1765> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/8432c421-032e-4ce3-ba4f-88cb3c0caf45> .
+
+      <http://data.lblod.info/id/identificatoren/60549b70-f9d1-48ce-a864-ce3607aaf022> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "60549b70-f9d1-48ce-a864-ce3607aaf022" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/f7dfc707-95bd-4e0a-88cf-5b23c381c6ff> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/f7dfc707-95bd-4e0a-88cf-5b23c381c6ff> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "f7dfc707-95bd-4e0a-88cf-5b23c381c6ff" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/f7dfc707-95bd-4e0a-88cf-5b23c381c6ff> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "837" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/4aa7eaf3-38d7-4817-a2f1-d71f9a40c322> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "4aa7eaf3-38d7-4817-a2f1-d71f9a40c322";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/cec9b5f8-2b3a-4eb9-81d9-92e25433c7a9>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/522352d9-aa91-4ca3-87f2-4cdfa3664406>,
+                        <http://data.lblod.info/id/contact-punten/df5b9e17-0191-47c2-a505-34b82e3bfcfa>.
+
+      <http://data.lblod.info/id/contact-punten/522352d9-aa91-4ca3-87f2-4cdfa3664406> a <http://schema.org/ContactPoint>;
+        mu:uuid "522352d9-aa91-4ca3-87f2-4cdfa3664406";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/df5b9e17-0191-47c2-a505-34b82e3bfcfa> a <http://schema.org/ContactPoint>;
+        mu:uuid "df5b9e17-0191-47c2-a505-34b82e3bfcfa";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/cec9b5f8-2b3a-4eb9-81d9-92e25433c7a9> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "cec9b5f8-2b3a-4eb9-81d9-92e25433c7a9".
+
+      <http://data.lblod.info/id/bestuurseenheden/a79dd82a5e400056b3f233fc646850f57918b6173036efa1c3597971cdc6649f> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "a79dd82a5e400056b3f233fc646850f57918b6173036efa1c3597971cdc6649f" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "Dienst voor Schuldbemiddeling Waasland" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/60549b70-f9d1-48ce-a864-ce3607aaf022> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/4aa7eaf3-38d7-4817-a2f1-d71f9a40c322> .
+
+      <http://data.lblod.info/id/identificatoren/b5eff540-9155-4eb4-b1a0-d3f3b237242e> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "b5eff540-9155-4eb4-b1a0-d3f3b237242e" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/69f62a25-01ac-4c50-8470-638f64b3b262> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/69f62a25-01ac-4c50-8470-638f64b3b262> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "69f62a25-01ac-4c50-8470-638f64b3b262" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/69f62a25-01ac-4c50-8470-638f64b3b262> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1371" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/a6bad628-a837-4b86-b222-9dc8ad761df2> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "a6bad628-a837-4b86-b222-9dc8ad761df2";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/efdbc59a-6991-44a0-ab53-2df1cbdfb9a6>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/7f8ffb3a-27e0-4ea2-a42b-3d17ca080000>,
+                        <http://data.lblod.info/id/contact-punten/c329aee0-591a-4bad-860d-0dbe593c0f99>.
+
+      <http://data.lblod.info/id/contact-punten/7f8ffb3a-27e0-4ea2-a42b-3d17ca080000> a <http://schema.org/ContactPoint>;
+        mu:uuid "7f8ffb3a-27e0-4ea2-a42b-3d17ca080000";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/c329aee0-591a-4bad-860d-0dbe593c0f99> a <http://schema.org/ContactPoint>;
+        mu:uuid "c329aee0-591a-4bad-860d-0dbe593c0f99";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/efdbc59a-6991-44a0-ab53-2df1cbdfb9a6> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "efdbc59a-6991-44a0-ab53-2df1cbdfb9a6".
+
+      <http://data.lblod.info/id/bestuurseenheden/1165717c-1203-41cd-b434-b041cbe66782> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "1165717c-1203-41cd-b434-b041cbe66782" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/34b5af85-dc9f-468f-9e03-ef89b174c267> ;
+        skos:prefLabel  "Algemeen Ziekenhuis Waasland" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/b5eff540-9155-4eb4-b1a0-d3f3b237242e> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/a6bad628-a837-4b86-b222-9dc8ad761df2> .
+
+      <http://data.lblod.info/id/identificatoren/6d990001-8efe-43d3-b3b5-05dc494d74e2> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "6d990001-8efe-43d3-b3b5-05dc494d74e2" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/e63ba21b-75fc-4f51-af79-9a8d495c6100> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/e63ba21b-75fc-4f51-af79-9a8d495c6100> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "e63ba21b-75fc-4f51-af79-9a8d495c6100" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/e63ba21b-75fc-4f51-af79-9a8d495c6100> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1369" .
+
+        <http://data.lblod.info/id/identificatoren/537dadf8-4333-4535-b536-d7ecbccb36f3> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "537dadf8-4333-4535-b536-d7ecbccb36f3";
+        skos:notation "KBO nummer";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/72843a75-62db-4e95-af2b-d587ec00bcae>.
+          <http://data.lblod.info/id/gestructureerdeIdentificatoren/72843a75-62db-4e95-af2b-d587ec00bcae>
+            a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "72843a75-62db-4e95-af2b-d587ec00bcae";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0249211806".
+      <http://data.lblod.info/id/bestuurseenheden/e2fdd5a7-c67f-4cad-99c5-6a2c5212f9a3> <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/537dadf8-4333-4535-b536-d7ecbccb36f3> .
+
+        <http://data.lblod.info/id/vestigingen/0d8f0f14-278b-4700-b090-10fbbeffb39b> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "0d8f0f14-278b-4700-b090-10fbbeffb39b";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/0bad25c1-a934-403f-98a5-419847f758df>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/2354e704-a514-488a-997a-687de21e21c3>,
+                        <http://data.lblod.info/id/contact-punten/2d9321b3-f3c5-475e-a4b2-aebfa7f5aadd>.
+
+      <http://data.lblod.info/id/contact-punten/2354e704-a514-488a-997a-687de21e21c3> a <http://schema.org/ContactPoint>;
+        mu:uuid "2354e704-a514-488a-997a-687de21e21c3";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/2d9321b3-f3c5-475e-a4b2-aebfa7f5aadd> a <http://schema.org/ContactPoint>;
+        mu:uuid "2d9321b3-f3c5-475e-a4b2-aebfa7f5aadd";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/0bad25c1-a934-403f-98a5-419847f758df> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "0bad25c1-a934-403f-98a5-419847f758df".
+
+      <http://data.lblod.info/id/bestuurseenheden/e2fdd5a7-c67f-4cad-99c5-6a2c5212f9a3> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "e2fdd5a7-c67f-4cad-99c5-6a2c5212f9a3" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/34b5af85-dc9f-468f-9e03-ef89b174c267> ;
+        skos:prefLabel  "AV Medisch Centum Noord-Oost Limburg" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/6d990001-8efe-43d3-b3b5-05dc494d74e2> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/0d8f0f14-278b-4700-b090-10fbbeffb39b> .
+
+      <http://data.lblod.info/id/identificatoren/c760582b-04db-4a6d-b92f-60d041919086> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "c760582b-04db-4a6d-b92f-60d041919086" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/bcf54849-d64b-4f85-9f1c-c5089b7d077c> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/bcf54849-d64b-4f85-9f1c-c5089b7d077c> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "bcf54849-d64b-4f85-9f1c-c5089b7d077c" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/bcf54849-d64b-4f85-9f1c-c5089b7d077c> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "839" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/200fd4a0-b920-4d49-ae77-2d5b3fad5ac6> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "200fd4a0-b920-4d49-ae77-2d5b3fad5ac6";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/28a1ef1e-03c8-45f8-8d78-e7c1c315e323>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/2ba276ae-ccc4-444d-b12c-c8456195ca2a>,
+                        <http://data.lblod.info/id/contact-punten/8244db2c-ee87-4ca6-a27b-175d49d0283e>.
+
+      <http://data.lblod.info/id/contact-punten/2ba276ae-ccc4-444d-b12c-c8456195ca2a> a <http://schema.org/ContactPoint>;
+        mu:uuid "2ba276ae-ccc4-444d-b12c-c8456195ca2a";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/8244db2c-ee87-4ca6-a27b-175d49d0283e> a <http://schema.org/ContactPoint>;
+        mu:uuid "8244db2c-ee87-4ca6-a27b-175d49d0283e";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/28a1ef1e-03c8-45f8-8d78-e7c1c315e323> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "28a1ef1e-03c8-45f8-8d78-e7c1c315e323".
+
+      <http://data.lblod.info/id/bestuurseenheden/21a70e74dbb297ec42d5cc72ab810178b298d12fc8f679c742d2501f7ce5b6a3> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "21a70e74dbb297ec42d5cc72ab810178b298d12fc8f679c742d2501f7ce5b6a3" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "Zorg Leuven" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/c760582b-04db-4a6d-b92f-60d041919086> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/200fd4a0-b920-4d49-ae77-2d5b3fad5ac6> .
+
+      <http://data.lblod.info/id/identificatoren/bb2bdd34-4c9a-4905-a0c4-018cc31fbc1d> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "bb2bdd34-4c9a-4905-a0c4-018cc31fbc1d" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/194cbd74-8f12-45cd-9812-66ee96201ee5> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/194cbd74-8f12-45cd-9812-66ee96201ee5> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "194cbd74-8f12-45cd-9812-66ee96201ee5" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/194cbd74-8f12-45cd-9812-66ee96201ee5> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "855" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/c61fdb3e-20d5-46f3-8963-e7098d3d6a02> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "c61fdb3e-20d5-46f3-8963-e7098d3d6a02";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/680cb1e4-e650-456e-8847-a3dfd7ba819d>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/836c1945-bd71-445f-b562-a18d26a7a734>,
+                        <http://data.lblod.info/id/contact-punten/efb28fad-fe9f-4171-bfe6-4999b6915d25>.
+
+      <http://data.lblod.info/id/contact-punten/836c1945-bd71-445f-b562-a18d26a7a734> a <http://schema.org/ContactPoint>;
+        mu:uuid "836c1945-bd71-445f-b562-a18d26a7a734";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/efb28fad-fe9f-4171-bfe6-4999b6915d25> a <http://schema.org/ContactPoint>;
+        mu:uuid "efb28fad-fe9f-4171-bfe6-4999b6915d25";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/680cb1e4-e650-456e-8847-a3dfd7ba819d> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "680cb1e4-e650-456e-8847-a3dfd7ba819d".
+
+      <http://data.lblod.info/id/bestuurseenheden/7a26207c8531ac7c1dba8efd78870dd90d2ad64cb0cf3e666529e60e10e73a2d> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "7a26207c8531ac7c1dba8efd78870dd90d2ad64cb0cf3e666529e60e10e73a2d" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "Autonome Vereniging Het Dak" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/bb2bdd34-4c9a-4905-a0c4-018cc31fbc1d> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/c61fdb3e-20d5-46f3-8963-e7098d3d6a02> .
+
+      <http://data.lblod.info/id/identificatoren/cd2e70eb-a7a8-434c-9110-f541dbabf66a> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "cd2e70eb-a7a8-434c-9110-f541dbabf66a" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/7350bb9f-4dc9-4960-a1d4-ec00701efb2d> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/7350bb9f-4dc9-4960-a1d4-ec00701efb2d> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "7350bb9f-4dc9-4960-a1d4-ec00701efb2d" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/7350bb9f-4dc9-4960-a1d4-ec00701efb2d> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "853" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/1c71a006-2ee4-4cc0-858b-3b5222609b9f> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "1c71a006-2ee4-4cc0-858b-3b5222609b9f";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/64eeab6d-0341-41fd-bcf4-be564e4b34b8>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/74f58b20-7462-48b9-b9a8-57724cf0a3ed>,
+                        <http://data.lblod.info/id/contact-punten/b8a92039-69d3-4983-b808-35e9f3e67a66>.
+
+      <http://data.lblod.info/id/contact-punten/74f58b20-7462-48b9-b9a8-57724cf0a3ed> a <http://schema.org/ContactPoint>;
+        mu:uuid "74f58b20-7462-48b9-b9a8-57724cf0a3ed";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/b8a92039-69d3-4983-b808-35e9f3e67a66> a <http://schema.org/ContactPoint>;
+        mu:uuid "b8a92039-69d3-4983-b808-35e9f3e67a66";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/64eeab6d-0341-41fd-bcf4-be564e4b34b8> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "64eeab6d-0341-41fd-bcf4-be564e4b34b8".
+
+      <http://data.lblod.info/id/bestuurseenheden/0964427f9f2e113607681e5c25bf744a41bc412a94e1c0acc784a48d79441df6> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "0964427f9f2e113607681e5c25bf744a41bc412a94e1c0acc784a48d79441df6" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "Woondienst Regio Izegem" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/cd2e70eb-a7a8-434c-9110-f541dbabf66a> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/1c71a006-2ee4-4cc0-858b-3b5222609b9f> .
+
+      <http://data.lblod.info/id/identificatoren/1124e3af-8fce-4cd0-bfae-fc47ec58f620> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "1124e3af-8fce-4cd0-bfae-fc47ec58f620" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/ffcf65f1-e497-45a6-81e0-72db8fecb5b4> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/ffcf65f1-e497-45a6-81e0-72db8fecb5b4> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "ffcf65f1-e497-45a6-81e0-72db8fecb5b4" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/ffcf65f1-e497-45a6-81e0-72db8fecb5b4> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "845" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/0c6ab0ff-d4c5-4a7a-bf8d-34dc1042d2dc> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "0c6ab0ff-d4c5-4a7a-bf8d-34dc1042d2dc";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/34682796-4630-4215-b87f-abdc69f635a7>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/ea21fdab-bc51-4569-80a8-3ced0c6494e5>,
+                        <http://data.lblod.info/id/contact-punten/03c43ac8-191d-44e8-9887-67b8d34d8741>.
+
+      <http://data.lblod.info/id/contact-punten/ea21fdab-bc51-4569-80a8-3ced0c6494e5> a <http://schema.org/ContactPoint>;
+        mu:uuid "ea21fdab-bc51-4569-80a8-3ced0c6494e5";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/03c43ac8-191d-44e8-9887-67b8d34d8741> a <http://schema.org/ContactPoint>;
+        mu:uuid "03c43ac8-191d-44e8-9887-67b8d34d8741";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/34682796-4630-4215-b87f-abdc69f635a7> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "34682796-4630-4215-b87f-abdc69f635a7".
+
+      <http://data.lblod.info/id/bestuurseenheden/03df783df9b22fa5340f962d439c46048ba62f6b4f43bd2497eca20db7cd8617> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "03df783df9b22fa5340f962d439c46048ba62f6b4f43bd2497eca20db7cd8617" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "Ons Huis" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/1124e3af-8fce-4cd0-bfae-fc47ec58f620> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/0c6ab0ff-d4c5-4a7a-bf8d-34dc1042d2dc> .
+
+      <http://data.lblod.info/id/identificatoren/461faba8-c5f0-4a4b-be3f-147a485a7822> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "461faba8-c5f0-4a4b-be3f-147a485a7822" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/a2bd54aa-1c78-4f20-a66a-8234a48afb84> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/a2bd54aa-1c78-4f20-a66a-8234a48afb84> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "a2bd54aa-1c78-4f20-a66a-8234a48afb84" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/a2bd54aa-1c78-4f20-a66a-8234a48afb84> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "857" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/fb348323-0a31-42ae-b8c5-0458ce252596> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "fb348323-0a31-42ae-b8c5-0458ce252596";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/55d44d92-f756-43d7-a9f3-6d4b0d452bf3>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/17d8e6be-1485-43d2-b331-3429f94005bc>,
+                        <http://data.lblod.info/id/contact-punten/33c060bb-a12d-4a21-b234-4cdaf16b6ad4>.
+
+      <http://data.lblod.info/id/contact-punten/17d8e6be-1485-43d2-b331-3429f94005bc> a <http://schema.org/ContactPoint>;
+        mu:uuid "17d8e6be-1485-43d2-b331-3429f94005bc";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/33c060bb-a12d-4a21-b234-4cdaf16b6ad4> a <http://schema.org/ContactPoint>;
+        mu:uuid "33c060bb-a12d-4a21-b234-4cdaf16b6ad4";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/55d44d92-f756-43d7-a9f3-6d4b0d452bf3> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "55d44d92-f756-43d7-a9f3-6d4b0d452bf3".
+
+      <http://data.lblod.info/id/bestuurseenheden/e10b5c6c27e642c4f6ae8b1aa623b1a696318483629e5edbea343ba20038d94c> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "e10b5c6c27e642c4f6ae8b1aa623b1a696318483629e5edbea343ba20038d94c" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "Sociaal Verhuurkantoor Koepel Bredene-Oostende" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/461faba8-c5f0-4a4b-be3f-147a485a7822> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/fb348323-0a31-42ae-b8c5-0458ce252596> .
+
+      <http://data.lblod.info/id/identificatoren/aa6a94f9-3ed5-404b-a9c3-ca5e4cadfb8a> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "aa6a94f9-3ed5-404b-a9c3-ca5e4cadfb8a" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/dc842530-01ce-4f54-86ee-ab97259f6ae8> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/dc842530-01ce-4f54-86ee-ab97259f6ae8> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "dc842530-01ce-4f54-86ee-ab97259f6ae8" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/dc842530-01ce-4f54-86ee-ab97259f6ae8> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "850" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/c805ca5a-46f1-4a8f-a96c-7a77d3f3b5a1> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "c805ca5a-46f1-4a8f-a96c-7a77d3f3b5a1";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/9731c264-853f-4a52-8a6b-2690c1ef2360>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/31bf35f0-2f5f-48de-a2c8-82761bc3e171>,
+                        <http://data.lblod.info/id/contact-punten/9551bf64-2991-41bb-8ff2-90993fb6dfc2>.
+
+      <http://data.lblod.info/id/contact-punten/31bf35f0-2f5f-48de-a2c8-82761bc3e171> a <http://schema.org/ContactPoint>;
+        mu:uuid "31bf35f0-2f5f-48de-a2c8-82761bc3e171";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/9551bf64-2991-41bb-8ff2-90993fb6dfc2> a <http://schema.org/ContactPoint>;
+        mu:uuid "9551bf64-2991-41bb-8ff2-90993fb6dfc2";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/9731c264-853f-4a52-8a6b-2690c1ef2360> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "9731c264-853f-4a52-8a6b-2690c1ef2360".
+
+      <http://data.lblod.info/id/bestuurseenheden/d9196423b3657e5484236c769737573e4574e223eaccde6a7b7207d632a6a669> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "d9196423b3657e5484236c769737573e4574e223eaccde6a7b7207d632a6a669" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "Woondienst Jogi" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/aa6a94f9-3ed5-404b-a9c3-ca5e4cadfb8a> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/c805ca5a-46f1-4a8f-a96c-7a77d3f3b5a1> .
+
+      <http://data.lblod.info/id/identificatoren/0999c976-3353-45ab-b23e-7b5ec490c6fd> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "0999c976-3353-45ab-b23e-7b5ec490c6fd" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/2ff452f5-6b26-402f-97e9-6b8c9e550bab> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/2ff452f5-6b26-402f-97e9-6b8c9e550bab> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "2ff452f5-6b26-402f-97e9-6b8c9e550bab" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/2ff452f5-6b26-402f-97e9-6b8c9e550bab> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "856" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/144c475f-0521-4f1b-b628-c627e95cf173> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "144c475f-0521-4f1b-b628-c627e95cf173";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/9539db61-e364-41a0-bcac-9fe3d399792d>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/1a86aafb-bc0c-4c8b-b745-3148b2c68e78>,
+                        <http://data.lblod.info/id/contact-punten/7b73ebde-2a3c-40a0-ad84-02e739d5bbcc>.
+
+      <http://data.lblod.info/id/contact-punten/1a86aafb-bc0c-4c8b-b745-3148b2c68e78> a <http://schema.org/ContactPoint>;
+        mu:uuid "1a86aafb-bc0c-4c8b-b745-3148b2c68e78";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/7b73ebde-2a3c-40a0-ad84-02e739d5bbcc> a <http://schema.org/ContactPoint>;
+        mu:uuid "7b73ebde-2a3c-40a0-ad84-02e739d5bbcc";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/9539db61-e364-41a0-bcac-9fe3d399792d> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "9539db61-e364-41a0-bcac-9fe3d399792d".
+
+      <http://data.lblod.info/id/bestuurseenheden/94158248e8e9bd9a05012e06db794178caa74731b2dadcf84f5ad7373f13abcc> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "94158248e8e9bd9a05012e06db794178caa74731b2dadcf84f5ad7373f13abcc" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "Woonwinkel Knokke-Heist" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/0999c976-3353-45ab-b23e-7b5ec490c6fd> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/144c475f-0521-4f1b-b628-c627e95cf173> .
+
+      <http://data.lblod.info/id/identificatoren/a22b7716-9baa-4749-a400-a02edd32ca92> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "a22b7716-9baa-4749-a400-a02edd32ca92" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/ef1d7a56-10c3-45c3-a5c4-d35c8c5a8dc0> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/ef1d7a56-10c3-45c3-a5c4-d35c8c5a8dc0> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "ef1d7a56-10c3-45c3-a5c4-d35c8c5a8dc0" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/ef1d7a56-10c3-45c3-a5c4-d35c8c5a8dc0> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1373" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/dd240b11-62ab-4aac-af7a-57b4fca373fe> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "dd240b11-62ab-4aac-af7a-57b4fca373fe";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/a4be0071-4787-4d9f-b434-212d147f39d2>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/749829fd-eefa-4abc-bc6c-2f61883e8e56>,
+                        <http://data.lblod.info/id/contact-punten/94a09710-a1cc-4102-8a0a-9386f0aaa9b8>.
+
+      <http://data.lblod.info/id/contact-punten/749829fd-eefa-4abc-bc6c-2f61883e8e56> a <http://schema.org/ContactPoint>;
+        mu:uuid "749829fd-eefa-4abc-bc6c-2f61883e8e56";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/94a09710-a1cc-4102-8a0a-9386f0aaa9b8> a <http://schema.org/ContactPoint>;
+        mu:uuid "94a09710-a1cc-4102-8a0a-9386f0aaa9b8";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/a4be0071-4787-4d9f-b434-212d147f39d2> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "a4be0071-4787-4d9f-b434-212d147f39d2".
+
+      <http://data.lblod.info/id/bestuurseenheden/7eff2130-5462-4569-8098-29ceec9e6a22> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "7eff2130-5462-4569-8098-29ceec9e6a22" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/34b5af85-dc9f-468f-9e03-ef89b174c267> ;
+        skos:prefLabel  "Algemeen Stedelijk Ziekenhuis" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/a22b7716-9baa-4749-a400-a02edd32ca92> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/dd240b11-62ab-4aac-af7a-57b4fca373fe> .
+
+      <http://data.lblod.info/id/identificatoren/ba2824b5-9278-4e3a-9668-1cb156740e1d> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "ba2824b5-9278-4e3a-9668-1cb156740e1d" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/f8a3b3a6-70b8-4764-84f6-2c634af2f760> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/f8a3b3a6-70b8-4764-84f6-2c634af2f760> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "f8a3b3a6-70b8-4764-84f6-2c634af2f760" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/f8a3b3a6-70b8-4764-84f6-2c634af2f760> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1377" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/eeeee0ad-1883-4993-b141-d7ec21ee868b> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "eeeee0ad-1883-4993-b141-d7ec21ee868b";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/5ae99ae4-8a3f-4eb5-99eb-db333102753e>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/48025368-9c75-429f-b191-4899b23cd7b5>,
+                        <http://data.lblod.info/id/contact-punten/03a9be34-3a00-48b5-ae19-7524c6cace9e>.
+
+      <http://data.lblod.info/id/contact-punten/48025368-9c75-429f-b191-4899b23cd7b5> a <http://schema.org/ContactPoint>;
+        mu:uuid "48025368-9c75-429f-b191-4899b23cd7b5";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/03a9be34-3a00-48b5-ae19-7524c6cace9e> a <http://schema.org/ContactPoint>;
+        mu:uuid "03a9be34-3a00-48b5-ae19-7524c6cace9e";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/5ae99ae4-8a3f-4eb5-99eb-db333102753e> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "5ae99ae4-8a3f-4eb5-99eb-db333102753e".
+
+      <http://data.lblod.info/id/bestuurseenheden/96ceb4cf-ece3-417d-914b-3e6eff293e6a> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "96ceb4cf-ece3-417d-914b-3e6eff293e6a" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/34b5af85-dc9f-468f-9e03-ef89b174c267> ;
+        skos:prefLabel  "Auroraziekenhuis A.V." ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/ba2824b5-9278-4e3a-9668-1cb156740e1d> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/eeeee0ad-1883-4993-b141-d7ec21ee868b> .
+
+      <http://data.lblod.info/id/identificatoren/48bbe970-43f2-4d10-9930-7b1c0307d4e0> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "48bbe970-43f2-4d10-9930-7b1c0307d4e0" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/43a711be-600c-4cda-ad7f-115b12652af2> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/43a711be-600c-4cda-ad7f-115b12652af2> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "43a711be-600c-4cda-ad7f-115b12652af2" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/43a711be-600c-4cda-ad7f-115b12652af2> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1395" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/59d45812-9dde-403e-9869-a8294c14a9d2> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "59d45812-9dde-403e-9869-a8294c14a9d2";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/d34d06b7-a66c-4d03-a4ae-e1eb62cfdac5>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/ff43d096-7d10-4617-b0e9-aab245999c3d>,
+                        <http://data.lblod.info/id/contact-punten/7c1a5b0d-d759-4da8-84da-cb407c49e912>.
+
+      <http://data.lblod.info/id/contact-punten/ff43d096-7d10-4617-b0e9-aab245999c3d> a <http://schema.org/ContactPoint>;
+        mu:uuid "ff43d096-7d10-4617-b0e9-aab245999c3d";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/7c1a5b0d-d759-4da8-84da-cb407c49e912> a <http://schema.org/ContactPoint>;
+        mu:uuid "7c1a5b0d-d759-4da8-84da-cb407c49e912";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/d34d06b7-a66c-4d03-a4ae-e1eb62cfdac5> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "d34d06b7-a66c-4d03-a4ae-e1eb62cfdac5".
+
+      <http://data.lblod.info/id/bestuurseenheden/e452e23b-95cb-4b75-8825-503288ede636> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "e452e23b-95cb-4b75-8825-503288ede636" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "De Zilveren Zwaan" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/48bbe970-43f2-4d10-9930-7b1c0307d4e0> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/59d45812-9dde-403e-9869-a8294c14a9d2> .
+
+      <http://data.lblod.info/id/identificatoren/032c3779-ab52-4790-91e9-2ee14ab3ea62> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "032c3779-ab52-4790-91e9-2ee14ab3ea62" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/4b6fc942-2426-4c4c-a8e5-d916673ae048> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/4b6fc942-2426-4c4c-a8e5-d916673ae048> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "4b6fc942-2426-4c4c-a8e5-d916673ae048" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/4b6fc942-2426-4c4c-a8e5-d916673ae048> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1394" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/7bacfd47-758d-4ac2-b266-93569358be50> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "7bacfd47-758d-4ac2-b266-93569358be50";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/15653850-cad5-4bd1-a013-5d347c81cd0f>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/ce6ba7e2-f0a7-4f84-bc9d-f620b3128908>,
+                        <http://data.lblod.info/id/contact-punten/d98267fb-4c46-48b4-b5b6-6a5ce77c5773>.
+
+      <http://data.lblod.info/id/contact-punten/ce6ba7e2-f0a7-4f84-bc9d-f620b3128908> a <http://schema.org/ContactPoint>;
+        mu:uuid "ce6ba7e2-f0a7-4f84-bc9d-f620b3128908";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/d98267fb-4c46-48b4-b5b6-6a5ce77c5773> a <http://schema.org/ContactPoint>;
+        mu:uuid "d98267fb-4c46-48b4-b5b6-6a5ce77c5773";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/15653850-cad5-4bd1-a013-5d347c81cd0f> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "15653850-cad5-4bd1-a013-5d347c81cd0f".
+
+      <http://data.lblod.info/id/bestuurseenheden/530dbb2c-a798-4cae-b42e-737b80b83b22> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "530dbb2c-a798-4cae-b42e-737b80b83b22" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "Welzijnsvereniging De Wijngaard" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/032c3779-ab52-4790-91e9-2ee14ab3ea62> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/7bacfd47-758d-4ac2-b266-93569358be50> .
+
+      <http://data.lblod.info/id/identificatoren/3212357f-3173-48fe-ab16-2698182ef6a0> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "3212357f-3173-48fe-ab16-2698182ef6a0" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/c5470780-f480-4827-a57c-745c7c05cbc8> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/c5470780-f480-4827-a57c-745c7c05cbc8> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "c5470780-f480-4827-a57c-745c7c05cbc8" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/c5470780-f480-4827-a57c-745c7c05cbc8> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1393" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/0312b5ba-dbc5-4daf-b388-e941f93de370> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "0312b5ba-dbc5-4daf-b388-e941f93de370";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/fbac962e-7d17-4ecd-8bc0-e86094ad8229>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/3710d4fd-d34a-44f6-89c0-97e3cafb64d3>,
+                        <http://data.lblod.info/id/contact-punten/c3bc513f-f7f0-44bc-8413-218cc7d4eaeb>.
+
+      <http://data.lblod.info/id/contact-punten/3710d4fd-d34a-44f6-89c0-97e3cafb64d3> a <http://schema.org/ContactPoint>;
+        mu:uuid "3710d4fd-d34a-44f6-89c0-97e3cafb64d3";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/c3bc513f-f7f0-44bc-8413-218cc7d4eaeb> a <http://schema.org/ContactPoint>;
+        mu:uuid "c3bc513f-f7f0-44bc-8413-218cc7d4eaeb";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/fbac962e-7d17-4ecd-8bc0-e86094ad8229> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "fbac962e-7d17-4ecd-8bc0-e86094ad8229".
+
+      <http://data.lblod.info/id/bestuurseenheden/8a301cf9-6611-450c-aa95-b104803180db> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "8a301cf9-6611-450c-aa95-b104803180db" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "Welzijnsvereniging Ter Nethe" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/3212357f-3173-48fe-ab16-2698182ef6a0> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/0312b5ba-dbc5-4daf-b388-e941f93de370> .
+
+      <http://data.lblod.info/id/identificatoren/9eb053f6-da3c-45c5-80fd-47a632a74e59> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "9eb053f6-da3c-45c5-80fd-47a632a74e59" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/ecc2e445-0eef-4435-bf09-ea20c6951bf5> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/ecc2e445-0eef-4435-bf09-ea20c6951bf5> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "ecc2e445-0eef-4435-bf09-ea20c6951bf5" .
+        
+
+        <http://data.lblod.info/id/identificatoren/cc5f8548-f0ea-45ac-8bc1-69b63aeaecd7> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "cc5f8548-f0ea-45ac-8bc1-69b63aeaecd7";
+        skos:notation "KBO nummer";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/f4e8903e-f61f-4aa4-a8b7-d198687da6f1>.
+          <http://data.lblod.info/id/gestructureerdeIdentificatoren/f4e8903e-f61f-4aa4-a8b7-d198687da6f1>
+            a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "f4e8903e-f61f-4aa4-a8b7-d198687da6f1";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "".
+      <http://data.lblod.info/id/bestuurseenheden/384b48dc-6860-49b4-a9ef-efa557299950> <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/cc5f8548-f0ea-45ac-8bc1-69b63aeaecd7> .
+
+        <http://data.lblod.info/id/vestigingen/86d940cf-6f9c-45da-9438-a57eb5dfbd44> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "86d940cf-6f9c-45da-9438-a57eb5dfbd44";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/b48ce6ed-e6b4-4243-9807-57e6e41b66e1>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/d964641f-90ab-44bc-95e2-7a2033a9b6c1>,
+                        <http://data.lblod.info/id/contact-punten/357776ff-856a-4057-af29-a76ec62d6abd>.
+
+      <http://data.lblod.info/id/contact-punten/d964641f-90ab-44bc-95e2-7a2033a9b6c1> a <http://schema.org/ContactPoint>;
+        mu:uuid "d964641f-90ab-44bc-95e2-7a2033a9b6c1";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/357776ff-856a-4057-af29-a76ec62d6abd> a <http://schema.org/ContactPoint>;
+        mu:uuid "357776ff-856a-4057-af29-a76ec62d6abd";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/b48ce6ed-e6b4-4243-9807-57e6e41b66e1> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "b48ce6ed-e6b4-4243-9807-57e6e41b66e1".
+
+      <http://data.lblod.info/id/bestuurseenheden/384b48dc-6860-49b4-a9ef-efa557299950> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "384b48dc-6860-49b4-a9ef-efa557299950" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "Ter Lembeek" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/9eb053f6-da3c-45c5-80fd-47a632a74e59> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/86d940cf-6f9c-45da-9438-a57eb5dfbd44> .
+
+      <http://data.lblod.info/id/identificatoren/ebfdcce9-604e-4ca2-881a-04d08a2deaa3> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "ebfdcce9-604e-4ca2-881a-04d08a2deaa3" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/1ddab8b8-e805-456b-ab65-d4f4360af105> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/1ddab8b8-e805-456b-ab65-d4f4360af105> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "1ddab8b8-e805-456b-ab65-d4f4360af105" .
+        
+
+        <http://data.lblod.info/id/identificatoren/86ec3944-c18e-4cf3-abb6-6dc969336587> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "86ec3944-c18e-4cf3-abb6-6dc969336587";
+        skos:notation "KBO nummer";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/da4eaf5f-3222-4aa3-bff9-a38d651350c2>.
+          <http://data.lblod.info/id/gestructureerdeIdentificatoren/da4eaf5f-3222-4aa3-bff9-a38d651350c2>
+            a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "da4eaf5f-3222-4aa3-bff9-a38d651350c2";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0264998753".
+      <http://data.lblod.info/id/bestuurseenheden/98afbe1f-4e7d-4896-925b-d7324302ce73> <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/86ec3944-c18e-4cf3-abb6-6dc969336587> .
+
+        <http://data.lblod.info/id/vestigingen/4e32b19e-44a6-4293-bb04-f16a775bea03> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "4e32b19e-44a6-4293-bb04-f16a775bea03";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/5a6f257b-6ba1-40fe-92a2-b997c18975cd>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/3050350a-2df7-40a6-ae08-9724fedac4cc>,
+                        <http://data.lblod.info/id/contact-punten/73f39c0b-98b3-4eb1-b4c5-cf81b7d40a05>.
+
+      <http://data.lblod.info/id/contact-punten/3050350a-2df7-40a6-ae08-9724fedac4cc> a <http://schema.org/ContactPoint>;
+        mu:uuid "3050350a-2df7-40a6-ae08-9724fedac4cc";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/73f39c0b-98b3-4eb1-b4c5-cf81b7d40a05> a <http://schema.org/ContactPoint>;
+        mu:uuid "73f39c0b-98b3-4eb1-b4c5-cf81b7d40a05";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/5a6f257b-6ba1-40fe-92a2-b997c18975cd> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "5a6f257b-6ba1-40fe-92a2-b997c18975cd".
+
+      <http://data.lblod.info/id/bestuurseenheden/98afbe1f-4e7d-4896-925b-d7324302ce73> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "98afbe1f-4e7d-4896-925b-d7324302ce73" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "Centrum voor Algemeen Welzijn Zenne en Zoniën" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/ebfdcce9-604e-4ca2-881a-04d08a2deaa3> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/4e32b19e-44a6-4293-bb04-f16a775bea03> .
+
+      <http://data.lblod.info/id/identificatoren/9199ff98-35ac-4431-b754-d5e5684a3219> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "9199ff98-35ac-4431-b754-d5e5684a3219" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/b4b5ccad-afe3-47d7-9ecc-54e730423d84> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/b4b5ccad-afe3-47d7-9ecc-54e730423d84> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "b4b5ccad-afe3-47d7-9ecc-54e730423d84" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/b4b5ccad-afe3-47d7-9ecc-54e730423d84> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "861" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/51a1118d-beb1-47be-b7b6-c317b4b60be8> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "51a1118d-beb1-47be-b7b6-c317b4b60be8";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/e6ef2406-06fe-41c2-87df-4144cceb9cd6>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/c5533a06-365a-44b1-b1dc-3c534c40b0f1>,
+                        <http://data.lblod.info/id/contact-punten/635f1a86-e2ac-4488-a317-13b2a3f30c10>.
+
+      <http://data.lblod.info/id/contact-punten/c5533a06-365a-44b1-b1dc-3c534c40b0f1> a <http://schema.org/ContactPoint>;
+        mu:uuid "c5533a06-365a-44b1-b1dc-3c534c40b0f1";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/635f1a86-e2ac-4488-a317-13b2a3f30c10> a <http://schema.org/ContactPoint>;
+        mu:uuid "635f1a86-e2ac-4488-a317-13b2a3f30c10";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/e6ef2406-06fe-41c2-87df-4144cceb9cd6> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "e6ef2406-06fe-41c2-87df-4144cceb9cd6".
+
+      <http://data.lblod.info/id/bestuurseenheden/77a07ee1348f6ef3b81ab685368d02c33812d92364e667f68fcdd073b050d949> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "77a07ee1348f6ef3b81ab685368d02c33812d92364e667f68fcdd073b050d949" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "Welzijnskoepel-Klein-Brabant-Vaartland" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/9199ff98-35ac-4431-b754-d5e5684a3219> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/51a1118d-beb1-47be-b7b6-c317b4b60be8> .
+
+      <http://data.lblod.info/id/identificatoren/df5cc2f4-d65d-49e1-9627-b8fa4a11c283> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "df5cc2f4-d65d-49e1-9627-b8fa4a11c283" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/25c97665-e50d-4775-94b0-5f90a37f4d96> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/25c97665-e50d-4775-94b0-5f90a37f4d96> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "25c97665-e50d-4775-94b0-5f90a37f4d96" .
+        
+
+        
+
+        <http://data.lblod.info/id/vestigingen/c62205d7-9b90-447f-aa49-972e2ff11d1e> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "c62205d7-9b90-447f-aa49-972e2ff11d1e";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/c20a4c19-fd1f-43cd-84cc-8e3aa6749c08>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/84938cf0-4104-44e2-8c70-0038ae5c6754>,
+                        <http://data.lblod.info/id/contact-punten/a72624f0-5c5f-4c7e-84bf-261d527fca54>.
+
+      <http://data.lblod.info/id/contact-punten/84938cf0-4104-44e2-8c70-0038ae5c6754> a <http://schema.org/ContactPoint>;
+        mu:uuid "84938cf0-4104-44e2-8c70-0038ae5c6754";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/a72624f0-5c5f-4c7e-84bf-261d527fca54> a <http://schema.org/ContactPoint>;
+        mu:uuid "a72624f0-5c5f-4c7e-84bf-261d527fca54";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/c20a4c19-fd1f-43cd-84cc-8e3aa6749c08> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "c20a4c19-fd1f-43cd-84cc-8e3aa6749c08".
+
+      <http://data.lblod.info/id/bestuurseenheden/53fefc09ccb63625eda802c01cf32df7fe8a14a14f020a89a08e68dc49d43e31> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "53fefc09ccb63625eda802c01cf32df7fe8a14a14f020a89a08e68dc49d43e31" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/34b5af85-dc9f-468f-9e03-ef89b174c267> ;
+        skos:prefLabel  "SOCiAL" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/df5cc2f4-d65d-49e1-9627-b8fa4a11c283> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/c62205d7-9b90-447f-aa49-972e2ff11d1e> .
+
+      <http://data.lblod.info/id/identificatoren/6a59cfc6-c749-447e-bdbe-f88a55b78ad0> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "6a59cfc6-c749-447e-bdbe-f88a55b78ad0" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/1212865c-e2e6-4723-bdf5-079148abf06a> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/1212865c-e2e6-4723-bdf5-079148abf06a> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "1212865c-e2e6-4723-bdf5-079148abf06a" .
+        
+
+        
+
+        <http://data.lblod.info/id/vestigingen/f35e1686-0278-435f-a241-4a61acbb1bb4> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "f35e1686-0278-435f-a241-4a61acbb1bb4";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/a2dee316-975a-4030-af6f-558a87494cd0>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/b55912c6-2029-4fc3-8386-1e357abe6e51>,
+                        <http://data.lblod.info/id/contact-punten/152206a3-f4d6-45c2-afd9-17509bcda9b9>.
+
+      <http://data.lblod.info/id/contact-punten/b55912c6-2029-4fc3-8386-1e357abe6e51> a <http://schema.org/ContactPoint>;
+        mu:uuid "b55912c6-2029-4fc3-8386-1e357abe6e51";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/152206a3-f4d6-45c2-afd9-17509bcda9b9> a <http://schema.org/ContactPoint>;
+        mu:uuid "152206a3-f4d6-45c2-afd9-17509bcda9b9";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/a2dee316-975a-4030-af6f-558a87494cd0> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "a2dee316-975a-4030-af6f-558a87494cd0".
+
+      <http://data.lblod.info/id/bestuurseenheden/927c0e00-65db-4003-b3ef-715428141de8> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "927c0e00-65db-4003-b3ef-715428141de8" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "Sociaal verhuurkantoor Melle - Destelbergen" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/6a59cfc6-c749-447e-bdbe-f88a55b78ad0> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/f35e1686-0278-435f-a241-4a61acbb1bb4> .
+
+      <http://data.lblod.info/id/identificatoren/3743a502-f301-478e-b0da-f49051d7fb97> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "3743a502-f301-478e-b0da-f49051d7fb97" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/2b35428a-d316-4907-83f8-bcc629c19201> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/2b35428a-d316-4907-83f8-bcc629c19201> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "2b35428a-d316-4907-83f8-bcc629c19201" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/2b35428a-d316-4907-83f8-bcc629c19201> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "860" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/c36e3756-57d0-4b25-b8bd-0138e610f3ef> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "c36e3756-57d0-4b25-b8bd-0138e610f3ef";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/1836f130-5f14-48c7-b717-e7b8ba697ebd>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/24c5185e-4265-4c5c-b7cc-f81eaddc9857>,
+                        <http://data.lblod.info/id/contact-punten/6c5e577e-0b2e-49b3-93bd-6d6e082ed369>.
+
+      <http://data.lblod.info/id/contact-punten/24c5185e-4265-4c5c-b7cc-f81eaddc9857> a <http://schema.org/ContactPoint>;
+        mu:uuid "24c5185e-4265-4c5c-b7cc-f81eaddc9857";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/6c5e577e-0b2e-49b3-93bd-6d6e082ed369> a <http://schema.org/ContactPoint>;
+        mu:uuid "6c5e577e-0b2e-49b3-93bd-6d6e082ed369";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/1836f130-5f14-48c7-b717-e7b8ba697ebd> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "1836f130-5f14-48c7-b717-e7b8ba697ebd".
+
+      <http://data.lblod.info/id/bestuurseenheden/d9c35f09-2a47-4ecf-b078-4cbe86ad8527> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "d9c35f09-2a47-4ecf-b078-4cbe86ad8527" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "De steenoven" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/3743a502-f301-478e-b0da-f49051d7fb97> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/c36e3756-57d0-4b25-b8bd-0138e610f3ef> .
+
+      <http://data.lblod.info/id/identificatoren/17fd0ff0-c4bb-4147-87b6-8978afbec085> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "17fd0ff0-c4bb-4147-87b6-8978afbec085" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/ef5d92bc-d05b-44bf-b98f-4edb62acbe85> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/ef5d92bc-d05b-44bf-b98f-4edb62acbe85> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "ef5d92bc-d05b-44bf-b98f-4edb62acbe85" .
+        <http://data.lblod.info/id/gestructureerdeIdentificatoren/ef5d92bc-d05b-44bf-b98f-4edb62acbe85> <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "863" .
+
+        
+
+        <http://data.lblod.info/id/vestigingen/b5713182-139a-4d22-8df4-4d8714d3d500> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "b5713182-139a-4d22-8df4-4d8714d3d500";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/877acb19-0fa2-4622-b7c6-e312fe9210ba>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/125a4e85-4bfe-4cc7-bdc4-db7fb96c52dd>,
+                        <http://data.lblod.info/id/contact-punten/0a885f4e-4579-41ca-9010-0d40be103495>.
+
+      <http://data.lblod.info/id/contact-punten/125a4e85-4bfe-4cc7-bdc4-db7fb96c52dd> a <http://schema.org/ContactPoint>;
+        mu:uuid "125a4e85-4bfe-4cc7-bdc4-db7fb96c52dd";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/0a885f4e-4579-41ca-9010-0d40be103495> a <http://schema.org/ContactPoint>;
+        mu:uuid "0a885f4e-4579-41ca-9010-0d40be103495";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/877acb19-0fa2-4622-b7c6-e312fe9210ba> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "877acb19-0fa2-4622-b7c6-e312fe9210ba".
+
+      <http://data.lblod.info/id/bestuurseenheden/0331f7d9259900c12c7cd16e081dca917d6b3ceda358cf69f12a1cdbb734b9ac> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "0331f7d9259900c12c7cd16e081dca917d6b3ceda358cf69f12a1cdbb734b9ac" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> ;
+        skos:prefLabel  "Woonzorgcentrum Van Lierde" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/17fd0ff0-c4bb-4147-87b6-8978afbec085> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/b5713182-139a-4d22-8df4-4d8714d3d500> .
+
+      <http://data.lblod.info/id/identificatoren/7aaf4860-d20a-4bea-b01e-fe5089306fc4> a <http://www.w3.org/ns/adms#Identifier> ;
+        mu:uuid "7aaf4860-d20a-4bea-b01e-fe5089306fc4" ;
+        skos:notation "SharePoint identificator" ;
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/9964f2f3-a786-439d-b06c-8bdc2f3c87b6> .
+
+      <http://data.lblod.info/id/gestructureerdeIdentificatoren/9964f2f3-a786-439d-b06c-8bdc2f3c87b6> a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
+        mu:uuid "9964f2f3-a786-439d-b06c-8bdc2f3c87b6" .
+        
+
+        <http://data.lblod.info/id/identificatoren/f80e4bc0-cc90-46d9-b565-13796d365f62> a <http://www.w3.org/ns/adms#Identifier>;
+        mu:uuid "f80e4bc0-cc90-46d9-b565-13796d365f62";
+        skos:notation "KBO nummer";
+        generiek:gestructureerdeIdentificator <http://data.lblod.info/id/gestructureerdeIdentificatoren/7cb04d95-300c-40ff-b61d-92d02f168ab8>.
+          <http://data.lblod.info/id/gestructureerdeIdentificatoren/7cb04d95-300c-40ff-b61d-92d02f168ab8>
+            a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>;
+        mu:uuid "7cb04d95-300c-40ff-b61d-92d02f168ab8";
+        <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0459993992".
+      <http://data.lblod.info/id/bestuurseenheden/fc648151-f691-4d75-a954-b3249a4deb76> <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/f80e4bc0-cc90-46d9-b565-13796d365f62> .
+
+        <http://data.lblod.info/id/vestigingen/d8a87b19-9600-4908-bd4c-8f6171aeecb6> a <http://www.w3.org/ns/org#Site>;
+        mu:uuid "d8a87b19-9600-4908-bd4c-8f6171aeecb6";
+        <http://data.lblod.info/vocabularies/erediensten/vestigingstype> <http://lblod.data.gift/concepts/f1381723dec42c0b6ba6492e41d6f5dd>;
+        <https://data.vlaanderen.be/ns/organisatie#bestaatUit> <http://data.lblod.info/id/adressen/4968a2cd-339d-4af9-ba75-d71240840670>;
+        org:siteAddress <http://data.lblod.info/id/contact-punten/c7a93cff-6c40-4cd1-ac90-9912c1c64260>,
+                        <http://data.lblod.info/id/contact-punten/60c5fc71-43c9-454c-bfe1-db0b7945639b>.
+
+      <http://data.lblod.info/id/contact-punten/c7a93cff-6c40-4cd1-ac90-9912c1c64260> a <http://schema.org/ContactPoint>;
+        mu:uuid "c7a93cff-6c40-4cd1-ac90-9912c1c64260";
+        <http://schema.org/contactType> "Primary".
+      <http://data.lblod.info/id/contact-punten/60c5fc71-43c9-454c-bfe1-db0b7945639b> a <http://schema.org/ContactPoint>;
+        mu:uuid "60c5fc71-43c9-454c-bfe1-db0b7945639b";
+        <http://schema.org/contactType> "Secondary".
+
+      <http://data.lblod.info/id/adressen/4968a2cd-339d-4af9-ba75-d71240840670> a <http://www.w3.org/ns/locn#Address>;
+        mu:uuid "4968a2cd-339d-4af9-ba75-d71240840670".
+
+      <http://data.lblod.info/id/bestuurseenheden/fc648151-f691-4d75-a954-b3249a4deb76> a besluit:Bestuurseenheid, org:Organization, dc_terms:Agent;
+        mu:uuid "fc648151-f691-4d75-a954-b3249a4deb76" ;
+        org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/34b5af85-dc9f-468f-9e03-ef89b174c267> ;
+        skos:prefLabel  "Algemeen Ziekenhuis Van Enschodt" ;
+        <http://www.w3.org/ns/regorg#orgStatus> <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> ;
+        <http://www.w3.org/ns/adms#identifier> <http://data.lblod.info/id/identificatoren/7aaf4860-d20a-4bea-b01e-fe5089306fc4> ;
+        <http://www.w3.org/ns/org#hasPrimarySite> <http://data.lblod.info/id/vestigingen/d8a87b19-9600-4908-bd4c-8f6171aeecb6> .

--- a/config/migrations/2024/20240212141020-onboarding-public-ocmw-associations/20240215140143-missing-organen-and-functies-for-ocmw-associations.sparql
+++ b/config/migrations/2024/20240212141020-onboarding-public-ocmw-associations/20240215140143-missing-organen-and-functies-for-ocmw-associations.sparql
@@ -1,0 +1,42 @@
+
+    INSERT {
+      GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+      ?orgaanInTime a <http://data.vlaanderen.be/ns/besluit#Bestuursorgaan> ;
+        <http://mu.semte.ch/vocabularies/core/uuid> ?uuidOrgaanInTime ;
+        <https://data.vlaanderen.be/ns/generiek#isTijdspecialisatieVan> ?orgaan ;
+        <http://data.vlaanderen.be/ns/mandaat#bindingStart> "2019-01-01T00:00:00"^^xsd:dateTime .
+
+      ?orgaan a <http://data.vlaanderen.be/ns/besluit#Bestuursorgaan> ;
+        <http://mu.semte.ch/vocabularies/core/uuid> ?uuidOrgaan ;
+        <http://www.w3.org/2004/02/skos/core#prefLabel> ?orgaanLabel ;
+        <http://www.w3.org/ns/org#classification> ?classificationOrgaan ;
+        <http://data.vlaanderen.be/ns/besluit#bestuurt> ?bestuurseenheid .
+      }
+    } WHERE {
+      VALUES ?classificationOrgaan {
+        "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943"
+        "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528"
+        "http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/41caf7e6-b040-4720-9cc2-a96cfffed5b4"
+      }
+
+      VALUES ?bestuurseenheid {
+        <http://data.lblod.info/id/bestuurseenheden/e2fdd5a7-c67f-4cad-99c5-6a2c5212f9a3>
+<http://data.lblod.info/id/bestuurseenheden/384b48dc-6860-49b4-a9ef-efa557299950>
+<http://data.lblod.info/id/bestuurseenheden/98afbe1f-4e7d-4896-925b-d7324302ce73>
+<http://data.lblod.info/id/bestuurseenheden/fc648151-f691-4d75-a954-b3249a4deb76>
+      }
+
+      ?bestuurseenheid a <http://data.vlaanderen.be/ns/besluit#Bestuurseenheid> ;
+        skos:prefLabel ?bestuurseenheidLabel .
+
+      ?classificationOrgaan skos:prefLabel ?classificationOrgaanLabel .
+
+      BIND(CONCAT(?classificationOrgaanLabel, " ", ?bestuurseenheidLabel) as ?orgaanLabel)
+
+      BIND(MD5(CONCAT(?bestuurseenheid, ?classificationOrgaan, "orgaanInTime")) as ?uuidOrgaanInTime)
+      BIND(MD5(CONCAT(?bestuurseenheid, ?classificationOrgaan, "orgaan")) as ?uuidOrgaan)
+      BIND(IRI(CONCAT("http://data.lblod.info/id/bestuursorganen/", ?uuidOrgaanInTime)) AS ?orgaanInTime)
+      BIND(IRI(CONCAT("http://data.lblod.info/id/bestuursorganen/", ?uuidOrgaan)) AS ?orgaan)
+    }
+    ;
+    

--- a/config/migrations/2024/20240212141020-onboarding-public-ocmw-associations/20240215140212-import-public-ocmw-association-addresses.sparql
+++ b/config/migrations/2024/20240212141020-onboarding-public-ocmw-associations/20240215140212-import-public-ocmw-association-addresses.sparql
@@ -1,0 +1,2352 @@
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "110";
+            
+            <http://www.w3.org/ns/locn#postCode> "2650";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Edegem";
+            <http://www.w3.org/ns/locn#thoroughfare> "Oude-Godstraat";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Edegem";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Oude-Godstraat 110, 2650 Edegem, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0685516024" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "35";
+            
+            <http://www.w3.org/ns/locn#postCode> "2018";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Antwerpen";
+            <http://www.w3.org/ns/locn#thoroughfare> "Ballaarstraat";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Antwerpen";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Ballaarstraat 35, 2018 Antwerpen, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0809699184" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "1";
+            
+            <http://www.w3.org/ns/locn#postCode> "3920";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Lommel";
+            <http://www.w3.org/ns/locn#thoroughfare> "Kapittelhof";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Lommel";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Kapittelhof 1, 3920 Lommel, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0689553994" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "30";
+            
+            <http://www.w3.org/ns/locn#postCode> "8940";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Wervik";
+            <http://www.w3.org/ns/locn#thoroughfare> "Steenakker";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Wervik";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Steenakker 30, 8940 Wervik, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0686537789" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "15";
+            
+            <http://www.w3.org/ns/locn#postCode> "2820";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Bonheiden";
+            <http://www.w3.org/ns/locn#thoroughfare> "Baxbos";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Bonheiden";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Baxbos 15, 2820 Bonheiden, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0875376696" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "70";
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.busnummer> "Bus 3";
+            <http://www.w3.org/ns/locn#postCode> "3910";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Pelt";
+            <http://www.w3.org/ns/locn#thoroughfare> "Hoekstraat";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Pelt";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Hoekstraat 70 - Bus 3, 3910 Pelt, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0267393663" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "25";
+            
+            <http://www.w3.org/ns/locn#postCode> "2900";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Schoten";
+            <http://www.w3.org/ns/locn#thoroughfare> "Verbertstraat";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Schoten";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Verbertstraat 25, 2900 Schoten, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0694597697" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "17";
+            
+            <http://www.w3.org/ns/locn#postCode> "8700";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Tielt";
+            <http://www.w3.org/ns/locn#thoroughfare> "Deken Darraslaan";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Tielt";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Deken Darraslaan 17, 8700 Tielt, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0711824305" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "5";
+            
+            <http://www.w3.org/ns/locn#postCode> "8530";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Harelbeke";
+            <http://www.w3.org/ns/locn#thoroughfare> "Kollegeplein";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Harelbeke";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Kollegeplein 5, 8530 Harelbeke, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0684891363" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "12";
+            
+            <http://www.w3.org/ns/locn#postCode> "3800";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Sint-Truiden";
+            <http://www.w3.org/ns/locn#thoroughfare> "Clement Cartuyvelstraat";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Sint-Truiden";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Clement Cartuyvelstraat 12, 3800 Sint-Truiden, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0687742074" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "75";
+            
+            <http://www.w3.org/ns/locn#postCode> "1745";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Opwijk";
+            <http://www.w3.org/ns/locn#thoroughfare> "Kloosterstraat";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Opwijk";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Kloosterstraat 75, 1745 Opwijk, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0684493762" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "30";
+            
+            <http://www.w3.org/ns/locn#postCode> "3530";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Houthalen-Helchteren";
+            <http://www.w3.org/ns/locn#thoroughfare> "Pastorijstraat";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Houthalen-Helchteren";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Pastorijstraat 30, 3530 Houthalen-Helchteren, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0688812935" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "10";
+            
+            <http://www.w3.org/ns/locn#postCode> "8500";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Kortrijk";
+            <http://www.w3.org/ns/locn#thoroughfare> "President Kennedypark";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Kortrijk";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "President Kennedypark 10, 8500 Kortrijk, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0630835639" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "91";
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.busnummer> "Bus 1";
+            <http://www.w3.org/ns/locn#postCode> "9900";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Eeklo";
+            <http://www.w3.org/ns/locn#thoroughfare> "Oostveldstraat";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Eeklo";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Oostveldstraat 91 - Bus 1, 9900 Eeklo, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0871009916" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "28";
+            
+            <http://www.w3.org/ns/locn#postCode> "2860";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Sint-Katelijne-Waver";
+            <http://www.w3.org/ns/locn#thoroughfare> "Wilsonstraat";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Sint-Katelijne-Waver";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Wilsonstraat 28, 2860 Sint-Katelijne-Waver, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0680439360" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "100";
+            
+            <http://www.w3.org/ns/locn#postCode> "9820";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Merelbeke";
+            <http://www.w3.org/ns/locn#thoroughfare> "Salisburylaan";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Merelbeke";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Salisburylaan 100, 9820 Merelbeke, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0698817989" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "72";
+            
+            <http://www.w3.org/ns/locn#postCode> "1800";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Vilvoorde";
+            <http://www.w3.org/ns/locn#thoroughfare> "Harensesteenweg";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Vilvoorde";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Harensesteenweg 72, 1800 Vilvoorde, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0697787118" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "80";
+            
+            <http://www.w3.org/ns/locn#postCode> "9300";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Aalst";
+            <http://www.w3.org/ns/locn#thoroughfare> "Merestraat";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Aalst";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Merestraat 80, 9300 Aalst, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0729523736" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "2";
+            
+            <http://www.w3.org/ns/locn#postCode> "9160";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Lokeren";
+            <http://www.w3.org/ns/locn#thoroughfare> "Lepelstraat";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Lokeren";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Lepelstraat 2, 9160 Lokeren, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0871206587" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "51";
+            
+            <http://www.w3.org/ns/locn#postCode> "3700";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Tongeren";
+            <http://www.w3.org/ns/locn#thoroughfare> "Hazelereik";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Tongeren";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Hazelereik 51, 3700 Tongeren, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0242469910" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "10";
+            
+            <http://www.w3.org/ns/locn#postCode> "8000";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Brugge";
+            <http://www.w3.org/ns/locn#thoroughfare> "Ruddershove";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Brugge";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Ruddershove 10, 8000 Brugge, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0266559859" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "84";
+            
+            <http://www.w3.org/ns/locn#postCode> "8400";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Oostende";
+            <http://www.w3.org/ns/locn#thoroughfare> "Kaïrostraat";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Oostende";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Kaïrostraat 84, 8400 Oostende, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0473908049" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "30";
+            
+            <http://www.w3.org/ns/locn#postCode> "9810";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Nazareth";
+            <http://www.w3.org/ns/locn#thoroughfare> "Zwanestraat";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Nazareth";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Zwanestraat 30, 9810 Nazareth, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0885714720" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "43";
+            
+            <http://www.w3.org/ns/locn#postCode> "9940";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Evergem";
+            <http://www.w3.org/ns/locn#thoroughfare> "Sleidinge-dorp";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Evergem";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Sleidinge-dorp 43, 9940 Evergem, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0666615870" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "12";
+            
+            <http://www.w3.org/ns/locn#postCode> "8900";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Ieper";
+            <http://www.w3.org/ns/locn#thoroughfare> "Briekestraat";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Ieper";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Briekestraat 12, 8900 Ieper, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0262926319" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "10";
+            
+            <http://www.w3.org/ns/locn#postCode> "8800";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Roeselare";
+            <http://www.w3.org/ns/locn#thoroughfare> "Gasthuisstraat";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Roeselare";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Gasthuisstraat 10, 8800 Roeselare, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0537951706" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "5";
+            
+            <http://www.w3.org/ns/locn#postCode> "9000";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Gent";
+            <http://www.w3.org/ns/locn#thoroughfare> "Watersportlaan";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Gent";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Watersportlaan 5, 9000 Gent, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0262926616" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "4";
+            
+            <http://www.w3.org/ns/locn#postCode> "8000";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Brugge";
+            <http://www.w3.org/ns/locn#thoroughfare> "Ruddershove";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Brugge";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Ruddershove 4, 8000 Brugge, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0682844465" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "503";
+            
+            <http://www.w3.org/ns/locn#postCode> "2390";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Malle";
+            <http://www.w3.org/ns/locn#thoroughfare> "Antwerpsesteenweg";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Malle";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Antwerpsesteenweg 503, 2390 Malle, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0445508132" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "18";
+            
+            <http://www.w3.org/ns/locn#postCode> "2300";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Turnhout";
+            <http://www.w3.org/ns/locn#thoroughfare> "Albert Van Dyckstraat";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Turnhout";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Albert Van Dyckstraat 18, 2300 Turnhout, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0665553622" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "86";
+            
+            <http://www.w3.org/ns/locn#postCode> "9000";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Gent";
+            <http://www.w3.org/ns/locn#thoroughfare> "Onderbergen";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Gent";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Onderbergen 86, 9000 Gent, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0643926085" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "2";
+            
+            <http://www.w3.org/ns/locn#postCode> "2440";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Geel";
+            <http://www.w3.org/ns/locn#thoroughfare> "J.B.-Stessensstraat";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Geel";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "J.B.-Stessensstraat 2, 2440 Geel, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0844179716" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "2";
+            
+            <http://www.w3.org/ns/locn#postCode> "8000";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Brugge";
+            <http://www.w3.org/ns/locn#thoroughfare> "Professor Dr. J. Sebrechtsstraat";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Brugge";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Professor Dr. J. Sebrechtsstraat 2, 8000 Brugge, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0871928743" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "4";
+            
+            <http://www.w3.org/ns/locn#postCode> "8000";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Brugge";
+            <http://www.w3.org/ns/locn#thoroughfare> "Ruddershove";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Brugge";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Ruddershove 4, 8000 Brugge, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0807042275" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "200";
+            
+            <http://www.w3.org/ns/locn#postCode> "2300";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Turnhout";
+            <http://www.w3.org/ns/locn#thoroughfare> "Campus Blairon";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Turnhout";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Campus Blairon 200, 2300 Turnhout, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0222947570" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "4";
+            
+            <http://www.w3.org/ns/locn#postCode> "8000";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Brugge";
+            <http://www.w3.org/ns/locn#thoroughfare> "Ruddershove";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Brugge";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Ruddershove 4, 8000 Brugge, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0894999895" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "4";
+            
+            <http://www.w3.org/ns/locn#postCode> "8000";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Brugge";
+            <http://www.w3.org/ns/locn#thoroughfare> "Ruddershove";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Brugge";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Ruddershove 4, 8000 Brugge, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0863329296" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "4";
+            
+            <http://www.w3.org/ns/locn#postCode> "8000";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Brugge";
+            <http://www.w3.org/ns/locn#thoroughfare> "Ruddershove";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Brugge";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Ruddershove 4, 8000 Brugge, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0831970978" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "4";
+            
+            <http://www.w3.org/ns/locn#postCode> "8000";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Brugge";
+            <http://www.w3.org/ns/locn#thoroughfare> "Ruddershove";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Brugge";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Ruddershove 4, 8000 Brugge, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0267404056" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "4";
+            
+            <http://www.w3.org/ns/locn#postCode> "8000";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Brugge";
+            <http://www.w3.org/ns/locn#thoroughfare> "Ruddershove";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Brugge";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Ruddershove 4, 8000 Brugge, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0860256673" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "29A";
+            
+            <http://www.w3.org/ns/locn#postCode> "9290";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Berlare";
+            <http://www.w3.org/ns/locn#thoroughfare> "Baron Tibbautstraat";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Berlare";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Baron Tibbautstraat 29A, 9290 Berlare, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0677764437" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "30";
+            
+            <http://www.w3.org/ns/locn#postCode> "8900";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Ieper";
+            <http://www.w3.org/ns/locn#thoroughfare> "Poperingseweg";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Ieper";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Poperingseweg 30, 8900 Ieper, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0233210764" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "11";
+            
+            <http://www.w3.org/ns/locn#postCode> "3500";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Hasselt";
+            <http://www.w3.org/ns/locn#thoroughfare> "Stadsomvaart";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Hasselt";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Stadsomvaart 11, 3500 Hasselt, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0267302405" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "27";
+            
+            <http://www.w3.org/ns/locn#postCode> "2800";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Mechelen";
+            <http://www.w3.org/ns/locn#thoroughfare> "Lange Schipstraat";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Mechelen";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Lange Schipstraat 27, 2800 Mechelen, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0827396340" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "51";
+            
+            <http://www.w3.org/ns/locn#postCode> "2000";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Antwerpen";
+            <http://www.w3.org/ns/locn#thoroughfare> "Falconrui";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Antwerpen";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Falconrui 51, 2000 Antwerpen, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0458878195" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "19";
+            
+            <http://www.w3.org/ns/locn#postCode> "2430";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Laakdal";
+            <http://www.w3.org/ns/locn#thoroughfare> "Markt";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Laakdal";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Markt 19, 2430 Laakdal, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0886198829" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "27";
+            
+            <http://www.w3.org/ns/locn#postCode> "2800";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Mechelen";
+            <http://www.w3.org/ns/locn#thoroughfare> "Lange Schipstraat";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Mechelen";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Lange Schipstraat 27, 2800 Mechelen, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0267313291" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "75";
+            
+            <http://www.w3.org/ns/locn#postCode> "2930";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Brasschaat";
+            <http://www.w3.org/ns/locn#thoroughfare> "Prins Kavellei";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Brasschaat";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Prins Kavellei 75, 2930 Brasschaat, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0647949706" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "44";
+            
+            <http://www.w3.org/ns/locn#postCode> "2870";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Puurs-Sint-Amands";
+            <http://www.w3.org/ns/locn#thoroughfare> "Palingstraat";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Puurs-Sint-Amands";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Palingstraat 44, 2870 Puurs-Sint-Amands, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0664681216" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "62";
+            
+            <http://www.w3.org/ns/locn#postCode> "9600";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Ronse";
+            <http://www.w3.org/ns/locn#thoroughfare> "Oscar Delghuststraat";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Ronse";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Oscar Delghuststraat 62, 9600 Ronse, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0480589567" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "50";
+            
+            <http://www.w3.org/ns/locn#postCode> "9660";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Brakel";
+            <http://www.w3.org/ns/locn#thoroughfare> "Kasteelstraat";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Brakel";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Kasteelstraat 50, 9660 Brakel, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0886485770" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "99";
+            
+            <http://www.w3.org/ns/locn#postCode> "9100";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Sint-Niklaas";
+            <http://www.w3.org/ns/locn#thoroughfare> "Abingdonstraat";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Sint-Niklaas";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Abingdonstraat 99, 9100 Sint-Niklaas, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0267314875" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "3";
+            
+            <http://www.w3.org/ns/locn#postCode> "9170";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Sint-Gillis-Waas";
+            <http://www.w3.org/ns/locn#thoroughfare> "Zwanenhoekstraat";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Sint-Gillis-Waas";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Zwanenhoekstraat 3, 9170 Sint-Gillis-Waas, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0683473579" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "2";
+            
+            <http://www.w3.org/ns/locn#postCode> "9160";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Lokeren";
+            <http://www.w3.org/ns/locn#thoroughfare> "Polderstraat";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Lokeren";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Polderstraat 2, 9160 Lokeren, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0684613726" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "92";
+            
+            <http://www.w3.org/ns/locn#postCode> "9120";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Beveren";
+            <http://www.w3.org/ns/locn#thoroughfare> "Oude Zandstraat";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Beveren";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Oude Zandstraat 92, 9120 Beveren, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0696715960" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "6";
+            
+            <http://www.w3.org/ns/locn#postCode> "3600";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Genk";
+            <http://www.w3.org/ns/locn#thoroughfare> "Schiepse Bos";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Genk";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Schiepse Bos 6, 3600 Genk, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0256543917" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "15";
+            
+            <http://www.w3.org/ns/locn#postCode> "3600";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Genk";
+            <http://www.w3.org/ns/locn#thoroughfare> "Welzijnscampus";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Genk";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Welzijnscampus 15, 3600 Genk, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0505849852" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "8";
+            
+            <http://www.w3.org/ns/locn#postCode> "1742";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Ternat";
+            <http://www.w3.org/ns/locn#thoroughfare> "Kapelleveld";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Ternat";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Kapelleveld 8, 1742 Ternat, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0467270576" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "8";
+            
+            <http://www.w3.org/ns/locn#postCode> "9140";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Temse";
+            <http://www.w3.org/ns/locn#thoroughfare> "Clement D'hooghelaan";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Temse";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Clement D'hooghelaan 8, 9140 Temse, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0736364909" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "14A";
+            
+            <http://www.w3.org/ns/locn#postCode> "9190";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Stekene";
+            <http://www.w3.org/ns/locn#thoroughfare> "Kerkstraat";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Stekene";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Kerkstraat 14A, 9190 Stekene, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0689674948" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "2";
+            
+            <http://www.w3.org/ns/locn#postCode> "8870";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Izegem";
+            <http://www.w3.org/ns/locn#thoroughfare> "Kokelarestraat";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Izegem";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Kokelarestraat 2, 8870 Izegem, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0683771509" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "99";
+            
+            <http://www.w3.org/ns/locn#postCode> "9100";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Sint-Niklaas";
+            <http://www.w3.org/ns/locn#thoroughfare> "Abingdonstraat";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Sint-Niklaas";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Abingdonstraat 99, 9100 Sint-Niklaas, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0862943474" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "5";
+            
+            <http://www.w3.org/ns/locn#postCode> "9100";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Sint-Niklaas";
+            <http://www.w3.org/ns/locn#thoroughfare> "Lodewijk De Meesterstraat";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Sint-Niklaas";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Lodewijk De Meesterstraat 5, 9100 Sint-Niklaas, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0262562568" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "1";
+            
+            <http://www.w3.org/ns/locn#postCode> "3680";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Maaseik";
+            <http://www.w3.org/ns/locn#thoroughfare> "Markt";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Maaseik";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Markt 1, 3680 Maaseik, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0249211806" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "47";
+            
+            <http://www.w3.org/ns/locn#postCode> "3000";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Leuven";
+            <http://www.w3.org/ns/locn#thoroughfare> "Andreas Vesaliusstraat";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Leuven";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Andreas Vesaliusstraat 47, 3000 Leuven, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0663810590" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "31";
+            
+            <http://www.w3.org/ns/locn#postCode> "8301";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Knokke-Heist";
+            <http://www.w3.org/ns/locn#thoroughfare> "Noordhinder";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Knokke-Heist";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Noordhinder 31, 8301 Knokke-Heist, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0863329989" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "10";
+            
+            <http://www.w3.org/ns/locn#postCode> "8870";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Izegem";
+            <http://www.w3.org/ns/locn#thoroughfare> "Korenmarkt";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Izegem";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Korenmarkt 10, 8870 Izegem, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0466193777" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "6";
+            
+            <http://www.w3.org/ns/locn#postCode> "8000";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Brugge";
+            <http://www.w3.org/ns/locn#thoroughfare> "Sint-Annarei";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Brugge";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Sint-Annarei 6, 8000 Brugge, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0878405769" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "401A";
+            
+            <http://www.w3.org/ns/locn#postCode> "8400";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Oostende";
+            <http://www.w3.org/ns/locn#thoroughfare> "Stuiverstraat";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Oostende";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Stuiverstraat 401A, 8400 Oostende, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0479985593" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "1";
+            
+            <http://www.w3.org/ns/locn#postCode> "8480";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Ichtegem";
+            <http://www.w3.org/ns/locn#thoroughfare> "Stationstraat";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Ichtegem";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Stationstraat 1, 8480 Ichtegem, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0873440458" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "1";
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.busnummer> "Bus 3";
+            <http://www.w3.org/ns/locn#postCode> "8301";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Knokke-Heist";
+            <http://www.w3.org/ns/locn#thoroughfare> "Kraaiennestplein";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Knokke-Heist";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Kraaiennestplein 1 - Bus 3, 8301 Knokke-Heist, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0865506155" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "80";
+            
+            <http://www.w3.org/ns/locn#postCode> "9300";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Aalst";
+            <http://www.w3.org/ns/locn#thoroughfare> "Merestraat";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Aalst";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Merestraat 80, 9300 Aalst, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0263545337" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "3";
+            
+            <http://www.w3.org/ns/locn#postCode> "9700";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Oudenaarde";
+            <http://www.w3.org/ns/locn#thoroughfare> "Minderbroedersstraat";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Oudenaarde";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Minderbroedersstraat 3, 9700 Oudenaarde, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0465810133" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "2";
+            
+            <http://www.w3.org/ns/locn#postCode> "2220";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Heist-Op-Den-Berg";
+            <http://www.w3.org/ns/locn#thoroughfare> "Stationsstraat";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Heist-op-den-Berg";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Stationsstraat 2, 2220 Heist-op-den-Berg, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0781430812" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "55";
+            
+            <http://www.w3.org/ns/locn#postCode> "2280";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Grobbendonk";
+            <http://www.w3.org/ns/locn#thoroughfare> "Schransstraat";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Grobbendonk";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Schransstraat 55, 2280 Grobbendonk, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0786960406" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "264";
+            
+            <http://www.w3.org/ns/locn#postCode> "2235";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Hulshout";
+            <http://www.w3.org/ns/locn#thoroughfare> "Grote Baan";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Hulshout";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Grote Baan 264, 2235 Hulshout, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0780658572" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "15";
+            
+            <http://www.w3.org/ns/locn#postCode> "8710";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Wielsbeke";
+            <http://www.w3.org/ns/locn#thoroughfare> "Hernieuwenstraat";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Wielsbeke";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Hernieuwenstraat 15, 8710 Wielsbeke, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "30";
+            
+            <http://www.w3.org/ns/locn#postCode> "1500";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Halle";
+            <http://www.w3.org/ns/locn#thoroughfare> "Auguste Demaeghtlaan";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Halle";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Auguste Demaeghtlaan 30, 1500 Halle, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0264998753" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "50";
+            
+            <http://www.w3.org/ns/locn#postCode> "2870";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Puurs-Sint-Amands";
+            <http://www.w3.org/ns/locn#thoroughfare> "Palingstraat";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Puurs-Sint-Amands";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Palingstraat 50, 2870 Puurs-Sint-Amands, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0866242662" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "30";
+            
+            <http://www.w3.org/ns/locn#postCode> "3070";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Kortenberg";
+            <http://www.w3.org/ns/locn#thoroughfare> "Dr. V. De Walsplein";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Kortenberg";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Dr. V. De Walsplein 30, 3070 Kortenberg, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0889412695" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "19";
+            
+            <http://www.w3.org/ns/locn#postCode> "9070";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Destelbergen";
+            <http://www.w3.org/ns/locn#thoroughfare> "Kouterlaan";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Destelbergen";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Kouterlaan 19, 9070 Destelbergen, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0874267037" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "120";
+            
+            <http://www.w3.org/ns/locn#postCode> "2890";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Puurs-Sint-Amands";
+            <http://www.w3.org/ns/locn#thoroughfare> "Kuitegemstraat";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Puurs-Sint-Amands";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Kuitegemstraat 120, 2890 Puurs-Sint-Amands, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0836906793" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "3";
+            
+            <http://www.w3.org/ns/locn#postCode> "1790";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Affligem";
+            <http://www.w3.org/ns/locn#thoroughfare> "Bellestraat";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Affligem";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Bellestraat 3, 1790 Affligem, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0834358069" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      INSERT {
+        GRAPH ?g {
+          ?addressUri 
+            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "27";
+            
+            <http://www.w3.org/ns/locn#postCode> "2830";
+            <http://www.w3.org/ns/locn#adminUnitL2> "Willebroek";
+            <http://www.w3.org/ns/locn#thoroughfare> "Tisseltsesteenweg";
+            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Willebroek";
+            <https://data.vlaanderen.be/ns/adres#land> "België";
+            <http://www.w3.org/ns/locn#fullAddress> "Tisseltsesteenweg 27, 2830 Willebroek, België".
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0459993992" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    

--- a/config/migrations/2024/20240212141020-onboarding-public-ocmw-associations/20240215140236-import-public-ocmw-association-contact-details.sparql
+++ b/config/migrations/2024/20240212141020-onboarding-public-ocmw-associations/20240215140236-import-public-ocmw-association-contact-details.sparql
@@ -1,0 +1,1584 @@
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3234508400" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.woonzorgnetwerkedegem.be/" .
+            ?contact <http://schema.org/email> "immaculata@wznedegem.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0685516024" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3234313131" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.zorgbedrijf.antwerpen.be/" .
+            ?contact <http://schema.org/email> "klantendienst@zorgbedrijf.antwerpen.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0809699184" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3211550180" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.zorggroeplommel.be/" .
+            ?contact <http://schema.org/email> "e-mailinfo@zorggroeplommel.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0689553994" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3256300200" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.wzbwervik.be/" .
+            ?contact <http://schema.org/email> "callcenter@wzbwervik.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0686537789" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3211238700" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://welzijnsregio.be/" .
+            ?contact <http://schema.org/email> "gezinszorg@welzijnsregio.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0267393663" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3232695100" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://wzgvoorkempen.be/" .
+            ?contact <http://schema.org/email> "info@wzgvoorkempen.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0694597697" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3251427979" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.ztielt.be/" .
+            ?contact <http://schema.org/email> "info@ztielt.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0711824305" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3256735390" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.zbharelbeke.be/nl" .
+            ?contact <http://schema.org/email> "onthaal@zbharelbeke.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0684891363" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3211697044" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.zorgbedrijfsinttruiden.be/" .
+            ?contact <http://schema.org/email> "info@zorgbedrijfsinttruiden.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0687742074" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3252365940" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://opcura.opwijk.be/" .
+            ?contact <http://schema.org/email> "info@opcura.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0684493762" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3211492000" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.houthalen-helchteren.be/zorg-houthalen-helchteren" .
+            ?contact <http://schema.org/email> "info@houthalen-helchteren.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0688812935" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3256241620" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.welzijn13.be/" .
+            ?contact <http://schema.org/email> "info@konektizwvl.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0630835639" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3292471081" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.welzijnsband.be/" .
+            ?contact <http://schema.org/email> "info@welzijnsband.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0871009916" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3215306997" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.zorgbedrijfrivierenland.be/" .
+            ?contact <http://schema.org/email> "info@zbrivierenland.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0680439360" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3292722000" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.zorgband.be/" .
+            ?contact <http://schema.org/email> "info@zorgband.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0698817989" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3224470700" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.zorgvilvoorde.be" .
+            ?contact <http://schema.org/email> "info@zorgvilvoorde.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0697787118" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3253764111" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "http://www.asz.be/" .
+            ?contact <http://schema.org/email> "info@asz.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0729523736" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3237606060" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://vitaz.be/" .
+            ?contact <http://schema.org/email> "info@vitaz.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0871206587" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3212396111" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.azvesalius.be/" .
+            ?contact <http://schema.org/email> "directiesecretariaat@azvesalius.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0242469910" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3250452111" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.azsintjan.be/nl" .
+            ?contact <http://schema.org/email> "info@azsintjan.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0266559859" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3259555297" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.azsintjan.be/nl/diensten/gynaecologie-verloskunde/materniteit/campus-henri-serruys" .
+            ?contact <http://schema.org/email> "cardiologie.oostende@azsintjan.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0473908049" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.svkleieenschelde.be/" .
+            
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0885714720" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3292103070" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.zorgbedrijfmeetjesland.be/" .
+            ?contact <http://schema.org/email> "info@zorgbedrijfmeetjesland.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0666615870" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3257353535" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://yperman.net/" .
+            ?contact <http://schema.org/email> "info@yperman.net" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0262926319" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3251805200" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://motena.be/nl" .
+            ?contact <http://schema.org/email> "info@motena.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0537951706" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3292247111" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.janpalfijn.be/" .
+            ?contact <http://schema.org/email> "info@janpalfijngent.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0262926616" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3250327000" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.mintus.be/" .
+            ?contact <http://schema.org/email> "info@mintus.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0682844465" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3232187209" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.kina.be/" .
+            ?contact <http://schema.org/email> "home@kina.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0445508132" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3214284000" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.zorggroep-orion.be/" .
+            ?contact <http://schema.org/email> "secretariaat@zorggroep-orion.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0665553622" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3292669561" .
+            
+            ?contact <http://schema.org/email> "info@sociaalverhuurkantoor.gent.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0643926085" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3214577777" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.ziekenhuisgeel.be/" .
+            ?contact <http://schema.org/email> "administratie@ziekenhuisgeel.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0844179716" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3250327678" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.ocmw-brugge.be/inloophuis-t-sas" .
+            ?contact <http://schema.org/email> "inloophuis@sasbrugge.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0871928743" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3250326087" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.spoorbrugge.be/" .
+            ?contact <http://schema.org/email> "info@spoorbrugge.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0807042275" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3214535350" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.welzijnszorgkempen.be/" .
+            ?contact <http://schema.org/email> "wzk.secretariaat@iok.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0222947570" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3250327240" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.maaltijdzorgplatform.be/" .
+            
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0894999895" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3250327555" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.deblauwelelie.be/" .
+            ?contact <http://schema.org/email> "onthaalouders@deblauwelelie.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0863329296" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.deschakelaar.be/" .
+            
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0831970978" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3250326325" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.wokbrugge.be/" .
+            ?contact <http://schema.org/email> "info@wokbrugge.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0267404056" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.svk-brugge.be/" .
+            
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0860256673" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3293375036" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.slaatjepraatje.be/weldenderend/" .
+            ?contact <http://schema.org/email> "info@slaatjepraatje.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0677764437" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3257226282" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.votjeugdhulp.be/" .
+            ?contact <http://schema.org/email> "administratie@votjeugdhulp.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0233210764" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3211335511" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.jessazh.be/" .
+            ?contact <http://schema.org/email> "info@jessazh.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0267302405" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3222115585" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.audio-lokaal.be/" .
+            
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0827396340" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3232981470" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://beschutwonenantwerpen.be/" .
+            ?contact <http://schema.org/email> "administratie@beschutwonenantwerpen.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0458878195" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3213663416​" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://heteepos.weebly.com/" .
+            
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0886198829" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3234313131" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.zorgbedrijfvlaanderen.be/woonzorgcentra/vesalius" .
+            ?contact <http://schema.org/email> "wzc.vesalius@zorgbedrijf.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0647949706" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3238901530" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.puurs-sint-amands.be/zorgbedrijfkleinbrabant" .
+            ?contact <http://schema.org/email> "info@zorgbedrijf.klein-brabant.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0664681216" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3255237411" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.ronse.be/nl/overo" .
+            ?contact <http://schema.org/email> "sociaalhuis@ronse.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0480589567" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3255432700" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.najaarszon.be/" .
+            
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0886485770" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3237786963" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.svkwaasland.be/" .
+            ?contact <http://schema.org/email> "info@svkwaasland.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0267314875" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3237271460" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.sint-gillis-waas.be/welzijn/welzijnsvereniging" .
+            ?contact <http://schema.org/email> "info@welzijnsvereniging.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0683473579" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3292350100" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://zorgbedrijf-sakura.lokeren.be/" .
+            ?contact <http://schema.org/email> "info@zorgbedrijfsakura.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0684613726" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3233755410" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://zorgpuntwaasland.be/" .
+            ?contact <http://schema.org/email> "info@zpw.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0696715960" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3289325050" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.zol.be/" .
+            ?contact <http://schema.org/email> "info@zol.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0256543917" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3289573500" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.zoggenk.be/nl" .
+            ?contact <http://schema.org/email> "info@zoggenk.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0505849852" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3225680990" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.welzijnskoepelwb.be/" .
+            ?contact <http://schema.org/email> "vraag@welzijnskoepelwb.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0467270576" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3237102560" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.sleutelzorgtemse.be/" .
+            ?contact <http://schema.org/email> "info@sleutelzorgtemse.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0736364909" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3234322900" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.zorgstekene.be/" .
+            ?contact <http://schema.org/email> "info@zorgstekene.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0689674948" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3251336677" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.izegem.be/zorg" .
+            ?contact <http://schema.org/email> "info@zorgizegem.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0683771509" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3237786240" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://schuldbemiddelingwaasland.be/" .
+            ?contact <http://schema.org/email> "info@schuldbemiddelingwaasland.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0862943474" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3237606060" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://vitaz.be/" .
+            ?contact <http://schema.org/email> "info@vitaz.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0262562568" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.zol.be/" .
+            
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0249211806" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3216248011" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.zorgleuven.be/" .
+            ?contact <http://schema.org/email> "info@zorgleuven.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0663810590" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3250530080" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.hetdak.org/" .
+            ?contact <http://schema.org/email> "dak@knokke-heist.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0863329989" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3251321622" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.woondienst.be/" .
+            ?contact <http://schema.org/email> "info@woondienst.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0466193777" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3250327190" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.onshuisbrugge.be/" .
+            ?contact <http://schema.org/email> "info@onshuisbrugge.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0878405769" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.svkbredeneoostende.be/" .
+            
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0479985593" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3259342273" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.woonpuntinfo.be/" .
+            ?contact <http://schema.org/email> "loket@woonpuntinfo.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0873440458" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3250530930" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.knokke-heist.be/openingsuren-en-contactinfo/de-woonwinkel" .
+            ?contact <http://schema.org/email> "woonwinkel@knokke-heist.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0865506155" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3253764111" .
+            
+            ?contact <http://schema.org/email> "info@asz.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0263545337" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3255336111" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.azoudenaarde.be/" .
+            ?contact <http://schema.org/email> "info@azoudenaarde.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0465810133" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3215246330" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.zilverenzwaan.be/" .
+            
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0781430812" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3214508120" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.grobbendonk.be/thema/detail/3003/woonzorgcentrum-de-wijngaard" .
+            ?contact <http://schema.org/email> "info.wzc@grobbendonk.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0786960406" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3215229390" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.hulshout.be/nl/welzijn/ouderen/woonzorgcentrum-ter-nethe" .
+            ?contact <http://schema.org/email> "wzcternethe@hulshout.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0780658572" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+        INSERT {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?contact <http://schema.org/telephone> "tel:+3256674504" .
+            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.wielsbeke.be/producten/woonzorgcentrum-ter-lembeek" .
+            ?contact <http://schema.org/email> "ouderenhuisvesting@wielsbeke.be" .
+          }
+        }
+        WHERE {
+          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
+            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "" .
+
+            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
+
+            ?contact <http://schema.org/contactType> "Primary" .
+          }
+        }
+      
+
+
+
+
+
+

--- a/config/migrations/2024/20240212141020-onboarding-public-ocmw-associations/20240216175509-import-public-ocmw-association-founders.sparql
+++ b/config/migrations/2024/20240212141020-onboarding-public-ocmw-associations/20240216175509-import-public-ocmw-association-founders.sparql
@@ -1,0 +1,4775 @@
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX adms: <http://www.w3.org/ns/adms#>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212236097" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212237285" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212240552" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212238374" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212246094" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212212541" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212214620" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0208038769" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212217885" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212218974" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207888816" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212221251" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212223726" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0216769165" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207713127" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212196705" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212198485" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212199673" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212203930" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212206801" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212209967" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212211452" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212210759" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212175721" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212178590" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212178788" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212181956" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0211104959" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0233210764" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212189676" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0233210764" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212208878" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0233210764" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212180570" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0233210764" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212181659" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0233210764" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212241047" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0242469910" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212175424" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0242469910" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212243720" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0249211806" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212195121" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0249211806" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207148052" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0256543917" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212215907" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0262562568" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212171860" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0262562568" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0211104959" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0262926319" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212214125" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0262926616" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212237186" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0263545337" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212182649" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0263545337" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212238473" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0264998753" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212247579" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0264998753" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212215511" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0264998753" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212207393" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0264998753" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212169682" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0264998753" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212172058" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0264998753" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207832792" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0266559859" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212216402" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0267302405" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212196111" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0267313291" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212240651" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0267314875" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212190072" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0267314875" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212169781" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0267314875" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212171860" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0267314875" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212241641" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0267393663" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0216772729" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0267393663" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0216772927" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0267393663" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212194230" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0267393663" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0216773323" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0267393663" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212204227" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0267393663" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212207591" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0267393663" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212207888" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0267393663" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207832792" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0267404056" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212235604" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0445508132" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212241740" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0445508132" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212242235" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0445508132" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212243423" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0445508132" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212243522" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0445508132" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212217390" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0445508132" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212224815" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0445508132" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212188983" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0445508132" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212200861" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0445508132" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212203831" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0445508132" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212167209" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0445508132" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212168001" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0445508132" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212172850" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0445508132" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212183540" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0445508132" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212185025" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0445508132" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212185421" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0445508132" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212186807" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0445508132" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212235604" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0458878195" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212184035" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0459993992" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212242235" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0459993992" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0308252043" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0465810133" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212207789" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0465810133" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212222241" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0466193777" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212192547" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0466193777" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212205415" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0466193777" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212344282" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212247282" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212212343" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212214026" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212194329" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212197891" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212208086" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212166021" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212174434" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212205118" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0473908049" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212243621" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0479985593" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212205118" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0479985593" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207460432" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0480589567" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212165922" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0480589567" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207148052" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0505849852" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207432520" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0537951706" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212174137" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0537951706" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212235703" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0630835639" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212236889" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0630835639" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212245205" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0630835639" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212218479" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0630835639" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212189676" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0630835639" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212190468" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0630835639" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212192745" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0630835639" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212198683" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0630835639" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0216770749" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0630835639" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212180570" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0630835639" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212181659" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0630835639" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212182748" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0630835639" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212191458" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0630835639" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212214125" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0643926085" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212243423" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0647949706" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207521503" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0663810590" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0208236927" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0663810590" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212210066" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0664681216" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212169088" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0664681216" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212175721" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0665553622" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212212244" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0666615870" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212195418" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0666615870" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212204326" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0666615870" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212239958" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0677764437" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212244215" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0677764437" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212190666" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0677764437" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212196111" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0680439360" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212170276" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0680439360" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207528035" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0682844465" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207832792" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0682844465" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212169781" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0683473579" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207489037" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0683771509" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212222241" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0683771509" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207511803" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0684493762" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212206504" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0684493762" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212194131" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0684613726" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212199277" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0684613726" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207492502" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0684891363" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212218479" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0684891363" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212248074" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0685516024" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212181659" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0686537789" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212172256" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0687742074" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0216773125" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0688812935" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212194230" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0689553994" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212173444" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0689674948" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212168001" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0694597697" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212183540" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0694597697" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212240651" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0696715960" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212190072" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0696715960" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212171860" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0696715960" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212187993" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0696715960" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207514474" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0697787118" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212177305" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0697787118" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212245106" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0698817989" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212246292" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0698817989" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212190666" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0698817989" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212199178" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0698817989" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212201356" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0698817989" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212176117" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0711824305" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212237186" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0729523736" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212213333" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0729523736" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212182649" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0729523736" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212173840" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0736364909" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212221251" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0780658572" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207535062" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0781430812" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212216895" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0781430812" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212214620" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0786960406" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207528035" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0807042275" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207832792" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0807042275" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212235604" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0809699184" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212237186" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0827396340" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207832792" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0827396340" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207148052" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0827396340" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212214125" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0827396340" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212216402" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0827396340" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212189676" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0827396340" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212196111" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0827396340" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212205118" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0827396340" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212174137" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0827396340" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212171860" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0827396340" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212175721" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0827396340" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207832792" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0831970978" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0231884636" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0834358069" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212184035" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0836906793" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212210066" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0836906793" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212169088" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0836906793" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207533874" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0844179716" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212212541" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0844179716" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207832792" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0860256673" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212240651" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0862943474" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212190072" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0862943474" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212169781" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0862943474" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212171860" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0862943474" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207832792" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0863329296" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207691252" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0863329989" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212334582" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0863329989" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207691252" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0865506155" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212334582" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0865506155" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212169088" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0866242662" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212242829" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0866242662" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212184035" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0866242662" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212210066" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0866242662" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212234416" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0871009916" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212237483" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0871009916" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212248173" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0871009916" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212212244" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0871009916" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212188488" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0871009916" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212195418" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0871009916" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212204326" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0871009916" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212170672" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0871009916" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212185817" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0871009916" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0697663986" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0871009916" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207463402" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0871206587" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212194131" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0871206587" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207528035" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0871928743" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207832792" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0871928743" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207491413" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0873440458" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207431332" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0873440458" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207528629" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0873440458" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207491215" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0873440458" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212221548" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0873440458" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212222340" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0873440458" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212209373" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0873440458" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212175523" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0873440458" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212197396" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0874267037" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212246292" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0874267037" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212242037" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0875376696" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212247777" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0875376696" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212209868" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0875376696" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212170276" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0875376696" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207832792" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0878405769" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212245106" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0885714720" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212201356" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0885714720" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212212541" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0886198829" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0216769165" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0886198829" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212330822" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0886485770" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212189478" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0889412695" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212238869" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0889412695" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212217786" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0889412695" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212219370" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0889412695" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212223033" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0889412695" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212190963" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0889412695" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212166120" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0889412695" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder ext:isFounderOfOrganization ?association .
+    ?founder org:hasSubOrganization ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?founder adms:identifier ?idFounder .
+    ?idFounder skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207832792" .
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0894999895" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;


### PR DESCRIPTION
# Context
These migrations add the data for public OCMW associations, this contains the core data, primary site data, contact details, and some boilerplate necessary to correctly model such organisations in OP.

Relevant tickets:
- OP-2947 for address data
- OP-2948 for contact details
- OP-2979 for related organisations

This data does **not** contain:
- Functionaries (will be synced from Loket)
- Change events

## Notes
- Finding the new organisations via the search functionality in the fronted requires re-indexing.
- Not all organisations have a SharePoint identifier
- Ter Lembeek has no KBO number, it will be added later by business.
- A zip-file containing all used data files and scripts can be found in OP-2540.
- For related organisations only founding organisations are added at this point

## TODO
- [X] Re-add organisation that was filtered due to duplicate KBO number when business corrected data
- [X] Add address information
- [X] Add contact data
- [x] Add related organizations

# Overview
This migration is spread over several files each introducing part of the data.

## [Import Loket data](https://github.com/lblod/app-organization-portal/blob/2c8651f56767da4cc08f5d06328336ce452b85a0/config/migrations/2024/20240212141020-onboarding-public-ocmw-associations/20240212141020-import-public-ocmw-associations-loket.ttl)
This file was generated from Loket's production data using the query below. It ensures we use the same URI's as Loket for organisations that are in both apps (most of the organisations in this case).

```sparql
CONSTRUCT {
    ?eenheid a <http://data.vlaanderen.be/ns/besluit#Bestuurseenheid> ;
      <http://mu.semte.ch/vocabularies/core/uuid> ?eenheidUuid ;
      <http://www.w3.org/ns/adms#identifier> ?idKbo ;
      <http://data.vlaanderen.be/ns/besluit#werkingsgebied> ?werkingsgebied .

    ?idKbo a <http://www.w3.org/ns/adms#Identifier> ;
      <http://mu.semte.ch/vocabularies/core/uuid> ?uuidIdKbo ;
      <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator> ?structuredIdKbo ;
      <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" .

    ?structuredIdKbo a <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator> ;
      <http://mu.semte.ch/vocabularies/core/uuid> ?uuidStructuredIdKbo ;
      <https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> ?kbo .

    ?orgaan a ?typeOrgaan ;
      <http://mu.semte.ch/vocabularies/core/uuid> ?orgaanUuid ;
      <http://www.w3.org/2004/02/skos/core#prefLabel> ?orgaanLabel ;
      <http://data.vlaanderen.be/ns/besluit#bestuurt> ?eenheid ;
      <http://www.w3.org/ns/org#classification> ?orgaanClassification .

    ?orgaanInTime a ?typeOrgaanInTime ;
      <http://mu.semte.ch/vocabularies/core/uuid> ?orgaanInTimeUuid ;
      <https://data.vlaanderen.be/ns/generiek#isTijdspecialisatieVan> ?orgaan ;
      <http://data.vlaanderen.be/ns/mandaat#bindingStart> ?orgaanStartDateTime .
  } WHERE {
    GRAPH <http://mu.semte.ch/graphs/public> {
      VALUES ?eenheidClassification {
        <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> # Welzijnsvereniging
        <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/cc4e2d67-603b-4784-9b61-e50bac1ec089> # OCMW vereniging
      }

      ?eenheid a <http://data.vlaanderen.be/ns/besluit#Bestuurseenheid> ;
        <http://mu.semte.ch/vocabularies/core/uuid> ?eenheidUuid ;
        <http://mu.semte.ch/vocabularies/ext/kbonummer> ?kbo ;
        <http://data.vlaanderen.be/ns/besluit#classificatie> ?eenheidClassification ;
        <http://data.vlaanderen.be/ns/besluit#werkingsgebied> ?werkingsgebied .

      ?orgaan a ?typeOrgaan ;
        <http://mu.semte.ch/vocabularies/core/uuid> ?orgaanUuid ;
        <http://www.w3.org/2004/02/skos/core#prefLabel> ?orgaanLabel ;
        <http://data.vlaanderen.be/ns/besluit#bestuurt> ?eenheid ;
        <http://data.vlaanderen.be/ns/besluit#classificatie> ?orgaanClassification .

      ?orgaanInTime a ?typeOrgaanInTime ;
        <http://mu.semte.ch/vocabularies/core/uuid> ?orgaanInTimeUuid ;
        <http://data.vlaanderen.be/ns/mandaat#isTijdspecialisatieVan> ?orgaan ;
        <http://data.vlaanderen.be/ns/mandaat#bindingStart> ?orgaanStart .

      BIND(strdt(concat(str(?orgaanStart), 'T00:00:00'), xsd:dateTime) AS ?orgaanStartDateTime)

      BIND(MD5(CONCAT(?eenheidUuid,"ID_KBO_NUMBER")) as ?uuidIdKbo)
      BIND(IRI(CONCAT("http://data.lblod.info/id/identificatoren/", ?uuidIdKbo)) AS ?idKbo)
      BIND(MD5(CONCAT(?eenheidUuid,"STRUCTURED_ID_KBO_NUMBER")) as ?uuidStructuredIdKbo)
      BIND(IRI(CONCAT("http://data.lblod.info/id/gestructureerdeIdentificator/", ?uuidStructuredIdKbo)) AS ?structuredIdKbo)
    }
  }
```
## [Import business core data](https://github.com/lblod/app-organization-portal/blob/2c8651f56767da4cc08f5d06328336ce452b85a0/config/migrations/2024/20240212141020-onboarding-public-ocmw-associations/20240213151820-import-public-ocmw-associations.ttl)
These files import the core data we received from business (name, classification, KBO number, SharePoint id, status) and adds the necessary placeholders for additional data such as sites. This script used to generate this can be found in the folder `02-core-data` of the zip file attached to OP-2540.

## [Complete organisations not in Loket](https://github.com/lblod/app-organization-portal/blob/2c8651f56767da4cc08f5d06328336ce452b85a0/config/migrations/2024/20240212141020-onboarding-public-ocmw-associations/20240213151821-missing-organen-and-functies-for-ocmw-associations.sparql)
The necessary governing bodies are created for the 4 organisations that are not in Loket. This script used to generate this can be found in the folder `02-core-data` of the zip file attached to OP-2540 (the same script as the previous migration).

## [Import addresses](https://github.com/lblod/app-organization-portal/blob/36ed52a55b44af6727457878c1593aaba6777e0c/config/migrations/2024/20240212141020-onboarding-public-ocmw-associations/2024021410742-import-public-ocmw-association-addresses.sparql)
The addresses provided by business are imported as primary sites for the organisations.  This script used to generate this can be found in the folder `03-addresses` of the zip file attached to OP-2540.

## [Import contact details](https://github.com/lblod/app-organization-portal/blob/89be9626716d6bafa148298310c4abc5bab62771/config/migrations/2024/20240212141020-onboarding-public-ocmw-associations/202402141191-import-public-ocmw-association-contact-details.sparql)
Imports the contact details (website, email, phone number) that were provided by business.  This script used to generate this can be found in the folder `04-contact-details` of the zip file attached to OP-2540.
