### PR TITLE
fix: set correct value for provinces of OCMW associations and PEVAs

### DIFF
--- a/config/migrations/2024/20240212141020-onboarding-public-ocmw-associations/20240306133508-fix-ocmw-associations-provinces.sparql
+++ b/config/migrations/2024/20240212141020-onboarding-public-ocmw-associations/20240306133508-fix-ocmw-associations-provinces.sparql
@@ -1,0 +1,3380 @@
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Antwerpen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0685516024" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Antwerpen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0809699184" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Antwerpen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0696665975" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Limburg" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0689553994" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "West-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0686537789" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Antwerpen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0875376696" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Limburg" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0267393663" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Antwerpen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0696899963" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Antwerpen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0694597697" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "West-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0711824305" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "West-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0684891363" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Oost-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0212165922" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Oost-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0698838775" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Limburg" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0687742074" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Vlaams-Brabant" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0712777279" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Vlaams-Brabant" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0684493762" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Limburg" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0688812935" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "West-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0735627214" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "West-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0630835639" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Oost-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0871009916" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Antwerpen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0680439360" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Oost-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0698817989" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Vlaams-Brabant" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0697787118" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Oost-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0729523736" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Antwerpen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0462239939" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Oost-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0871206587" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Oost-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0881291322" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Limburg" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0242469910" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "West-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0266559859" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Vlaams-Brabant" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0473908049" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "West-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0262925527" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "West-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0505931808" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Oost-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0885714720" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Antwerpen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0862382656" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Oost-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0666615870" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "West-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0262926319" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "West-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0537951706" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Oost-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0262926616" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "West-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0682844465" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Antwerpen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0445508132" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Antwerpen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0665553622" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Oost-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0643926085" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Antwerpen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0844179716" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "West-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0871928743" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "West-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0807042275" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Antwerpen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0222947570" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "West-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0894999895" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "West-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0863329296" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "West-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0831970978" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "West-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0267404056" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "West-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0860256673" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Oost-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0677764437" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "West-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0233210764" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "West-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0738896510" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Limburg" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0267302405" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Limburg" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0821142117" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Antwerpen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0827396340" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Antwerpen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0458878195" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Antwerpen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0886198829" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Antwerpen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0267313291" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Antwerpen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0647949706" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Antwerpen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0664681216" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Oost-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0480589567" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Oost-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0886485770" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Oost-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0267314875" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Oost-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0683473579" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Oost-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0684613726" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Oost-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0696715960" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Limburg" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0256543917" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Limburg" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0505849852" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Vlaams-Brabant" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0467270576" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Oost-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0736364909" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Oost-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0689674948" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "West-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0683771509" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Oost-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0862943474" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Oost-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0262562568" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Limburg" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0249211806" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Vlaams-Brabant" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0663810590" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "West-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0863329989" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "West-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0466193777" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "West-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0878405769" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Vlaams-Brabant" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0479985593" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "West-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0873440458" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "West-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0865506155" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Antwerpen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0897191602" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Antwerpen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0821734213" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Oost-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0870757023" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Limburg" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0475777476" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Vlaams-Brabant" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0267386438" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "West-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0472222625" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Antwerpen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0883325451" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Antwerpen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0865013039" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Antwerpen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0865010069" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Antwerpen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0473360790" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Antwerpen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0871619135" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Antwerpen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0870855409" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Antwerpen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0632607670" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Limburg" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0887953044" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Limburg" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0838654674" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Vlaams-Brabant" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0471364174" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Vlaams-Brabant" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0861157387" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Oost-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0476803795" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Vlaams-Brabant" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0884212804" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Vlaams-Brabant" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0848738221" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "West-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0833161902" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "West-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0472751175" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "West-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0832024923" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Oost-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0644984078" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Vlaams-Brabant" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0633854022" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "West-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0566983014" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Limburg" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0881602118" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Oost-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0263545337" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Oost-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0465810133" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Antwerpen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0781430812" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Antwerpen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0786960406" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Antwerpen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0780658572" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "West-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0799574166" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Vlaams-Brabant" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0800023336" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "West-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Oost-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "1005154085" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Limburg" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0867804659" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Vlaams-Brabant" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0264998753" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Antwerpen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0866242662" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Vlaams-Brabant" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0889412695" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Oost-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0874267037" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Antwerpen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0836906793" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Vlaams-Brabant" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0834358069" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Antwerpen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0459993992" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Antwerpen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0459644990" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Oost-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0823319370" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    

--- a/config/migrations/2024/20240214133210-onboarding-peva-data-import/20240306132750-fix-peva-provinces.sparql
+++ b/config/migrations/2024/20240214133210-onboarding-peva-data-import/20240306132750-fix-peva-provinces.sparql
@@ -1,0 +1,1248 @@
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Oost-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0686668938" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Antwerpen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0459795044" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Vlaams-Brabant" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0862298029" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Antwerpen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0678818074" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Limburg" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0456552868" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Vlaams-Brabant" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0749418139" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Vlaams-Brabant" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0893525002" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Vlaams-Brabant" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0639968287" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Antwerpen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0741624386" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Oost-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0507873093" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Oost-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0413873759" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Oost-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0895509839" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Oost-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0462429187" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Oost-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0630602344" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Oost-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0665587076" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Oost-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0469368647" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Oost-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0468105073" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "West-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0542485762" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "West-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0543423395" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "West-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0542480220" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "West-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0543424880" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "West-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0542487247" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Oost-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0867303526" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Oost-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0474761451" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Oost-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0455635130" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Limburg" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0866093105" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "West-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0820653751" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Vlaams-Brabant" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0771948863" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Antwerpen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0418558364" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Antwerpen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0450062281" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Antwerpen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0841556855" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Antwerpen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0749895122" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Vlaams-Brabant" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0413845055" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Limburg" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0436978070" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Oost-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0410436890" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "West-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0802469815" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Vlaams-Brabant" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0546845319" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Limburg" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0422264556" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Limburg" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0407576182" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Vlaams-Brabant" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0420175591" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Vlaams-Brabant" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0464169348" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Antwerpen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0861837773" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Antwerpen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0881008933" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Antwerpen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0642642123" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Antwerpen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0445294237" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Antwerpen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0420392258" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "Limburg" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0806608349" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    
+
+      DELETE {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?addressUri <http://www.w3.org/ns/locn#adminUnitL2> "West-Vlaanderen" .
+        }
+      }
+      WHERE {
+        GRAPH ?g {
+          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
+            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
+
+          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
+            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "0463025441" .
+
+          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
+          ?boundAddress <http://www.w3.org/ns/locn#adminUnitL2> ?province .
+
+          BIND( ?boundAddress AS ?addressUri )
+        }
+      }
+    


### PR DESCRIPTION
OP-3062 and OP-3063

## Context
In the initial migrations the province was incorrectly set to the same value as the municipality for OCMW associations as wll as PEVAs. These new migrations first remove the incorrect province and then insert the correct value.

## Notes
- These migrations are generated using a script so each query is identical except for the concrete values such as KBO number and province. It is thus not necessary to go through all the queries in the migrations.
- The province column on the index page will still display the old, incorrect values. Updating these requires a reindexing. The province shown on the core data page should display the new, corrected value.