### PR TITLE
Fix: correct type for classification to match resource configuration

### DIFF
--- a/config/migrations/2024/20240415085335-correct-representative-body-classification-code-type.sparql
+++ b/config/migrations/2024/20240415085335-correct-representative-body-classification-code-type.sparql
@@ -1,0 +1,15 @@
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s a ext:RepresentatieveOrgaanClassificatieCode .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s a ext:RepresentatiefOrgaanClassificatieCode .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s a ext:RepresentatieveOrgaanClassificatieCode .
+  }
+}


### PR DESCRIPTION
For representative body classification codes there was an inconsistency between our `mu-cl-resources` configuration and the actual type object stored in the triplestore.
Our `domain.json` specifies as `ext:RepresentatiefOrgaanClassificatieCode` as class for `representative-body-classification-codes`. While the stored triples specified `ext:RepresentatieveOrgaanClassificatieCode` as type. This error was introduced in #342. The new migration corrects the type in the triplestore.

An alternative solution would be to change our `domain.json` but "representatief orgaan" is the correct term in Dutch we use through the app.