### PR TITLE
Fix kbo-data-sync rewrite all `fullAddress` and override `sameAs`

### DIFF
--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -316,8 +316,9 @@ defmodule Dispatcher do
     forward conn, path, "http://kbo-data-sync/sync-kbo-data/"
   end
 
+  # TODO: Remove when the kbo feature flag is removed on the frontend
   post "/sync-ovo-number/*path", %{ layer: :api_services, accept: %{ json: true } } do
-    forward conn, path, "http://sync-ovo-numbers/sync-from-kbo/"
+    forward conn, path, "http://kbo-data-sync/sync-kbo-data/"
   end
 
   get "/ldes/*path", %{ layer: :api_services } do

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -301,21 +301,13 @@ services:
     restart: always
     logging: *default-logging
   kbo-data-sync:
-    image: lblod/sync-wegwijs-organization-service:2.0.0
+    image: lblod/sync-wegwijs-organization-service:2.0.2
     links:
       - db:database
     labels:
       - "logging=true"
     restart: always
     logging: *default-logging
-  sync-ovo-numbers:
-    image: lblod/sync-ovo-numbers-service:0.1.0
-    links:
-      - db:database
-    labels:
-      - "logging=true"
-    restart: always
-    logging: *default-logging  
 
   ################################################################################
   # DELTA GENERAL


### PR DESCRIPTION
The new version of the service bring 2 fixes : 
- fix the rewrite of all `fullAddress` https://github.com/lblod/sync-wegwijs-organization-service/pull/8
- fix the rewrite of `sameAs` on KBO organization https://github.com/lblod/sync-wegwijs-organization-service/pull/7

Do not use the old version when feature flag is false is needed to prevent the `sameAs` override. 