### PR TITLE
Refactor: generalise backend for non-administrative unit organisations

### DIFF
--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -73,7 +73,7 @@ defmodule Dispatcher do
   end
 
   match "/organizations/*path", %{ accept: [:json], layer: :api} do
-    Proxy.forward conn, path, "http://cache/organizations/"
+    Proxy.forward conn, path, "http://resource/organizations/"
   end
 
   match "/administrative-units/*path", %{ accept: [:json], layer: :api} do

--- a/config/resources/domain.json
+++ b/config/resources/domain.json
@@ -50,9 +50,7 @@
     },
     "people": {
       "class": "person:Person",
-      "super": [
-        "agents"
-      ],
+      "super": ["agents"],
       "attributes": {
         "given-name": {
           "type": "string",
@@ -91,9 +89,7 @@
     },
     "agents-in-position": {
       "class": "ch:AgentInPositie",
-      "super": [
-        "agents"
-      ],
+      "super": ["agents"],
       "attributes": {
         "agent-start-date": {
           "type": "datetime",
@@ -141,9 +137,7 @@
     },
     "mandatories": {
       "class": "mandaat:Mandataris",
-      "super": [
-        "agents-in-position"
-      ],
+      "super": ["agents-in-position"],
       "attributes": {
         "start-date": {
           "type": "datetime",
@@ -186,16 +180,12 @@
           "predicate": "skos:prefLabel"
         }
       },
-      "features": [
-        "include-uri"
-      ],
+      "features": ["include-uri"],
       "new-resource-base": "http://data.vlaanderen.be/id/concept/MandatarisStatusCode/"
     },
     "worship-mandatories": {
       "class": "ere:EredienstMandataris",
-      "super": [
-        "mandatories"
-      ],
+      "super": ["mandatories"],
       "attributes": {
         "expected-end-date": {
           "type": "datetime",
@@ -260,9 +250,7 @@
     },
     "mandates": {
       "class": "mandaat:Mandaat",
-      "super": [
-        "posts"
-      ],
+      "super": ["posts"],
       "relationships": {
         "role-board": {
           "predicate": "org:role",
@@ -286,9 +274,7 @@
     },
     "functionaries": {
       "class": "lblodlg:Functionaris",
-      "super": [
-        "agents-in-position"
-      ],
+      "super": ["agents-in-position"],
       "attributes": {
         "start-date": {
           "type": "datetime",
@@ -326,16 +312,12 @@
           "predicate": "skos:prefLabel"
         }
       },
-      "features": [
-        "include-uri"
-      ],
+      "features": ["include-uri"],
       "new-resource-base": "http://data.vlaanderen.be/id/concept/functionarisStatusCode/"
     },
     "board-positions": {
       "class": "lblodlg:Bestuursfunctie",
-      "super": [
-        "posts"
-      ],
+      "super": ["posts"],
       "relationships": {
         "role-board": {
           "predicate": "org:role",
@@ -385,9 +367,7 @@
     },
     "organizations": {
       "class": "org:Organization",
-      "super": [
-        "agents"
-      ],
+      "super": ["agents"],
       "attributes": {
         "name": {
           "type": "string",
@@ -411,6 +391,11 @@
         }
       },
       "relationships": {
+        "classification": {
+          "predicate": "org:classification",
+          "target": "organization-classification-codes",
+          "cardinality": "one"
+        },
         "identifiers": {
           "predicate": "adms:identifier",
           "target": "identifiers",
@@ -519,15 +504,8 @@
     },
     "administrative-units": {
       "class": "besluit:Bestuurseenheid",
-      "super": [
-        "organizations"
-      ],
+      "super": ["organizations"],
       "relationships": {
-        "classification": {
-          "predicate": "org:classification",
-          "target": "administrative-unit-classification-codes",
-          "cardinality": "one"
-        },
         "governing-bodies": {
           "predicate": "besluit:bestuurt",
           "target": "governing-bodies",
@@ -569,16 +547,12 @@
     },
     "administrative-unit-classification-codes": {
       "class": "code:BestuurseenheidClassificatieCode",
-      "super": [
-        "organization-classification-codes"
-      ],
+      "super": ["organization-classification-codes"],
       "new-resource-base": "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/"
     },
     "worship-administrative-units": {
       "class": "ere:EredienstBestuurseenheid",
-      "super": [
-        "administrative-units"
-      ],
+      "super": ["administrative-units"],
       "relationships": {
         "recognized-worship-type": {
           "predicate": "ere:typeEredienst",
@@ -601,9 +575,7 @@
     },
     "worship-services": {
       "class": "ere:BestuurVanDeEredienst",
-      "super": [
-        "worship-administrative-units"
-      ],
+      "super": ["worship-administrative-units"],
       "attributes": {
         "denomination": {
           "type": "string",
@@ -628,16 +600,12 @@
     },
     "central-worship-services": {
       "class": "ere:CentraalBestuurVanDeEredienst",
-      "super": [
-        "worship-administrative-units"
-      ],
+      "super": ["worship-administrative-units"],
       "new-resource-base": "http://data.lblod.info/id/centraleBesturenVanDeEredienst/"
     },
     "kbo-organizations": {
       "class": "ext:KboOrganisatie",
-      "super": [
-        "organizations"
-      ],
+      "super": ["organizations"],
       "attributes": {
         "rechtsvorm": {
           "type": "string",
@@ -653,19 +621,17 @@
         }
       },
       "relationships": {
-          "organization": {
-            "predicate": "owl:sameAs",
-            "target": "organizations",
-            "cardinality": "one"
-          }
-        },
-        "new-resource-base": "http://data.lblod.info/id/kboOrganisaties/"
+        "organization": {
+          "predicate": "owl:sameAs",
+          "target": "organizations",
+          "cardinality": "one"
+        }
+      },
+      "new-resource-base": "http://data.lblod.info/id/kboOrganisaties/"
     },
     "representative-bodies": {
       "class": "ere:RepresentatiefOrgaan",
-      "super": [
-        "organizations"
-      ],
+      "super": ["organizations"],
       "relationships": {
         "classification": {
           "predicate": "org:classification",
@@ -688,9 +654,7 @@
     },
     "representative-body-classification-codes": {
       "class": "ext:RepresentatiefOrgaanClassificatieCode",
-      "super": [
-        "organization-classification-codes"
-      ],
+      "super": ["organization-classification-codes"],
       "new-resource-base": "http://data.vlaanderen.be/id/concept/RepresentatiefOrgaanClassificatieCode/"
     },
     "governing-bodies": {
@@ -914,9 +878,7 @@
           "predicate": "skos:prefLabel"
         }
       },
-      "features": [
-        "include-uri"
-      ],
+      "features": ["include-uri"],
       "new-resource-base": "http://lblod.data.gift/concepts/"
     },
     "locations": {
@@ -969,9 +931,7 @@
     },
     "ministers": {
       "class": "ere:RolBedienaar",
-      "super": [
-        "agents-in-position"
-      ],
+      "super": ["agents-in-position"],
       "relationships": {
         "minister-position": {
           "predicate": "org:holds",
@@ -1039,9 +999,7 @@
     },
     "minister-positions": {
       "class": "ere:PositieBedienaar",
-      "super": [
-        "posts"
-      ],
+      "super": ["posts"],
       "relationships": {
         "function": {
           "predicate": "ere:functie",

--- a/config/search/config.json
+++ b/config/search/config.json
@@ -754,8 +754,8 @@
       }
     },
     {
-      "type": "unit",
-      "on_path": "units",
+      "type": "organization",
+      "on_path": "organization",
       "rdf_type": [
         "http://data.vlaanderen.be/ns/besluit#Bestuurseenheid",
         "http://data.lblod.info/vocabularies/erediensten/EredienstBestuurseenheid",

--- a/config/search/dev/config.json
+++ b/config/search/dev/config.json
@@ -727,8 +727,8 @@
       }
     },
     {
-      "type": "unit",
-      "on_path": "units",
+      "type": "organization",
+      "on_path": "organizations",
       "rdf_type": [
         "http://data.vlaanderen.be/ns/besluit#Bestuurseenheid",
         "http://data.lblod.info/vocabularies/erediensten/EredienstBestuurseenheid",


### PR DESCRIPTION
OP-3142

Corresponding frontend: [PR 602](https://github.com/lblod/frontend-organization-portal/pull/602)

## Changes

- Moved the classification relationship from `administrative-units` to `organizations` and generalised its target to `organization-classification-codes`.
- Rename the `units` index in the search configuration to `organizations` to indicate it covers more than administrative units. (Which it already did since it includes representative bodies.)
- Dispatch requests on the `organizations` path directly to the `resources` service instead of the `cache` service