### PR TITLE
Adding 2 new recognized worship types

### DIFF
--- a/config/migrations/2024/20240318142001-add-new-recognized-worship-types.sparql
+++ b/config/migrations/2024/20240318142001-add-new-recognized-worship-types.sparql
@@ -1,0 +1,27 @@
+PREFIX code: <http://lblod.data.gift/vocabularies/organisatie/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX core: <http://mu.semte.ch/vocabularies/core/>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://lblod.data.gift/concepts/cbd4c767ea184b41bf51b65d406754d4> a code:TypeEredienst ;
+      core:uuid "cbd4c767ea184b41bf51b65d406754d4" ;
+      skos:prefLabel "Niet-confessioneel" ;
+      skos:inScheme <http://lblod.data.gift/concept-schemes/5be1fce008d73105d9bc6de9e488b0b9> ;
+      skos:inScheme <http://lblod.data.gift/concept-schemes/10caf4a4-1ff5-4c05-917e-56489910d68b> ;
+      skos:topConceptOf <http://lblod.data.gift/concept-schemes/5be1fce008d73105d9bc6de9e488b0b9> .
+  }
+}
+
+;
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://lblod.data.gift/concepts/f076c85e72814278814776b038ac33f7> a code:TypeEredienst ;
+      core:uuid "f076c85e72814278814776b038ac33f7" ;
+      skos:prefLabel "Boeddhistisch" ;
+      skos:inScheme <http://lblod.data.gift/concept-schemes/5be1fce008d73105d9bc6de9e488b0b9> ;
+      skos:inScheme <http://lblod.data.gift/concept-schemes/10caf4a4-1ff5-4c05-917e-56489910d68b> ;
+      skos:topConceptOf <http://lblod.data.gift/concept-schemes/5be1fce008d73105d9bc6de9e488b0b9> .
+  }
+}

--- a/config/migrations/2024/20240318144801-update-missing-types-representative-bodies.sparql
+++ b/config/migrations/2024/20240318144801-update-missing-types-representative-bodies.sparql
@@ -1,0 +1,15 @@
+PREFIX ere: <http://data.lblod.info/vocabularies/erediensten/>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+   <http://data.lblod.info/id/representatieveOrganen/45a0c64b0f2ee4ac0fa8c151e6f2209c> a ere:RepresentatiefOrgaan ;
+         ere:typeEredienst <http://lblod.data.gift/concepts/cbd4c767ea184b41bf51b65d406754d4>
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+   <http://data.lblod.info/id/representatieveOrganen/5871503aa86b44cd470f97228a2ce413> a ere:RepresentatiefOrgaan ;
+         ere:typeEredienst <http://lblod.data.gift/concepts/f076c85e72814278814776b038ac33f7>
+  }
+}


### PR DESCRIPTION
"Boeddistisch" and "Niet-confessioneel" are added as recognized worship types for 2 new representative organs that had no type of worship service.

Change can go paired with typo fix "Boeddistiche" to  "Boeddistische" because change requires Re-Indexing
related PR: https://github.com/lblod/app-organization-portal/pull/398 