### PR TITLE
feat: export legal and alternative names via producers

### DIFF
--- a/config/delta-producer/organizations/export.json
+++ b/config/delta-producer/organizations/export.json
@@ -127,6 +127,7 @@
       ],
       "properties": [
         "http://www.w3.org/2004/02/skos/core#prefLabel",
+        "http://www.w3.org/ns/regorg#legalName",
         "http://www.w3.org/2004/02/skos/core#altLabel",
         "http://www.w3.org/ns/adms#identifier",
         "http://www.w3.org/ns/regorg#orgStatus",
@@ -155,6 +156,7 @@
       ],
       "properties": [
         "http://www.w3.org/2004/02/skos/core#prefLabel",
+        "http://www.w3.org/ns/regorg#legalName",
         "http://www.w3.org/2004/02/skos/core#altLabel",
         "http://www.w3.org/ns/adms#identifier",
         "http://www.w3.org/ns/regorg#orgStatus",
@@ -191,6 +193,7 @@
         "http://www.w3.org/2002/07/owl#sameAs",
         "http://www.w3.org/2004/02/skos/core#altLabel",
         "http://www.w3.org/2004/02/skos/core#prefLabel",
+        "http://www.w3.org/ns/regorg#legalName",
         "http://www.w3.org/ns/adms#identifier",
         "http://www.w3.org/ns/org#changedBy",
         "http://www.w3.org/ns/org#classification",
@@ -214,6 +217,7 @@
       ],
       "properties": [
         "http://www.w3.org/2004/02/skos/core#prefLabel",
+        "http://www.w3.org/ns/regorg#legalName",
         "http://www.w3.org/2004/02/skos/core#altLabel",
         "http://www.w3.org/ns/adms#identifier",
         "http://www.w3.org/ns/regorg#orgStatus",

--- a/config/delta-producer/public/export.json
+++ b/config/delta-producer/public/export.json
@@ -15,6 +15,7 @@
       "properties": [
         "http://mu.semte.ch/vocabularies/core/uuid",
         "http://www.w3.org/2004/02/skos/core#prefLabel",
+        "http://www.w3.org/ns/regorg#legalName",
         "http://www.w3.org/2004/02/skos/core#altLabel",
         "http://www.w3.org/ns/adms#identifier",
         "http://www.w3.org/ns/regorg#orgStatus",
@@ -46,6 +47,7 @@
       "properties": [
         "http://mu.semte.ch/vocabularies/core/uuid",
         "http://www.w3.org/2004/02/skos/core#prefLabel",
+        "http://www.w3.org/ns/regorg#legalName",
         "http://www.w3.org/2004/02/skos/core#altLabel",
         "http://www.w3.org/ns/adms#identifier",
         "http://www.w3.org/ns/regorg#orgStatus",
@@ -84,6 +86,7 @@
         "http://www.w3.org/2002/07/owl#sameAs",
         "http://www.w3.org/2004/02/skos/core#altLabel",
         "http://www.w3.org/2004/02/skos/core#prefLabel",
+        "http://www.w3.org/ns/regorg#legalName",
         "http://www.w3.org/ns/adms#identifier",
         "http://www.w3.org/ns/org#changedBy",
         "http://www.w3.org/ns/org#classification",
@@ -105,6 +108,8 @@
       "properties": [
         "http://mu.semte.ch/vocabularies/core/uuid",
         "http://www.w3.org/2004/02/skos/core#prefLabel",
+        "http://www.w3.org/ns/regorg#legalName",
+        "http://www.w3.org/2004/02/skos/core#altLabel",
         "http://www.w3.org/ns/org#linkedTo",
         "http://data.lblod.info/vocabularies/erediensten/typeEredienst",
         "http://www.w3.org/ns/adms#identifier"

--- a/config/delta-producer/worship-posts/export.json
+++ b/config/delta-producer/worship-posts/export.json
@@ -22,6 +22,7 @@
       "properties": [
         "http://mu.semte.ch/vocabularies/core/uuid",
         "http://www.w3.org/2004/02/skos/core#prefLabel",
+        "http://www.w3.org/ns/regorg#legalName",
         "http://www.w3.org/2004/02/skos/core#altLabel",
         "http://www.w3.org/ns/regorg#orgStatus",
         "http://data.lblod.info/vocabularies/erediensten/typeEredienst",
@@ -42,6 +43,7 @@
       "properties": [
         "http://mu.semte.ch/vocabularies/core/uuid",
         "http://www.w3.org/2004/02/skos/core#prefLabel",
+        "http://www.w3.org/ns/regorg#legalName",
         "http://www.w3.org/2004/02/skos/core#altLabel",
         "http://www.w3.org/ns/regorg#orgStatus",
         "http://data.lblod.info/vocabularies/erediensten/typeEredienst",
@@ -61,6 +63,7 @@
       "properties": [
         "http://mu.semte.ch/vocabularies/core/uuid",
         "http://www.w3.org/2004/02/skos/core#prefLabel",
+        "http://www.w3.org/ns/regorg#legalName",
         "http://www.w3.org/2004/02/skos/core#altLabel",
         "http://www.w3.org/ns/regorg#orgStatus",
         "http://data.lblod.info/vocabularies/erediensten/typeEredienst",
@@ -121,6 +124,7 @@
       "properties": [
         "http://mu.semte.ch/vocabularies/core/uuid",
         "http://www.w3.org/2004/02/skos/core#prefLabel",
+        "http://www.w3.org/ns/regorg#legalName",
         "http://www.w3.org/2004/02/skos/core#altLabel",
         "http://www.w3.org/ns/regorg#orgStatus",
         "http://www.w3.org/ns/org#hasPrimarySite",


### PR DESCRIPTION
Following #406 this adds the legal and alternative names to the exports for all other consumers.

Notes:
- The alternative name was previously already included in most exports.
- I do not think the consumers of our data require immediate changes to keep up to date data. The frontend will update the value for `skos:prefLabel` whenever a user changes an organisation's `regorg:legalName`.