### PR TITLE
removed empty literals and uris

### DIFF
--- a/config/migrations/2024/20240316100500-delete-all-empty-uris.sparql
+++ b/config/migrations/2024/20240316100500-delete-all-empty-uris.sparql
@@ -15,7 +15,8 @@ WHERE {
   GRAPH ?g {
     ?s <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type  ;
       <http://mu.semte.ch/vocabularies/core/uuid> ?uuid .
-
+      
+    FILTER (?type != <https://data.vlaanderen.be/ns/generiek#GestructureerdeIdentificator>)
     FILTER NOT EXISTS {
       FILTER (?p != <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>)
       FILTER (?p != <http://mu.semte.ch/vocabularies/core/uuid>)

--- a/config/migrations/2024/20240316100500-delete-all-empty-uris.sparql
+++ b/config/migrations/2024/20240316100500-delete-all-empty-uris.sparql
@@ -1,0 +1,25 @@
+DELETE {
+  GRAPH ?g {
+    ?s <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type  ;
+      <http://mu.semte.ch/vocabularies/core/uuid> ?uuid . 
+  }
+}
+WHERE {
+  VALUES ?g {
+    <http://mu.semte.ch/graphs/administrative-unit>
+    <http://mu.semte.ch/graphs/worship-service>
+    <http://mu.semte.ch/graphs/public>
+    <http://mu.semte.ch/graphs/privacy-centric-graph>
+    <http://mu.semte.ch/graphs/worship-privacy-centric-graph>
+  }
+  GRAPH ?g {
+    ?s <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ?type  ;
+      <http://mu.semte.ch/vocabularies/core/uuid> ?uuid .
+
+    FILTER NOT EXISTS {
+      FILTER (?p != <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>)
+      FILTER (?p != <http://mu.semte.ch/vocabularies/core/uuid>)
+      ?s ?p ?o .
+    }
+  }
+}

--- a/config/migrations/2024/20240327131000-delete-all-empty-literals.sparql
+++ b/config/migrations/2024/20240327131000-delete-all-empty-literals.sparql
@@ -14,7 +14,7 @@ WHERE {
   graph ?g {
     ?s ?p ?o
 
-    Filter(?o = " " || ?o = "")
-
+    FILTER (isLiteral(?o))
+    FILTER regex(str(?o), "^\\s*$")
   }
 }

--- a/config/migrations/2024/20240327131000-delete-all-empty-literals.sparql
+++ b/config/migrations/2024/20240327131000-delete-all-empty-literals.sparql
@@ -1,0 +1,20 @@
+DELETE {
+  GRAPH ?g { 
+    ?s ?p ?o .
+  }
+}
+WHERE {
+  VALUES ?g {
+    <http://mu.semte.ch/graphs/administrative-unit>
+    <http://mu.semte.ch/graphs/worship-service>
+    <http://mu.semte.ch/graphs/public>
+    <http://mu.semte.ch/graphs/privacy-centric-graph>
+    <http://mu.semte.ch/graphs/worship-privacy-centric-graph>
+  }
+  graph ?g {
+    ?s ?p ?o
+
+    Filter(?o = " " || ?o = "")
+
+  }
+}


### PR DESCRIPTION
All removed empty literals and uris.

FOr the URIs there are still a few empty ones in the landingzone and producer graphs. I'm not entirely sure if i need to include them.
Comparing to a similar query done in the past it seems that they included those too but I am not sure if that was just an irregularity from back then or not