### PR TITLE
chore: bumped consumers to latest version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -535,7 +535,7 @@ services:
   # LOKET MANDATARISSEN CONSUMERS
   ################################################################################
   mandatarissen-consumer:
-    image: lblod/delta-consumer:0.0.17-rc.7
+    image: lblod/delta-consumer:0.0.24
     environment:
       DCR_SERVICE_NAME: "mandatarissen-consumer"
       DCR_SYNC_BASE_URL: "https://loket.lblod.info" # replace with link to Loket API
@@ -566,7 +566,7 @@ services:
   # LOKET LEIDINGGEVENDEN CONSUMERS
   ################################################################################
   leidinggevenden-consumer:
-    image: lblod/delta-consumer:0.0.18
+    image: lblod/delta-consumer:0.0.24
     environment:
       DCR_SERVICE_NAME: "leidinggevenden-consumer"
       DCR_SYNC_BASE_URL: "https://loket.lblod.info" # replace with link to Loket API
@@ -597,7 +597,7 @@ services:
   # LOKET WORSHIP SENSITIVE CONSUMERS
   ################################################################################
   worship-services-sensitive-consumer:
-    image: lblod/delta-consumer:0.0.17-rc.7
+    image: lblod/delta-consumer:0.0.24
     environment:
       DCR_SYNC_BASE_URL: "https://loket.lblod.info/"
       DCR_SERVICE_NAME: "worship-services-sensitive-consumer"


### PR DESCRIPTION
Bumped the 3 consumers to the latest version of the `delta-consumer`. It should be backwards compatible but some testing/monitoring seems prudent.