### PR TITLE
Feature: support registered organisations

### DIFF
--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -40,6 +40,7 @@ defmodule Acl.UserGroups.Config do
     "http://lblod.data.gift/vocabularies/organisatie/BestuursorgaanClassificatieCode",
     "http://lblod.data.gift/vocabularies/organisatie/MandatarisStatusCode",
     "http://lblod.data.gift/vocabularies/organisatie/BestuurseenheidClassificatieCode",
+    "http://mu.semte.ch/vocabularies/ext/GeregistreerdeOrganisatieClassificatieCode",
     "http://lblod.data.gift/vocabularies/organisatie/TypeEredienst",
     "http://www.w3.org/2004/02/skos/core#ConceptScheme",
     "http://lblod.data.gift/vocabularies/organisatie/BedienaarFinancieringCode",

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -76,6 +76,10 @@ defmodule Dispatcher do
     Proxy.forward conn, path, "http://resource/organizations/"
   end
 
+  match "/registered-organizations/*path", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, path, "http://resource/registered-organizations/"
+  end
+
   match "/administrative-units/*path", %{ accept: [:json], layer: :api} do
     Proxy.forward conn, path, "http://resource/administrative-units/"
   end
@@ -86,6 +90,10 @@ defmodule Dispatcher do
 
   match "/organization-classification-codes/*path", %{ accept: [:json], layer: :api} do
     Proxy.forward conn, path, "http://cache/organization-classification-codes/"
+  end
+
+  match "/registered-organization-classification-codes/*path", %{ accept: [:json], layer: :api} do
+    Proxy.forward conn, path, "http://cache/registered-organization-classification-codes/"
   end
 
   match "/worship-administrative-units/*path", %{ accept: [:json], layer: :api} do

--- a/config/resources/domain.json
+++ b/config/resources/domain.json
@@ -535,6 +535,11 @@
       },
       "new-resource-base": "http://data.lblod.info/id/bestuurseenheden/"
     },
+    "registered-organizations": {
+      "class": "regorg:RegisteredOrganization",
+      "super": ["organizations"],
+      "new-resource-base": "http://data.lblod.info/id/geregistreerdeOrganisaties/"
+    },
     "organization-classification-codes": {
       "class": "ext:OrganizationClassificationCode",
       "attributes": {
@@ -549,6 +554,11 @@
       "class": "code:BestuurseenheidClassificatieCode",
       "super": ["organization-classification-codes"],
       "new-resource-base": "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/"
+    },
+    "registered-organization-classification-codes": {
+      "class": "ext:GeregistreerdeOrganisatieClassificatieCode",
+      "super": ["organization-classification-codes"],
+      "new-resource-base": "http://data.vlaanderen.be/id/concept/GeregistreerdeOrganisatieClassificatieCode/"
     },
     "worship-administrative-units": {
       "class": "ere:EredienstBestuurseenheid",

--- a/config/search/config.json
+++ b/config/search/config.json
@@ -761,7 +761,8 @@
         "http://data.lblod.info/vocabularies/erediensten/EredienstBestuurseenheid",
         "http://data.lblod.info/vocabularies/erediensten/CentraalBestuurVanDeEredienst",
         "http://data.lblod.info/vocabularies/erediensten/BestuurVanDeEredienst",
-        "http://data.lblod.info/vocabularies/erediensten/RepresentatiefOrgaan"
+        "http://data.lblod.info/vocabularies/erediensten/RepresentatiefOrgaan",
+        "http://www.w3.org/ns/regorg#RegisteredOrganization",
       ],
       "properties": {
         "name": "http://www.w3.org/2004/02/skos/core#prefLabel",

--- a/config/search/config.json
+++ b/config/search/config.json
@@ -762,7 +762,7 @@
         "http://data.lblod.info/vocabularies/erediensten/CentraalBestuurVanDeEredienst",
         "http://data.lblod.info/vocabularies/erediensten/BestuurVanDeEredienst",
         "http://data.lblod.info/vocabularies/erediensten/RepresentatiefOrgaan",
-        "http://www.w3.org/ns/regorg#RegisteredOrganization",
+        "http://www.w3.org/ns/regorg#RegisteredOrganization"
       ],
       "properties": {
         "name": "http://www.w3.org/2004/02/skos/core#prefLabel",

--- a/config/search/dev/config.json
+++ b/config/search/dev/config.json
@@ -735,7 +735,7 @@
         "http://data.lblod.info/vocabularies/erediensten/CentraalBestuurVanDeEredienst",
         "http://data.lblod.info/vocabularies/erediensten/BestuurVanDeEredienst",
         "http://data.lblod.info/vocabularies/erediensten/RepresentatiefOrgaan",
-        "http://www.w3.org/ns/regorg#RegisteredOrganization",
+        "http://www.w3.org/ns/regorg#RegisteredOrganization"
       ],
       "properties": {
         "name": "http://www.w3.org/2004/02/skos/core#prefLabel",

--- a/config/search/dev/config.json
+++ b/config/search/dev/config.json
@@ -734,7 +734,8 @@
         "http://data.lblod.info/vocabularies/erediensten/EredienstBestuurseenheid",
         "http://data.lblod.info/vocabularies/erediensten/CentraalBestuurVanDeEredienst",
         "http://data.lblod.info/vocabularies/erediensten/BestuurVanDeEredienst",
-        "http://data.lblod.info/vocabularies/erediensten/RepresentatiefOrgaan"
+        "http://data.lblod.info/vocabularies/erediensten/RepresentatiefOrgaan",
+        "http://www.w3.org/ns/regorg#RegisteredOrganization",
       ],
       "properties": {
         "name": "http://www.w3.org/2004/02/skos/core#prefLabel",


### PR DESCRIPTION
OP-3186

## Summary
The necessary service (configurations) are extended to handle a new type of organization: Registered organizations (nl. Geregistreerde organisaties). An example of such organizations are the private OCMW associations.

## Notes
- For registered organizations the dispatcher routes directly to the `resources` service instead of the `cache` due to OP-3173.
- The actual migrations importing the data for private OCMW associations will be added in a separate PR.
- The actual classifications codes were already imported previously in #367 
- The `construct-administrative-unit-relationships-service` itself was previously already extended with the necessary classification codes, see https://github.com/lblod/construct-administrative-unit-relationships-service/pull/8 (A follow-up ticket to rename/refactor that service to correctly show that it is used for more than administrative units is already created, see OP-3230)