### PR TITLE
Feature: add legal name for organisations

### DIFF
--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -128,6 +128,12 @@ defmodule Acl.UserGroups.Config do
             constraint: %ResourceConstraint{
               resource_types: @org_type ++ @error_type
             }
+          },
+          %GraphSpec{
+            graph: "http://mu.semte.ch/graphs/shared",
+            constraint: %ResourceConstraint{
+              resource_types: @org_type
+            }
           }
         ]
       },

--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -132,7 +132,7 @@ defmodule Acl.UserGroups.Config do
           %GraphSpec{
             graph: "http://mu.semte.ch/graphs/shared",
             constraint: %ResourceConstraint{
-              resource_types: @org_type
+              resource_types: @org_type ++ @error_type
             }
           }
         ]
@@ -144,6 +144,12 @@ defmodule Acl.UserGroups.Config do
         graphs: [
           %GraphSpec{
             graph: "http://mu.semte.ch/graphs/administrative-unit",
+            constraint: %ResourceConstraint{
+              resource_types: @org_type ++ @error_type
+            }
+          },
+          %GraphSpec{
+            graph: "http://mu.semte.ch/graphs/shared",
             constraint: %ResourceConstraint{
               resource_types: @org_type ++ @error_type
             }

--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -128,12 +128,6 @@ defmodule Acl.UserGroups.Config do
             constraint: %ResourceConstraint{
               resource_types: @org_type ++ @error_type
             }
-          },
-          %GraphSpec{
-            graph: "http://mu.semte.ch/graphs/shared",
-            constraint: %ResourceConstraint{
-              resource_types: @org_type ++ @error_type
-            }
           }
         ]
       },
@@ -144,12 +138,6 @@ defmodule Acl.UserGroups.Config do
         graphs: [
           %GraphSpec{
             graph: "http://mu.semte.ch/graphs/administrative-unit",
-            constraint: %ResourceConstraint{
-              resource_types: @org_type ++ @error_type
-            }
-          },
-          %GraphSpec{
-            graph: "http://mu.semte.ch/graphs/shared",
             constraint: %ResourceConstraint{
               resource_types: @org_type ++ @error_type
             }

--- a/config/migrations/2024/20240226102340-copy-name-to-legal-name.sparql
+++ b/config/migrations/2024/20240226102340-copy-name-to-legal-name.sparql
@@ -1,0 +1,25 @@
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX regorg: <http://www.w3.org/ns/regorg#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?org regorg:legalName ?name .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?org a org:Organization ;
+      skos:prefLabel ?name .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?org regorg:legalName ?name .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?org a org:Organization ;
+      skos:prefLabel ?name .
+  }
+}

--- a/config/migrations/2024/20240226102340-copy-name-to-legal-name.sparql
+++ b/config/migrations/2024/20240226102340-copy-name-to-legal-name.sparql
@@ -14,6 +14,16 @@ INSERT {
 }
 ;
 INSERT {
+  GRAPH <http://mu.semte.ch/graphs/shared> {
+    ?org regorg:legalName ?name .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/shared> {
+    ?org a org:Organization ;
+      skos:prefLabel ?name .
+  }
+}
+;INSERT {
   GRAPH <http://mu.semte.ch/graphs/worship-service> {
     ?org regorg:legalName ?name .
   }

--- a/config/migrations/2024/20240226102340-copy-name-to-legal-name.sparql
+++ b/config/migrations/2024/20240226102340-copy-name-to-legal-name.sparql
@@ -3,34 +3,18 @@ PREFIX regorg: <http://www.w3.org/ns/regorg#>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 
 INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?org regorg:legalName ?name .
+  GRAPH ?g {
+    ?org regorg:legalName ?legalName .
   }
 } WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+  GRAPH ?g {
     ?org a org:Organization ;
       skos:prefLabel ?name .
   }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/shared> {
-    ?org regorg:legalName ?name .
+  VALUES ?g {
+    <http://mu.semte.ch/graphs/administrative-unit>
+    <http://mu.semte.ch/graphs/shared>
+    <http://mu.semte.ch/graphs/worship-service>
   }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/shared> {
-    ?org a org:Organization ;
-      skos:prefLabel ?name .
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/worship-service> {
-    ?org regorg:legalName ?name .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/worship-service> {
-    ?org a org:Organization ;
-      skos:prefLabel ?name .
-  }
+  BIND(?name AS ?legalName)
 }

--- a/config/migrations/2024/20240226102340-copy-name-to-legal-name.sparql
+++ b/config/migrations/2024/20240226102340-copy-name-to-legal-name.sparql
@@ -23,7 +23,8 @@ INSERT {
       skos:prefLabel ?name .
   }
 }
-;INSERT {
+;
+INSERT {
   GRAPH <http://mu.semte.ch/graphs/worship-service> {
     ?org regorg:legalName ?name .
   }

--- a/config/resources/domain.json
+++ b/config/resources/domain.json
@@ -377,6 +377,10 @@
           "type": "string",
           "predicate": "skos:altLabel"
         },
+        "legal-name": {
+          "type": "string",
+          "predicate": "regorg:legalName"
+        },
         "expected-end-date": {
           "type": "date",
           "predicate": "lblodgeneriek:geplandeEindDatum"

--- a/config/search/config.json
+++ b/config/search/config.json
@@ -765,6 +765,7 @@
       ],
       "properties": {
         "name": "http://www.w3.org/2004/02/skos/core#prefLabel",
+        "legal_name": "http://www.w3.org/ns/regorg#legalName",
         "classification_id": [
           "http://www.w3.org/ns/org#classification",
           "http://mu.semte.ch/vocabularies/core/uuid"
@@ -814,6 +815,15 @@
             "type": "text"
           },
           "name": {
+            "type": "text",
+            "fields": {
+              "field": {
+                "type": "keyword",
+                "normalizer": "custom_sort_normalizer"
+              }
+            }
+          },
+          "legal_name": {
             "type": "text",
             "fields": {
               "field": {

--- a/config/search/dev/config.json
+++ b/config/search/dev/config.json
@@ -738,6 +738,7 @@
       ],
       "properties": {
         "name": "http://www.w3.org/2004/02/skos/core#prefLabel",
+        "legal_name": "http://www.w3.org/ns/regorg#legalName",
         "classification_id": [
           "http://www.w3.org/ns/org#classification",
           "http://mu.semte.ch/vocabularies/core/uuid"
@@ -787,6 +788,15 @@
             "type": "text"
           },
           "name": {
+            "type": "text",
+            "fields": {
+              "field": {
+                "type": "keyword",
+                "normalizer": "custom_sort_normalizer"
+              }
+            }
+          },
+          "legal_name": {
             "type": "text",
             "fields": {
               "field": {


### PR DESCRIPTION
OP-2999

# Summary
- Add a `legal-name` attribute to organisations
- For existing organisations, initialise this new attribute with the value of `skos:prefLabel` via a migration
- Include this new attribute in the search index

# TODO
- [x] Prevent data from being duplicated to `administrative-unit` graph when altering legal name for a municipality or province