### PR TITLE
Chore: bump mu-cl-resources to latest version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,7 +72,7 @@ services:
     restart: always
     logging: *default-logging
   resource:
-    image: semtech/mu-cl-resources:feature-optional-native-booleans
+    image: semtech/mu-cl-resources:1.23.0
     environment:
       CACHE_CLEAR_PATH: "http://cache/.mu/clear-keys"
     links:


### PR DESCRIPTION
Updating the `mu-cl-resources` service to the lasted in order to resolve bugs such as the one reported in OP-2940.

