### PR TITLE
fix: exclude KBO organisations as participants

### DIFF
--- a/config/dev-migrations/20240522095345-public-ocmw-associations-remov-participants.sparql
+++ b/config/dev-migrations/20240522095345-public-ocmw-associations-remov-participants.sparql
@@ -1,0 +1,16 @@
+PREFIX org: <http://www.w3.org/ns/org#>
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+    ?association org:classification ?class
+  }
+  VALUES ?class {
+    <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/e8294b73-87c9-4fa2-9441-1937350763c9> # Welzijnsvereniging
+        <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/34b5af85-dc9f-468f-9e03-ef89b174c267> # Autonome verzorgingsinstelling
+  }
+}

--- a/config/migrations/2024/20240517134134-public-ocmw-associations-related-organizations/20240522120919-ter-lembeek-import-participants.sparql
+++ b/config/migrations/2024/20240517134134-public-ocmw-associations-related-organizations/20240522120919-ter-lembeek-import-participants.sparql
@@ -3,6 +3,7 @@ PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX adms: <http://www.w3.org/ns/adms#>
 PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
 
 INSERT {
   GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
@@ -11,6 +12,7 @@ INSERT {
 } WHERE {
   GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
     ?participant adms:identifier ?idParticipant .
+    FILTER NOT EXISTS { ?participant a ext:KboOrganisatie . }
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator ?kboNumber .
 

--- a/config/migrations/2024/20240517134134-public-ocmw-associations-related-organizations/20240522123045-import-public-ocmw-association-participants-part1.sparql
+++ b/config/migrations/2024/20240517134134-public-ocmw-associations-related-organizations/20240522123045-import-public-ocmw-association-participants-part1.sparql
@@ -1,0 +1,3009 @@
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX adms: <http://www.w3.org/ns/adms#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212236097" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212237285" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212240552" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212238374" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212246094" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212212541" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212214620" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0208038769" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212217885" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212218974" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207888816" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212221251" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212223726" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0216769165" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207713127" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212196705" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212198485" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212199673" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212203930" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212206801" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212209967" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212211452" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212210759" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212175721" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212178590" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212178788" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212181956" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207505368" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207509427" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207537042" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207505764" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207536943" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207533874" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207501806" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207504675" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207502004" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207502103" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207502202" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207502497" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207502596" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0216769066" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207502794" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207502992" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207503190" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207503388" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207503784" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207503982" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207504378" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207504477" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207504576" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207533082" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207215160" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207534765" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207505566" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0204212714" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0211104959" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0233210764" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212189676" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0233210764" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212180570" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0233210764" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212181659" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0233210764" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212208878" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0233210764" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212241047" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0242469910" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212175424" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0242469910" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207148052" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0256543917" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212215907" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0262562568" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212171860" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0262562568" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0211104959" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0262926319" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212214125" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0262926616" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212237186" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0263545337" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212182649" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0263545337" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212213333" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0263545337" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207832792" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0266559859" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0473908049" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0266559859" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212216402" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0267302405" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212196111" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0267313291" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212173444" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0267314875" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212171860" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0267314875" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212240651" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0267314875" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212190072" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0267314875" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212169781" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0267314875" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212187993" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0267314875" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212194131" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0267314875" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212179778" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0267314875" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212241641" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0267393663" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212243720" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0267393663" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0216772729" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0267393663" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0216772927" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0267393663" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212194230" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0267393663" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0216773323" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0267393663" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212204227" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0267393663" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212207591" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0267393663" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212207888" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0267393663" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207832792" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0267404056" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212241740" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0445508132" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212242235" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0445508132" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212243423" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0445508132" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212243522" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0445508132" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212217390" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0445508132" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212224815" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0445508132" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212188983" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0445508132" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212200861" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0445508132" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212203831" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0445508132" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212167209" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0445508132" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212168001" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0445508132" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212172850" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0445508132" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212183540" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0445508132" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212185421" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0445508132" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212186807" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0445508132" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212235604" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0458878195" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212184035" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0459993992" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212242235" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0459993992" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207501113" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0459993992" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207506952" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0459993992" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212207789" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0465810133" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212222241" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0466193777" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212221845" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0466193777" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212192547" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0466193777" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212205415" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0466193777" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212183243" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0466193777" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207489037" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0466193777" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207485473" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0466193777" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207487354" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0466193777" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207436676" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0466193777" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207437864" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0466193777" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0231884636" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212344282" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212247282" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212247579" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212212343" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212213333" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212218182" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212219469" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212223033" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212223330" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212189973" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0216769363" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212193141" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212196408" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212194329" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212195319" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212197002" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212197891" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212207393" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212208086" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212166021" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212172058" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212173345" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212181362" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212174434" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212205118" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0473908049" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212165922" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0480589567" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207148052" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0505849852" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212174137" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0537951706" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207432520" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0537951706" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212235703" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0630835639" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212236889" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0630835639" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212245205" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0630835639" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212218479" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0630835639" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant adms:identifier ?idParticipant .
+    ?idParticipant skos:notation ?kboLabel ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212189676" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
+
+    ?association adms:identifier ?idAssociation .
+    ?idAssociation skos:notation "KBO nummer" ;
+      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0630835639" .
+
+    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
+  }
+}
+;

--- a/config/migrations/2024/20240517134134-public-ocmw-associations-related-organizations/20240522123045-import-public-ocmw-association-participants-part2.sparql
+++ b/config/migrations/2024/20240517134134-public-ocmw-associations-related-organizations/20240522123045-import-public-ocmw-association-participants-part2.sparql
@@ -3,2851 +3,8 @@ PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
 PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
 PREFIX adms: <http://www.w3.org/ns/adms#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
 
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212236097" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212237285" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212240552" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212238374" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212246094" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212212541" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212214620" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0208038769" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212217885" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212218974" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207888816" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212221251" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212223726" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0216769165" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207713127" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212196705" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212198485" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212199673" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212203930" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212206801" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212209967" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212211452" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212210759" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212175721" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212178590" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212178788" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212181956" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207505368" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207509427" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207537042" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207505764" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207536943" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207533874" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207501806" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207504675" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207502004" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207502103" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207502202" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207502497" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207502596" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0216769066" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207502794" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207502992" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207503190" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207503388" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207503784" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207503982" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207504378" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207504477" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207504576" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207533082" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207215160" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207534765" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207505566" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0204212714" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0211104959" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0233210764" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212189676" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0233210764" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212180570" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0233210764" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212181659" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0233210764" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212208878" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0233210764" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212241047" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0242469910" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212175424" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0242469910" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207148052" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0256543917" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212215907" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0262562568" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212171860" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0262562568" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0211104959" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0262926319" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212214125" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0262926616" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212237186" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0263545337" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212182649" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0263545337" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212213333" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0263545337" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207832792" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0266559859" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0473908049" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0266559859" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212216402" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0267302405" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212196111" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0267313291" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212173444" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0267314875" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212171860" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0267314875" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212240651" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0267314875" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212190072" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0267314875" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212169781" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0267314875" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212187993" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0267314875" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212194131" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0267314875" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212179778" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0267314875" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212241641" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0267393663" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212243720" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0267393663" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0216772729" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0267393663" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0216772927" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0267393663" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212194230" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0267393663" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0216773323" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0267393663" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212204227" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0267393663" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212207591" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0267393663" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212207888" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0267393663" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207832792" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0267404056" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212241740" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0445508132" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212242235" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0445508132" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212243423" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0445508132" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212243522" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0445508132" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212217390" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0445508132" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212224815" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0445508132" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212188983" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0445508132" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212200861" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0445508132" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212203831" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0445508132" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212167209" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0445508132" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212168001" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0445508132" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212172850" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0445508132" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212183540" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0445508132" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212185421" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0445508132" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212186807" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0445508132" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212235604" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0458878195" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212184035" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0459993992" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212242235" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0459993992" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207501113" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0459993992" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207506952" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0459993992" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212207789" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0465810133" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212222241" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0466193777" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212221845" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0466193777" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212192547" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0466193777" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212205415" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0466193777" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212183243" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0466193777" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207489037" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0466193777" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207485473" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0466193777" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207487354" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0466193777" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207436676" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0466193777" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207437864" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0466193777" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0231884636" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212344282" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212247282" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212247579" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212212343" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212213333" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212218182" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212219469" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212223033" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212223330" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212189973" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0216769363" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212193141" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212196408" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212194329" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212195319" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212197002" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212197891" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212207393" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212208086" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212166021" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212172058" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212173345" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212181362" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212174434" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0467270576" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212205118" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0473908049" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212165922" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0480589567" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207148052" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0505849852" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212174137" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0537951706" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207432520" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0537951706" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212235703" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0630835639" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212236889" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0630835639" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212245205" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0630835639" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212218479" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0630835639" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
-INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant org:memberOf ?association .
-  }
-} WHERE {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-    ?participant adms:identifier ?idParticipant .
-    ?idParticipant skos:notation ?kboLabel ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212189676" .
-
-    ?association adms:identifier ?idAssociation .
-    ?idAssociation skos:notation "KBO nummer" ;
-      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0630835639" .
-
-    FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
-  }
-}
-;
 INSERT {
   GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
     ?participant org:memberOf ?association .
@@ -2857,6 +14,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212190468" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -2875,6 +33,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212192745" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -2893,6 +52,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212198683" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -2911,6 +71,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0216770749" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -2929,6 +90,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212180570" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -2947,6 +109,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212181659" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -2965,6 +128,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212182748" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -2983,6 +147,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212191458" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -3001,6 +166,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212183243" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -3019,6 +185,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212243423" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -3037,6 +204,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0208236927" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -3055,6 +223,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207521503" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -3073,6 +242,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212210066" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -3091,6 +261,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212169088" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -3109,6 +280,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212175721" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -3127,6 +299,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212212244" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -3145,6 +318,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212195418" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -3163,6 +337,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212204326" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -3181,6 +356,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0697663986" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -3199,6 +375,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212239958" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -3217,6 +394,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212244215" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -3235,6 +413,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212391891" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -3253,6 +432,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212190666" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -3271,6 +451,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212192151" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -3289,6 +470,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212169781" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -3307,6 +489,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212179778" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -3325,6 +508,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212183045" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -3343,6 +527,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212196111" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -3361,6 +546,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212170276" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -3379,6 +565,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207832792" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -3397,6 +584,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207528035" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -3415,6 +603,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212169781" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -3433,6 +622,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212222241" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -3451,6 +641,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207489037" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -3469,6 +660,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212206504" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -3487,6 +679,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207511803" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -3505,6 +698,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212194131" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -3523,6 +717,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212199277" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -3541,6 +736,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212218479" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -3559,6 +755,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207492502" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -3577,6 +774,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212248074" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -3595,6 +793,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212181659" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -3613,6 +812,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212172256" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -3631,6 +831,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0216773125" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -3649,6 +850,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212194230" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -3667,6 +869,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212173444" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -3685,6 +888,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212168001" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -3703,6 +907,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212183540" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -3721,6 +926,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212240651" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -3739,6 +945,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212190072" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -3757,6 +964,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212171860" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -3775,6 +983,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212187993" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -3793,6 +1002,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212177305" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -3811,6 +1021,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207514474" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -3829,6 +1040,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212246292" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -3847,6 +1059,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212190666" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -3865,6 +1078,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212199178" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -3883,6 +1097,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212201356" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -3901,6 +1116,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212245106" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -3919,6 +1135,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212176117" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -3937,6 +1154,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212237186" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -3955,6 +1173,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212213333" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -3973,6 +1192,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212182649" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -3991,6 +1211,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207437468" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -4009,6 +1230,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207485374" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -4027,6 +1249,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207447366" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -4045,6 +1268,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0263545337" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -4063,6 +1287,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212173840" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -4081,6 +1306,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212221251" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -4099,6 +1325,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212216895" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -4117,6 +1344,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212214620" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -4135,6 +1363,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207832792" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -4153,6 +1382,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212241542" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -4171,6 +1401,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207528035" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -4189,6 +1420,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0206684927" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -4207,6 +1439,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212235604" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -4225,6 +1458,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212237186" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -4243,6 +1477,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0697663491" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -4261,6 +1496,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212237483" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -4279,6 +1515,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207832792" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -4297,6 +1534,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212391891" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -4315,6 +1553,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212247183" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -4333,6 +1572,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212248173" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -4351,6 +1591,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212212244" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -4369,6 +1610,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207148052" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -4387,6 +1629,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212214125" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -4405,6 +1648,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212216402" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -4423,6 +1667,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212217786" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -4441,6 +1686,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212218083" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -4459,6 +1705,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0216772531" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -4477,6 +1724,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0216773125" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -4495,6 +1743,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212220855" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -4513,6 +1762,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212223627" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -4531,6 +1781,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212189676" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -4549,6 +1800,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212190963" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -4567,6 +1819,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0697663986" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -4585,6 +1838,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212196408" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -4603,6 +1857,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212194131" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -4621,6 +1876,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212196111" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -4639,6 +1895,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212199178" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -4657,6 +1914,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212199277" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -4675,6 +1933,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212205118" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -4693,6 +1952,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212174137" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -4711,6 +1971,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212165922" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -4729,6 +1990,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212170672" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -4747,6 +2009,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212171860" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -4765,6 +2028,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212175622" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -4783,6 +2047,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212175721" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -4801,6 +2066,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212177305" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -4819,6 +2085,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212179877" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -4837,6 +2104,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212191656" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -4855,6 +2123,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212185817" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -4873,6 +2142,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212187203" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -4891,6 +2161,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207437468" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -4909,6 +2180,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0697608063" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -4927,6 +2199,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207447861" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -4945,6 +2218,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207528035" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -4963,6 +2237,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207445584" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -4981,6 +2256,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207531894" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -4999,6 +2275,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207448158" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -5017,6 +2294,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207451128" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -5035,6 +2313,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207201797" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -5053,6 +2332,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207466964" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -5071,6 +2351,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207506160" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -5089,6 +2370,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207519127" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -5107,6 +2389,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207467162" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -5125,6 +2408,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0216773026" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -5143,6 +2427,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207535557" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -5161,6 +2446,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207448356" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -5179,6 +2465,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207494678" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -5197,6 +2484,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207521206" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -5215,6 +2503,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0697609152" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -5233,6 +2522,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207463402" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -5251,6 +2541,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207499430" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -5269,6 +2560,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207453207" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -5287,6 +2579,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207453405" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -5305,6 +2598,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207436775" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -5323,6 +2617,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207432520" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -5341,6 +2636,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207460432" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -5359,6 +2655,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207464093" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -5377,6 +2674,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207448851" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -5395,6 +2693,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207464192" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -5413,6 +2712,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207525956" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -5431,6 +2731,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207533082" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -5449,6 +2750,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207514474" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -5467,6 +2769,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207456076" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -5485,6 +2788,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207447663" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -5503,6 +2807,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207449346" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -5521,6 +2826,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207432124" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -5539,6 +2845,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0682844465" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -5557,6 +2864,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0222947570" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -5575,6 +2883,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0505849852" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -5593,6 +2902,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0266559859" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -5611,6 +2921,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0500927893" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -5629,6 +2940,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0500913839" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -5647,6 +2959,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212212541" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -5665,6 +2978,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207533874" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -5683,6 +2997,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212171860" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -5701,6 +3016,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212240651" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -5719,6 +3035,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212190072" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -5737,6 +3054,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212169781" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -5755,6 +3073,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207832792" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -5773,6 +3092,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0266559859" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -5791,6 +3111,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212334582" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -5809,6 +3130,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207691252" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -5827,6 +3149,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212334582" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -5845,6 +3168,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207691252" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -5863,6 +3187,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0697663491" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -5881,6 +3206,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212248173" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -5899,6 +3225,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212195418" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -5917,6 +3244,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212212244" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -5935,6 +3263,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212170672" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -5953,6 +3282,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212188488" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -5971,6 +3301,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0697663986" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -5989,6 +3320,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212237483" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -6007,6 +3339,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212204326" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -6025,6 +3358,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212185817" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -6043,6 +3377,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212179877" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -6061,6 +3396,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212223627" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -6079,6 +3415,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212194131" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -6097,6 +3434,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207463402" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -6115,6 +3453,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207832792" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -6133,6 +3472,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207528035" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -6151,6 +3491,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212221548" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -6169,6 +3510,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212222340" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -6187,6 +3529,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212209373" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -6205,6 +3548,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212175523" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -6223,6 +3567,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212213729" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -6241,6 +3586,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207431332" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -6259,6 +3605,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207528629" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -6277,6 +3624,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207491215" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -6295,6 +3643,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207530609" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -6313,6 +3662,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207491413" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -6331,6 +3681,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207832792" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -6349,6 +3700,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0216769165" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -6367,6 +3719,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212212541" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -6385,6 +3738,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0212330822" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -6403,6 +3757,7 @@ INSERT {
     ?participant adms:identifier ?idParticipant .
     ?idParticipant skos:notation ?kboLabel ;
       generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "0207832792" .
+    FILTER EXISTS { ?participant a besluit:Bestuurseenheid . }
 
     ?association adms:identifier ?idAssociation .
     ?idAssociation skos:notation "KBO nummer" ;
@@ -6411,4 +3766,3 @@ INSERT {
     FILTER (?kboLabel IN ("KBO nummer"@nl, "KBO nummer"))
   }
 }
-;


### PR DESCRIPTION
The initial version of these migrations introduced in #423 were defined too
broadly. Since they only matched on KBO numbers they also included the KBO
organisations, imported from wegwijs, adding them as participants.

This PR fixes these issues by
- Removing the previously imported data using a DEV-specific migration
- Add additional `FILTER` statements to exclude KBO organisations
- Split the main migration into two parts to work around an error otherwise
  encountered when executing the migration in one go