### PR TITLE
Feature: add alternative names for organisations

### DIFF
--- a/config/resources/domain.json
+++ b/config/resources/domain.json
@@ -374,7 +374,7 @@
           "predicate": "skos:prefLabel"
         },
         "alternative-name": {
-          "type": "string",
+          "type": "string-set",
           "predicate": "skos:altLabel"
         },
         "legal-name": {

--- a/config/search/config.json
+++ b/config/search/config.json
@@ -766,6 +766,7 @@
       "properties": {
         "name": "http://www.w3.org/2004/02/skos/core#prefLabel",
         "legal_name": "http://www.w3.org/ns/regorg#legalName",
+        "alternative_name": "http://www.w3.org/2004/02/skos/core#altLabel",
         "classification_id": [
           "http://www.w3.org/ns/org#classification",
           "http://mu.semte.ch/vocabularies/core/uuid"
@@ -824,6 +825,15 @@
             }
           },
           "legal_name": {
+            "type": "text",
+            "fields": {
+              "field": {
+                "type": "keyword",
+                "normalizer": "custom_sort_normalizer"
+              }
+            }
+          },
+          "alternative_name": {
             "type": "text",
             "fields": {
               "field": {

--- a/config/search/dev/config.json
+++ b/config/search/dev/config.json
@@ -739,6 +739,7 @@
       "properties": {
         "name": "http://www.w3.org/2004/02/skos/core#prefLabel",
         "legal_name": "http://www.w3.org/ns/regorg#legalName",
+        "alternative_name": "http://www.w3.org/2004/02/skos/core#altLabel",
         "classification_id": [
           "http://www.w3.org/ns/org#classification",
           "http://mu.semte.ch/vocabularies/core/uuid"
@@ -797,6 +798,15 @@
             }
           },
           "legal_name": {
+            "type": "text",
+            "fields": {
+              "field": {
+                "type": "keyword",
+                "normalizer": "custom_sort_normalizer"
+              }
+            }
+          },
+          "alternative_name": {
             "type": "text",
             "fields": {
               "field": {


### PR DESCRIPTION
OP-3000

## Summary
- Changed type for `alternative-name` attribute to `string-set` which allows to retrieve multiple values for the same predicate
- Add alternative name attribute to search index
- Fronted [PR](https://github.com/lblod/frontend-organization-portal/pull/586)