### PR TITLE
Feature: Import juridical and alternative names for PZ and HVZ

### DIFF
--- a/config/migrations/2024/20240311134000-import-pz-hvz-names/20240311151100-delete-existing-alternative-names.sparql
+++ b/config/migrations/2024/20240311134000-import-pz-hvz-names/20240311151100-delete-existing-alternative-names.sparql
@@ -1,0 +1,17 @@
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel ?name .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s org:classification ?class ;
+      skos:altLabel ?name .
+  }
+  VALUES ?class {
+    <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/ea446861-2c51-45fa-afd3-4e4a37b71562> # HVZ
+    <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/a3922c6d-425b-474f-9a02-ffb71a436bfc> # PZ
+  }
+}

--- a/config/migrations/2024/20240311134000-import-pz-hvz-names/20240311161908-import-politiezone-juridical-names.sparql
+++ b/config/migrations/2024/20240311134000-import-pz-hvz-names/20240311161908-import-politiezone-juridical-names.sparql
@@ -1,0 +1,1953 @@
+PREFIX core: <http://mu.semte.ch/vocabularies/core/>
+PREFIX regorg: <http://www.w3.org/ns/regorg#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5408 PZ Asse/Merchtem/Opwijk/Wemmel" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "90688b32e0808b6ebbb7b36030526750236527e8019414449065f57ea384ce71" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5462 PZ Ieper/Wervik/Heuvelland/Mesen/Poperinge/Vleteren/Langemark-Poelkapelle/Moorslede/Staden/Zonnebeke" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "195d911f1417b20a4b715b1a54e8ae6e92b9a23cde908f2fb03a0081910d8fce" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5440 PZ Aalst" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "e5f3c3f23f6791de122a5e6f1af83543651d272eba40e138c2fdf91ec05f8a40" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5423 PZ Aalter/Knesselare" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "e06ce64825e386178b350aa6b2fa869c70ad39aa99ddb3ca2a73d6b103e91161" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5394 PZ Aarschot" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "254bbfb6c31a668446c339c0996864d23c3fe129a5aa05e274b463cbbb4a4bc2" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5345 PZ Antwerpen" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "097191c539cc02e6044671221f3ea0a8428c7fbc8dbdd5f38ee8f02ca51c6082" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5421 PZ Assenede/Evergem" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "96d87c4956c98414938dd5fceeb05f65feebf21fbe5918e6d23bc2b58a7fc716" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5359 PZ Bonheiden/Duffel/Putte/Sint-Katelijne-Waver" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "f4838c2bb548a35f92a6ddcf725676b9f137f3fcb11e6737caa7cab1f1314e27" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5399 PZ Begijnendijk/Rotselaar/Tremelo" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "81083789b63917e32ab90ef1a45adf893f370ee38da2e0542e5c035db4f60794" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5368 PZ Balen/Dessel/Mol" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "d847f2f345c5e58882e0e468c31de8868e71a73f4cbfa63823de17da3c7f1942" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5404 PZ Beersel" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "cbb5b8b80d03be75744a41580e5658b3c236fa0a12822bbb334f893c524b5b18" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5373 PZ Beringen/Ham/Tessenderlo" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "08b6bdc2c34dacae28168cf967ef2e13384f032a147ddaea7f1145eff4f0d161" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5361 PZ Berlaar/Nijlen" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "f5094b8d7f26d69d04ba2c469a09e0c6dc08a78615c9483fd97d6d029e064121" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5436 PZ Berlare/Zele" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "414f3538e482d3c1c21382ca22de18998ca1d3f5b517ced85946ecf90143149c" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5397 PZ Bertem/ Huldenberg/Oud-Heverlee" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "3efcad40be18e793d070f78a44f2e63bc105778d6c8c4edc4bfeb5a87f06554c" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5430 PZ Beveren" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "488938bd557800723290a816c51b471fff7f4918237a509f697973af6f509390" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5391 PZ Bierbeek/Boutersem/Holsbeek/Lubbeek" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "da737a74e5094054c3bb3ef077839626a02eb79d148e15cfeee18e10c18ba55a" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5381 PZ Bilzen/Hoeselt/Riemst" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "19ac0fa207989c27c3391e327aee16435475292296f010867945bf2987f95477" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5445 PZ Blankenberge/Zuienkerke" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "05354d6fcc016d06f988a0e044fb160be7573550c11fe414b3c011961150a686" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5385 PZ Bocholt/Bree/Kinrooi/Meeuwen-Gruitrode" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "9893dc25d4b91aef9e2ef6f712e0aac68cdf6f144dbed887c9500e6360df080d" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5395 PZ Boortmeerbeek/Haacht/Keerbergen" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "d5d6693850ba1a749739c4574e7c75a98820629fdbbbbb143b7a4f7c279247ea" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5356 PZ Bornem/Puurs/Sint-Amands" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "3b2c2151632d84c55dd93372a4e91a7493455a7f77a90fa2066fc618411d0ed6" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5426 PZ Brakel/Horebeke/Maarkedal/Zwalm" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "b7af3483cb5d0021c6f5864a433b211fce30246ef685621d104b1951915c21c4" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5352 PZ Brasschaat" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "dce9ffab7edf87d670ce7ec399084fc2e12c6b5bb300b865e87c5237beae4ae0" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5450 PZ Bredene/DeHaan" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "c7d15b793e42f0024e56ae7a89d02f8d6f491ec42cd2ece4c856ee24b154559d" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5444 PZ Brugge" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "eed6ef4fd7723fca33613bb9c9570825be3f8e50c32ce9456ded3d54bc624370" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5437 PZ Buggenhout/Lebbeke" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "7e526f7f2d12f55a06620b512401826b6855ed478ff0693e04fba59cabba3c4d" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5909 PZ Genk/Zutendaal/As/Oudsbergen/Houthalen-Helchteren/Bocholt/Bree/Kinrooi" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "e7692f99-9a36-43e3-af78-b320390318dc" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5446 PZ Damme/Knokke-Heist" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "165a9a64a6b84a278806b11c3f760f48198990168f591cf7a7462beb0f2cb16b" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5420 PZ Deinze/Zulte" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "19c1183ad20b9b4023da2eb7d1ab3eb5dda64558e050c8198abf9714463362ff" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5911 PZ Deinze/Zulte/Lievegem" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "dad37923-85b4-4c30-8bd6-050061bde51c" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5396 PZ Diest/Scherpenheuvel-Zichem" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "41e3bb71cb1fe2763a64ce47ee758fbeb532fbd4348281f34a86a5f88dd71980" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5439 PZ Denderleeuw/Haaltert" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "c5726151c11e3ec6dd94a158ead5e9bd9e4a7307ab76e4f64da20fc526d481aa" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5443 PZ Dendermonde" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "67b25dc29ad301f607aed564241d318de74be7dc1ec15202a67111d7a86becf9" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5370 PZ Diepenbeek/Hasselt/Zonhoven" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "9e2072f69e9c1ecd1af7f65a234f141ef6cfe36eb63b2758d54d1414618188ff" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5406 PZ Dilbeek" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "e65a70ecf702fb23f1447e234eab584fe788e9618fb7d52cd1d562718207b499" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5402 PZ Hoeilaart/Overijse" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "b5aee7f43fc9c5d0df74e2cbb9214c03c425cf026b1fd77dd1e3b08e5fc7f875" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5441 PZ Erpe-Mere/Lede" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "622fa725ba8455b01817c8e48974edeab56607018fce5c1cb3694306d3e7005c" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5458 PZ Deerlijk/Harelbeke" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "479036ca47b011e16fefafbe4d3512a44c564804dc26d331ce4dcbe0fa3366d2" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5366 PZ Geel/Laakdal/Meerhout" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "7271a57b8249b4dd3175f50ea96c66ff536eff057c6bc0acfe40281e2a91ddc2" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5384 PZ As/Opglabbeek/Genk/Zutendaal" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "d39a7017044dcf082194095e3b3ec72de112bd47528e32125c697be1aa3c10cd" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5415 PZ Gent" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "5187962dfd40789953d4fbde3634751ee90b48b17147c585ccf4f2ac1ee72fd3" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5428 PZ Geraardsbergen/Lierde" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "25572d6c63bc386d742bbb6ac0d8ddc739dc0599e156c6eac68aca492390840e" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5910 PZ Landen/Linter/Zoutleeuw/Hoegaarden/Tienen" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "81334af3-1b6f-4308-aca3-107121462d56" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5350 PZ Essen/Kalmthout/Wuustwezel" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "4ffd00c0ba7ceab20db24832a4b9963112ed66914dcca05f3e5dc8b8b9d4479d" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5455 PZ Menen/Ledegem/Wevelgem" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "e39d8bf95a03ade08ef25a79ebc050abfc81a69731f1de66fe6d031d27135aac" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5410 PZ Grimbergen" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "5018524f9ceca4f9e21764f9e8e4e63d1ad6890c338c090d0dd074faccf1bfb2" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5372 PZ Hamont-Achel/Pelt" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "77801115dec7f63400134c21d897a41bddb775eb438d81b354ad18fb6d7ab956" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5349 PZ Aartselaar/Edegem/Hove/Kontich/Lint" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "bb9a9db9c00189c27a851f0b772772675cba77e2463ab734477d00e4294db5df" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5389 PZ Bekkevoort/Geetbets/Glabbeek/Kortenaken/Tielt-Winge" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "39e0e2e69be463a4628f87bffe7dc6206aa6daa4a5516fb4ce11907f57d77079" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5374 PZ Halen/Herk-de-Stad/Lummen" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "abca98258a8436dd7f74c633f0b60c7e50b407a1bb27777c102a1963f8843f8b" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5413 PZ Halle" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "458df2d318d52e34278e4ce1886b9458351d3a4b06fe28c68a7558b0cdd528c3" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5435 PZ Hamme/Waasmunster" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "31bceaaaa3f4019e85edfe0e509340aa30554d0f3bb343616841c20641788b6e" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5362 PZ Heist-op-den-Berg" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "52bda330e11552b586106748bf652e5dd41163670d5c4226b2c02bfa2f579946" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5393 PZ Herent/Kortenberg" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "b6fb86dcca01c89d6787801c958d6b8551f3755ec6f1c35bb97c0cf37b9ddc2c" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5447 PZ Beernem/Oostkamp/Zedelgem" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "2ca642d589b8012fe65bf54df3a87f740acac78624a902ad378dc4ee6c50a848" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5375 PZ Heusden-Zolder" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "8a72024e99b1e083aca28a026122ad2bc517372bc18e95210fb54f080136e3f8" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5392 PZ Hoegaarden/Tienen" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "a65afe7380499a2c24c2d039f2a97493f2f99bc03836de9bb99c2c267676388f" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5378 PZ Houthalen-Helchteren" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "08293a0d743c13f37e99deddf000e75ba13f70ca6a5ac65cde49ad23d600ab3c" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5409 PZ Kapelle-op-den-Bos/Londerzeel/Meise" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "c7778ecc532ee037ab821de348f7c6d98ed5b2401abce2e7da64687290c08962" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5412 PZ Kampenhout/Steenokkerzeel/Zemst" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "7ddda00fc45a0994092bc26f30d97352b7586676438d5557b3f5cc336daab063" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5379 PZ Alken/Borgloon/Heers/Kortessem/Wellen" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "150440a8bb763d6f53d24ca1c6f1460cb5817c8a261fd90e74aadac3292c3efe" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5367 PZ Arendonk/Ravels/Retie" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "306340a51c1504e59f1c3b85c1ba1b62de8c70cb94d3998f27819761bcee5a98" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5377 PZ Hechtel-Eksel/Leopoldsburg/Peer" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "ee07affaf869f10517967da1ba7e79151646a1f3621b3cbca591cec2b8c549b7" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5452 PZ Gistel/Ichtegem/Jabbeke/Oudenburg/Torhout" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "a32dc005ecbc001abd3338cdacb111895d3053b313654136ef1903035c10a53c" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5433 PZ Kruibeke/Temse" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "7dd1250996188607bb1e28df1ebea0b943e8db59c08ea01e3c57672531c43ec6" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5853 PZ Lanaken-Maasmechelen" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "1db0e6fb09e60db1e8534b20c69abb03584870612717a454937717be9b7fd019" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5386 PZ Lanaken" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "9b1af8b3306f7f2966d2326a7a301c149d2a62db4803335aaffae9ff45fe068d" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5390 PZ Landen/Linter/Zoutleeuw" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "520ae455030cb427fa5dead38ba62d2975fcf2d0f695d365cf9e84b5b5b5b73e" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5388 PZ Leuven" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "35454115a5e3a31059e0c4fd55906df42c75885b0233c1f17eb4bcef6e696908" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5360 PZ Lier" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "b77b75f239b9a14e40750981aa88976e46df7ddf83c3554103409a4a2291fea3" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5907 PZ Diepenbeek/Hasselt/Zonhoven/Halen/Herk-de Stad/Lummen" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "ff7d80dc-ec00-43ac-ac7e-d51694df37ff" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5434 PZ Lokeren" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "d8cb6ca314f27d657f4043f27110632e63a9520070728922d3c958f51d70c281" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5371 PZ Lommel" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "0b1af0370213e4b8ea5c3d5a2ccadcfce1149d092da47a3e447fe383050f9506" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5422 PZ Lovendegem/Nevele/Waarschoot/Zomergem" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "2ba0f1e28168459a963a81784a8404e94268f70b49f99342d50ff421ab8a06c6" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5454 PZ Dentergem/Ingelmunster/Meulebeke/Oostrozebeke/Wielsbeke" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "fa52110c7c3e70feab724980e2d991a97712a1deeeb25b168ef6de7b16de41ae" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5351 PZ Boechout/Borsbeek/Mortsel/Wijnegem/Wommelgem" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "80a9ab8eb46716ab23c597d13313ce24b17884ffcbdf00d216b877d57a52ade4" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5457 PZ Waregem/ Anzegem/ Spiere-Helkijn/Zw evegem/Avelgem" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "7b6bbae823b20191525038cd52089d22128163fb3c7f851ce56149938628d941" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5383 PZ Dilsen-Stokkem/Maaseik" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "97028faf77fd95eb5016a13c19f3a3a8ccf97c6c937398ba96976e52d171dbd8" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5387 PZ Maasmechelen" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "d71ddb7a663a892d7a8cb511d30bf5ae3ba49fda39dd65e39dae9c789bb901fe" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5424 PZ Maldegem" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "3b7a6d691943806c23f59d22482dea27e451bd440f91f884aeb42e8c72016ee3" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5358 PZ Mechelen" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "1915208b0a66992ee2014df894f7a9c538fe727a975fd9538d9e2c949e1a8471" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5906 PZ Mechelen/Willebroek" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "73777b2512fc25f16554612a13b0de2265a56540a5ea6665bf69a8b5a805569a" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5417 PZ Eeklo/Kaprijke/Sint-Laureins" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "d8d1b52a9170168ad481f2495652e1b9753aea23385f79710abd86549f1373fa" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5451 PZ Middelkerke" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "04e7a09c988feed3cf8df1c51aafe0f0a50811e325f5f5ab8e1b9750f48630fd" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5888 PZ Genk/Zutendaal/As/Opglabbeek/Houthalen-Helchteren" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "3efb7cb7fad9f61917093d42513c8a7153120906e9701b08e3560c8f109e64c1" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5369 PZ Grobbendonk/Herentals/Herenthout/Olen/Vorselaar" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "97a393c64a3c30e619bc115ab8b2bbe0bd7a83265ebb8960c0f1154b9628d340" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5442 PZ Ninove" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "7b1c9132de06d5b3626e7118dc16c7f129d7c911b3298a0f4609725372e64588" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5348 PZ Kapellen/Stabroek" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "0594a740b99274c7347f3492ae4d05f9b05d057a1cbad30683634296e189cc38" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5363 PZ Hoogstraten/Merkplas/Rijkevorsel" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "b2fdc615ffb131e53a200e14c74ac92d4ed6dac176e3e6ea2c79d227835077c9" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5449 PZ Oostende" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "b7e07299d7acf9e78f802915227b243c31fc56eadfb575039b81fb871eec9755" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5405 PZ Bever/Galmaarden/Gooik/Herne/Lennik/Pepingen" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "7cb2089a8c6746d514711908abfd38414a2b01f6ad9a83f28be2e835888b3da7" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5460 PZ Diksmuide/Houthulst/Koekelare/Kortemark" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "95871bddebd4ad93db54cb1b40d41af29f7ce08f0b59698b0540be129a9a3433" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5453 PZ Hooglede/Roeselare/Izegem" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "5ba4a42bd459dda75ce452a253ddc09547174265456ad1e3f9389a3ff139a1f9" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5416 PZ Lochristi/Moerbeke/Wachtebeke/Zelzate" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "9cb5a65d9190da4bb96d0f59882cbcfb34248d354e6bd27101fccba186f4c7b7" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5418 PZ Destelbergen/Melle/Merelbeke/Oosterzele" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "93389f5157ceb037c5e38d7b8119cef632528b870e91e209c033bc2eac220cc1" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5448 PZ Ardooie/Pittem/Ruiselede/Tielt/Wingene/Lichtervelde" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "39e3e46f7cf031133152e763eaa26cab3df81f842f9912a25c69c445f0c428b8" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5364 PZ Beerse/ Lille/ Vosselaar/ Baarle-Hertog/Kasterlee /Oud-Turnhout/Turnhout" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "a31131dd72b614c89184b331821c10a0f8feb109881a1b164749e9c8941c5e6b" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5913 PZ Bornem/Puurs-Sint-Amands/Mechelen/Willebroek" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "81dd243d-f66c-4157-b105-5407aa83cb62" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5403 PZ Drogenbos/Linkebeek/Sint-Genesius-Rode" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "a691d36ff95b67005d30d5fb89594dab69ec7fdbf975ffdcd36ef9bb39efb06d" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5427 PZ Ronse" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "f398f3ebafe08244f84eac783b61eac71c60bd39b8ca9ee8d9c2a4dc8638a772" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5347 PZ Boom/Rumst/Niel/Schelle/Hemiksem" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "46616861cfaae13b550a36ae5c05187638df0873024f13043d3f40f24cabf4e6" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5419 PZ De Pinte/Gavere/Nazareth/Sint-Martens-Latem" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "c16d166294750ae2c48acae9855a49cd3280a3597c0d8f3257021c68fdede345" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5353 PZ Schoten" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "1298cc0fec62af4dcaa86b44d43fe7e3ee3632247e66e8fccd87c0e5c7b7742f" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5431 PZ Sint-Gillis-Waas/Stekene" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "0cfc443c59ad06e1292b9805d967f181b989913a1ccc3e3f50a4dd8ca16bc772" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5432 PZ Sint-Niklaas" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "5d55c0281e70d053158a06a7898bb3e1a89ed48cf111c4b6fc2a9502ebafcade" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5414 PZ Sint-Pieters-Leeuw" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "b9fd6a7fa1ddabcaa0eb9d2eac74b41d5671623a6799a520308daabb53d5937d" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5376 PZ Gingelom/Nieuwerkerken/Sint-Truiden" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "11feae29e6178a2b58ac73bb639360d58248e3e438f2201f219b95b58c6b4ef4" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5459 PZ Alveringen/Lo-Reninge/Veurne" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "a62fddadcb0a8fb878c3edbdc71a4eb1e6c419b212d41a8bd589fb1a370eb112" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5407 PZ Affligem/Liedekerke/Roosdaal/Ternat" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "0610b306e95fae751dc07050565e987f31ba06420863bc44616b2e05452d8822" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5398 PZ Tervuren" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "dea71925b69de424a8bb3c90ad5751f39c35df9e85ade437e6f6404b3ba12a42" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5380 PZ Tongeren/Herstappe" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "41d31a2eb697af977aadf64c73e0bcffb094e0f20e4017fe3b49c507079c0976" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5456 PZ Kortrijk/Kuurne/Lendelede" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "477e468496131b7d35f145b0361bca5c2cad577fd9ec27d385d703942dc944d0" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5411 PZ Machelen/Vilvoorde" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "d6fe7204ffe4c6c227156eb34caddcd860f911cc98728f9593d9cd7d28d3161d" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5425 PZ Kluisbergen/Kruisem/Oudenaarde/Wortegem-Petegem" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "4deae42b2b25bff407f5abc7cbb6d62eb02afaf2892086341c324fdf2c0e6e92" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5908 PZ Bertem/Huldenberg/Oud-Heverlee/Tervuren" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "cdcd4403-d4cd-4400-80a3-9882d79933f4" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5382 PZ Voeren" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "92609bcab00475b084e747cb49f942abfb9e737ab023a999c69baf60acb8c06d" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5355 PZ Brecht/Malle/Schilde/Zoersel" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "5dab8a7b0656aaf0db13044fcafc0088f9f0b7776c294a6e9abfdbf7420effae" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5401 PZ Kraainem/Wezembeek-Oppem" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "beff71011cde3ac0ee0d94b592462be141cc9f0deb5c6ea996ea191bf79ae2fe" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5904 PZ Beveren/Sint-Gillis-Waas/Stekene" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "541c1603eb8c01968f95d1f262854134499e00d135cd7c9147d307ccbd1e20fd" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5461 PZ DePanne/Koksijde/Nieuwpoort" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "68ad1301fbb5f209b4ef0fe2b11e77c7bea6011f5e28f8f6875597a7b08f0f1e" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5438 PZ Laarne/Wetteren/Wichelen" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "c747c462297c0fd1d31076b8f5b20e23aa3309ccb0f5b0b072097aa7612950e9" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5357 PZ Willebroek" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "ab9269754d1266e010c1878a1199525898f0846ff0e9a0add9e7fbaed42ac43c" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5354 PZ Ranst/Zandhoven" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "805a977a29725d94f50bf7f0d91a0de1a727c4eec88940e90035f71c6c9b1655" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5400 PZ Zaventem" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "782682349b24078a97dc181bdb7dc62fb2cabc072878fc75a29f4ed70c86250d" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5905 PZ Beersel/Halle/Sint-Pieters-Leeuw" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "e4f4aa293734f92302439270cf98805e4b617088cb19144b558db2dff087d886" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5429 PZ Herzele/Sint-Lievens-Houtem/Zottegem" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "08b125860dd7716256dd35ba2e38a009206555f29adc44642c655450a471ebef" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5365 PZ Herselt/Hulshout/Westerlo" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "dbfedd56289924d8a7cc26a5aada392281547e053a10c0678238fc08a219fb6e" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5346 PZ Zwijndrecht" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "330516b323c00851cf4b93e6d5d7a2ef4591f68ae6e71ad9c1f432ee70521bb2" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "5914 PZ Aalter/Maldegem" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "65EB0324E77A4F2289F6B63D" ;
+      regorg:legalName ?oldName .
+  }
+}

--- a/config/migrations/2024/20240311134000-import-pz-hvz-names/20240311161909-import-politiezone-alternative-names.sparql
+++ b/config/migrations/2024/20240311134000-import-pz-hvz-names/20240311161909-import-politiezone-alternative-names.sparql
@@ -1,0 +1,583 @@
+PREFIX core: <http://mu.semte.ch/vocabularies/core/>
+PREFIX regorg: <http://www.w3.org/ns/regorg#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5408 AMOW" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "90688b32e0808b6ebbb7b36030526750236527e8019414449065f57ea384ce71" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5462 ARRO IEPER" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "195d911f1417b20a4b715b1a54e8ae6e92b9a23cde908f2fb03a0081910d8fce" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5359 BoDuKaP" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "f4838c2bb548a35f92a6ddcf725676b9f137f3fcb11e6737caa7cab1f1314e27" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5399 BRT" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "81083789b63917e32ab90ef1a45adf893f370ee38da2e0542e5c035db4f60794" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5426 Brakel" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "b7af3483cb5d0021c6f5864a433b211fce30246ef685621d104b1951915c21c4" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5909 CARMA" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "e7692f99-9a36-43e3-af78-b320390318dc" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5396 Demerdal-DSZ" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "41e3bb71cb1fe2763a64ce47ee758fbeb532fbd4348281f34a86a5f88dd71980" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5402 Druivenstreek" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "b5aee7f43fc9c5d0df74e2cbb9214c03c425cf026b1fd77dd1e3b08e5fc7f875" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5458 Gavers" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "479036ca47b011e16fefafbe4d3512a44c564804dc26d331ce4dcbe0fa3366d2" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5910 Getevallei" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "81334af3-1b6f-4308-aca3-107121462d56" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5350 GRENS" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "4ffd00c0ba7ceab20db24832a4b9963112ed66914dcca05f3e5dc8b8b9d4479d" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5455 Grensleie" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "e39d8bf95a03ade08ef25a79ebc050abfc81a69731f1de66fe6d031d27135aac" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5372 HANO" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "77801115dec7f63400134c21d897a41bddb775eb438d81b354ad18fb6d7ab956" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5349 HEKLA" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "bb9a9db9c00189c27a851f0b772772675cba77e2463ab734477d00e4294db5df" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5389 Hageland" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "39e0e2e69be463a4628f87bffe7dc6206aa6daa4a5516fb4ce11907f57d77079" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5362 Heist" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "52bda330e11552b586106748bf652e5dd41163670d5c4226b2c02bfa2f579946" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5393 HerKo" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "b6fb86dcca01c89d6787801c958d6b8551f3755ec6f1c35bb97c0cf37b9ddc2c" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5447 Het Houtsche" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "2ca642d589b8012fe65bf54df3a87f740acac78624a902ad378dc4ee6c50a848" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5409 K - L - M" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "c7778ecc532ee037ab821de348f7c6d98ed5b2401abce2e7da64687290c08962" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5412 KASTZE" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "7ddda00fc45a0994092bc26f30d97352b7586676438d5557b3f5cc336daab063" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5379 PZ Kanton Borgloon" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "150440a8bb763d6f53d24ca1c6f1460cb5817c8a261fd90e74aadac3292c3efe" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5367 Kempen N-O" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "306340a51c1504e59f1c3b85c1ba1b62de8c70cb94d3998f27819761bcee5a98" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5377 Kempenland" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "ee07affaf869f10517967da1ba7e79151646a1f3621b3cbca591cec2b8c549b7" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5452 Kouter" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "a32dc005ecbc001abd3338cdacb111895d3053b313654136ef1903035c10a53c" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5853 LaMA" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "1db0e6fb09e60db1e8534b20c69abb03584870612717a454937717be9b7fd019" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5907 Limburg Regio Hoofdstad" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "ff7d80dc-ec00-43ac-ac7e-d51694df37ff" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5454 MIDOW" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "fa52110c7c3e70feab724980e2d991a97712a1deeeb25b168ef6de7b16de41ae" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5351 Minos" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "80a9ab8eb46716ab23c597d13313ce24b17884ffcbdf00d216b877d57a52ade4" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5457 Mira" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "7b6bbae823b20191525038cd52089d22128163fb3c7f851ce56149938628d941" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5383 Maasland" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "97028faf77fd95eb5016a13c19f3a3a8ccf97c6c937398ba96976e52d171dbd8" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5417 Meetjesland Centrum" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "d8d1b52a9170168ad481f2495652e1b9753aea23385f79710abd86549f1373fa" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5888 MidLim" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "3efb7cb7fad9f61917093d42513c8a7153120906e9701b08e3560c8f109e64c1" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5369 Neteland" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "97a393c64a3c30e619bc115ab8b2bbe0bd7a83265ebb8960c0f1154b9628d340" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5348 Noord" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "0594a740b99274c7347f3492ae4d05f9b05d057a1cbad30683634296e189cc38" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5363 PZ Noorderkempen" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "b2fdc615ffb131e53a200e14c74ac92d4ed6dac176e3e6ea2c79d227835077c9" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5405 Pajottenland" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "7cb2089a8c6746d514711908abfd38414a2b01f6ad9a83f28be2e835888b3da7" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5460 Polder" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "95871bddebd4ad93db54cb1b40d41af29f7ce08f0b59698b0540be129a9a3433" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5453 RIHO" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "5ba4a42bd459dda75ce452a253ddc09547174265456ad1e3f9389a3ff139a1f9" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5416 Regio Puyenbroeck" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "9cb5a65d9190da4bb96d0f59882cbcfb34248d354e6bd27101fccba186f4c7b7" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5418 Regio Rhode & Schelde" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "93389f5157ceb037c5e38d7b8119cef632528b870e91e209c033bc2eac220cc1" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5448 Regio Tielt" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "39e3e46f7cf031133152e763eaa26cab3df81f842f9912a25c69c445f0c428b8" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5364 Regio Turnhout" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "a31131dd72b614c89184b331821c10a0f8feb109881a1b164749e9c8941c5e6b" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5913 Rivierenland" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "81dd243d-f66c-4157-b105-5407aa83cb62" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5403 Politiezone Rode" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "a691d36ff95b67005d30d5fb89594dab69ec7fdbf975ffdcd36ef9bb39efb06d" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5347 Politiezone Rupel" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "46616861cfaae13b550a36ae5c05187638df0873024f13043d3f40f24cabf4e6" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5419 Schelde-Leie" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "c16d166294750ae2c48acae9855a49cd3280a3597c0d8f3257021c68fdede345" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5459 Spoorkin" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "a62fddadcb0a8fb878c3edbdc71a4eb1e6c419b212d41a8bd589fb1a370eb112" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5407 TARL" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "0610b306e95fae751dc07050565e987f31ba06420863bc44616b2e05452d8822" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5456 VLAS" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "477e468496131b7d35f145b0361bca5c2cad577fd9ec27d385d703942dc944d0" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5425 Vlaamse Ardennen" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "4deae42b2b25bff407f5abc7cbb6d62eb02afaf2892086341c324fdf2c0e6e92" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5908 Voer en Dijle" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "cdcd4403-d4cd-4400-80a3-9882d79933f4" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5355 Voorkempen" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "5dab8a7b0656aaf0db13044fcafc0088f9f0b7776c294a6e9abfdbf7420effae" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5401 Wokra" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "beff71011cde3ac0ee0d94b592462be141cc9f0deb5c6ea996ea191bf79ae2fe" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5904 Waasland-Noord" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "541c1603eb8c01968f95d1f262854134499e00d135cd7c9147d307ccbd1e20fd" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5461 Westkust" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "68ad1301fbb5f209b4ef0fe2b11e77c7bea6011f5e28f8f6875597a7b08f0f1e" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5354 ZARA" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "805a977a29725d94f50bf7f0d91a0de1a727c4eec88940e90035f71c6c9b1655" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5905 Zennevallei" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "e4f4aa293734f92302439270cf98805e4b617088cb19144b558db2dff087d886" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "5365 Zuiderkempen" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "dbfedd56289924d8a7cc26a5aada392281547e053a10c0678238fc08a219fb6e" .
+  }
+}

--- a/config/migrations/2024/20240311134000-import-pz-hvz-names/20240311161910-import-hvz-juridical-names.sparql
+++ b/config/migrations/2024/20240311134000-import-pz-hvz-names/20240311161910-import-hvz-juridical-names.sparql
@@ -1,0 +1,303 @@
+PREFIX core: <http://mu.semte.ch/vocabularies/core/>
+PREFIX regorg: <http://www.w3.org/ns/regorg#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "Brandweer Westhoek" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "c74e71fb4ccf2e143731873471a890b87076a9b1dcc470b937b339d7c191fce4" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "Brandweer Zone Antwerpen" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "c8d171d9735146131fcb9e2ad7f4e271585b0bf68f7a43d8873b6848576d13a1" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "Brandweer Zone Centrum" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "4bb83a0635b69132a4de91667c0a30f228720bda01584b3a01c4cf7ddfc12664" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "Brandweer zone Kempen" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "215d1409dda860a1ce4f39f1f6c082c5662620d9d29de456f4242fb6cc6df0b5" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "Brandweerzone Midwest" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "b312420a9e4331da36afd70237db5061825cacadcdaa68e6ad0f1ea8a9426f77" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "Brandweerzone Oost-Limburg" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "7800a6f5e9c3f646e274b280703730ed5e83fe0cba1f0d6c7fb18141337fe781" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "Brandweer Zone Rand" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "2d25be1712e809bbeed7d439c93bace752e0742f6b2ed9802302dec9a8906e2a" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "Hulpverleningszone West" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "b3e202bf5ab9d30f1928f7a1ea8911c60da595819774702eb1745e83c25cf106" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "Hulpverleningszone Fluvia" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "9d0e3fc23f4fb9c23cbcc30474a1e518c9725c069255090d46eb58c13d62baef" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "Hulpverleningszone Meetjesland" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "0e951dd15341d38413bf809f16ef5f1bd163092001ac04ce78a4de5b5e9cdd37" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "Hulpverleningszone Noord-Limburg" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "505e727b7b078c3eb9a05f754d834fca559d28cb3cdb02d5e4cdb3be300ea699" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "Brandweerzone Oost" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "db299add14cc24e7a99ce4eb51015f32925690fb9816962e500f3341842ef6fa" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "Hulpverleningszone Oost" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "9fdf19f0cfc9e12bd58fc10c4da6e8c6c40e813ec5b9f3bdde92cb00ecd972fe" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "Brandweerzone Rivierenland" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "98967d1e1e3dd66ac9e32bd1d536ee8e85c9126cc5fc04354a335d5aabcf9b01" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "Hulpverleningszone Taxandria" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "c1fcc0a6c6132cb34dff9ed6e6f361d1587c211ac8ec1ddef409510bf68b724b" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "Brandweerzone Vlaamse Ardennen" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "bfc36f138e0c7d11757eb321d034cfbffce281679eae93c2bc5df1048aa05789" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "Hulpverleningszone Waasland" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "e8bd746e2dc3c5a72fe4fb3da0c92803b0728150bdd66e860d6218bc83098941" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "Hulpverleningszone 1" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "2c1fc56876479e83c7b144e98b84174dd10087ae59621204b9d6701d968e8aba" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "Hulpverleningszone Zuid-Oost" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "db5adb1e2e7ad0e33725b83edda44f9b4638e328a1534a1b4eef2683d337975a" ;
+      regorg:legalName ?oldName .
+  }
+}
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName ?oldName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:legalName "Hulpverleningszone Zuidwest" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "a3b32431cfbb18905e2c7deeaf9ef7af35cd17c55d053a05ed9cd8fdec550724" ;
+      regorg:legalName ?oldName .
+  }
+}

--- a/config/migrations/2024/20240311134000-import-pz-hvz-names/20240311161911-import-hvz-alternative-names.sparql
+++ b/config/migrations/2024/20240311134000-import-pz-hvz-names/20240311161911-import-hvz-alternative-names.sparql
@@ -1,0 +1,203 @@
+PREFIX core: <http://mu.semte.ch/vocabularies/core/>
+PREFIX regorg: <http://www.w3.org/ns/regorg#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "HVZ Brandweer Westhoek" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "c74e71fb4ccf2e143731873471a890b87076a9b1dcc470b937b339d7c191fce4" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "HVZ Brandweer Zone Antwerpen" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "c8d171d9735146131fcb9e2ad7f4e271585b0bf68f7a43d8873b6848576d13a1" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "HVZ Brandweer Zone Centrum" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "4bb83a0635b69132a4de91667c0a30f228720bda01584b3a01c4cf7ddfc12664" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "HVZ Brandweer Zone Kempen" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "215d1409dda860a1ce4f39f1f6c082c5662620d9d29de456f4242fb6cc6df0b5" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "HVZ Brandweer Zone Midwest" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "b312420a9e4331da36afd70237db5061825cacadcdaa68e6ad0f1ea8a9426f77" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "HVZ Brandweer Zone Oost-Limburg" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "7800a6f5e9c3f646e274b280703730ed5e83fe0cba1f0d6c7fb18141337fe781" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "HVZ Brandweer Zone Rand" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "2d25be1712e809bbeed7d439c93bace752e0742f6b2ed9802302dec9a8906e2a" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "HVZ Brandweer Zone Vlaams-Brabant West" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "b3e202bf5ab9d30f1928f7a1ea8911c60da595819774702eb1745e83c25cf106" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "HVZ Fluvia" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "9d0e3fc23f4fb9c23cbcc30474a1e518c9725c069255090d46eb58c13d62baef" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "HVZ Meetjesland" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "0e951dd15341d38413bf809f16ef5f1bd163092001ac04ce78a4de5b5e9cdd37" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "HVZ Noord-Limburg" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "505e727b7b078c3eb9a05f754d834fca559d28cb3cdb02d5e4cdb3be300ea699" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "HVZ Oost" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "db299add14cc24e7a99ce4eb51015f32925690fb9816962e500f3341842ef6fa" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "HVZ Oost-Vlaams-Brabant" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "9fdf19f0cfc9e12bd58fc10c4da6e8c6c40e813ec5b9f3bdde92cb00ecd972fe" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "HVZ Rivierenland" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "98967d1e1e3dd66ac9e32bd1d536ee8e85c9126cc5fc04354a335d5aabcf9b01" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "HVZ Taxandria" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "c1fcc0a6c6132cb34dff9ed6e6f361d1587c211ac8ec1ddef409510bf68b724b" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "HVZ Vlaamse Ardennen" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "bfc36f138e0c7d11757eb321d034cfbffce281679eae93c2bc5df1048aa05789" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "HVZ Waasland" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "e8bd746e2dc3c5a72fe4fb3da0c92803b0728150bdd66e860d6218bc83098941" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "HVZ Zone 1" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "2c1fc56876479e83c7b144e98b84174dd10087ae59621204b9d6701d968e8aba" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "HVZ Zuid-Oost" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "db5adb1e2e7ad0e33725b83edda44f9b4638e328a1534a1b4eef2683d337975a" .
+  }
+}
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s skos:altLabel "HVZ Zuid-West-Limburg" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s core:uuid "a3b32431cfbb18905e2c7deeaf9ef7af35cd17c55d053a05ed9cd8fdec550724" .
+  }
+}


### PR DESCRIPTION
OP-3087

Added (generated) migrations to import the juridical and alternative names for PZs and HVZs as provided by business.
- PZ = Politiezone = Police zone
- HVZ = Hulpverleningszone = Assistance zone

## Notes
- This PR is branched from #390 to simplify working with alternative names. Correctly displaying alternative names requires using https://github.com/lblod/frontend-organization-portal/pull/586 for the frontend. 
- Displaying the newly imported juridical names in the index table requires re-indexing.