### PR TITLE
avoid inserting duplicate triples to the database

### DIFF
--- a/config/clb-consumer/contact-data/delta-sync-dispatching.js
+++ b/config/clb-consumer/contact-data/delta-sync-dispatching.js
@@ -53,7 +53,7 @@ async function dispatch(lib, data) {
 }
 
 function separateBetweenTargetAndPublic(changes, context) {
-  const changesOnPublic = [];
+  const changesOnPublic = new Set();
   const changesOnGraphs = {};
   for(let change of changes) {
     const subject = change.subject;
@@ -71,18 +71,16 @@ function separateBetweenTargetAndPublic(changes, context) {
       const graph = graphTriple.object.slice(1,-1); // We have to slice it to remove the "<" and ">"
       if(change.object !== '') {
         if(!changesOnGraphs[graph]) {
-          changesOnGraphs[graph] = [`${change.subject} ${change.predicate} ${change.object}.`]                                         
-        } else {
-          changesOnGraphs[graph].push(`${change.subject} ${change.predicate} ${change.object}.`)
-        }   
+          changesOnGraphs[graph] = new Set();
+        }  
+        changesOnGraphs[graph].add(`${change.subject} ${change.predicate} ${change.object}.`)
       }                    
       for(let triple of otherContextTriples) {
         if(triple.object === '') continue;
         if(!changesOnGraphs[graph]) {
-          changesOnGraphs[graph] = [`${triple.subject} ${triple.predicate} ${triple.object}.`]                                      
-        } else {
-          changesOnGraphs[graph].push(`${triple.subject} ${triple.predicate} ${triple.object}.`)
-        }                                        
+          changesOnGraphs[graph] = new Set();
+        }  
+        changesOnGraphs[graph].add(`${triple.subject} ${triple.predicate} ${triple.object}.`)                                       
       }
     }
     const typeTriple = contextTriples.find(
@@ -92,9 +90,9 @@ function separateBetweenTargetAndPublic(changes, context) {
     if(!typeTriple) continue;
     const type = typeTriple.object;
     if(publicTypes.includes(type)) {
-      changesOnPublic.push(`${change.subject} ${change.predicate} ${change.object}.`)
+      changesOnPublic.add(`${change.subject} ${change.predicate} ${change.object}.`)
       for(let triple of otherContextTriples) {
-        changesOnPublic.push(`${triple.subject} ${triple.predicate} ${triple.object}.`)
+        changesOnPublic.add(`${triple.subject} ${triple.predicate} ${triple.object}.`)
       }
     }
   }

--- a/config/clb-consumer/contact-data/util.js
+++ b/config/clb-consumer/contact-data/util.js
@@ -91,7 +91,7 @@ async function insertIntoPublicGraph(lib, statements) {
   await batchedDbUpdate(
     lib.muAuthSudo.updateSudo,
     'http://mu.semte.ch/graphs/public',
-    statements,
+    Array.from(statements),
     {},
     process.env.MU_SPARQL_ENDPOINT,
     BATCH_SIZE,
@@ -108,7 +108,7 @@ async function insertIntoSpecificGraphs(lib, statementsWithGraphs) {
     await batchedDbUpdate(
       lib.muAuthSudo.updateSudo,
       graph,
-      statementsWithGraphs[graph],
+      Array.from(statementsWithGraphs[graph]),
       {},
       process.env.MU_SPARQL_ENDPOINT,
       BATCH_SIZE,
@@ -126,7 +126,7 @@ async function deleteFromPublicGraph(lib, statements) {
   await batchedDbUpdate(
     lib.muAuthSudo.updateSudo,
     'http://mu.semte.ch/graphs/public',
-    statements,
+    Array.from(statements),
     {},
     process.env.MU_SPARQL_ENDPOINT,
     BATCH_SIZE,
@@ -144,7 +144,7 @@ async function deleteFromSpecificGraphs(lib, statementsWithGraphs) {
     await batchedDbUpdate(
       lib.muAuthSudo.updateSudo,
       graph,
-      statementsWithGraphs[graph],
+      Array.from(statementsWithGraphs[graph]),
       {},
       process.env.MU_SPARQL_ENDPOINT,
       BATCH_SIZE,


### PR DESCRIPTION
This lowers down the problematic delta from 200k insertions to "only" 2k. Still takes a lot of time because of the cascade queries we make, but there's no solution for that yet according to Boris.
Also this deltas will be removed in the future from CLB as they are an error so we won't have this problem, but anyway this makes the consumer more perfomant overall