### PR TITLE
Remove faulty address and contact data for AGBs

### DIFF
--- a/config/migrations/2024/20240212141020-onboarding-public-ocmw-associations/20240215140212-import-public-ocmw-association-addresses.sparql
+++ b/config/migrations/2024/20240212141020-onboarding-public-ocmw-associations/20240215140212-import-public-ocmw-association-addresses.sparql
@@ -2130,34 +2130,6 @@
       INSERT {
         GRAPH ?g {
           ?addressUri 
-            <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "15";
-            
-            <http://www.w3.org/ns/locn#postCode> "8710";
-            <http://www.w3.org/ns/locn#adminUnitL2> "Wielsbeke";
-            <http://www.w3.org/ns/locn#thoroughfare> "Hernieuwenstraat";
-            <https://data.vlaanderen.be/ns/adres#gemeentenaam> "Wielsbeke";
-            <https://data.vlaanderen.be/ns/adres#land> "België";
-            <http://www.w3.org/ns/locn#fullAddress> "Hernieuwenstraat 15, 8710 Wielsbeke, België".
-        }
-      }
-      WHERE {
-        GRAPH ?g {
-          ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
-            <http://www.w3.org/ns/org#hasPrimarySite> ?site .
-
-          ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
-            <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "" .
-
-          ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?boundAddress .
-
-          BIND( ?boundAddress AS ?addressUri )
-        }
-      }
-    
-
-      INSERT {
-        GRAPH ?g {
-          ?addressUri 
             <https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer> "30";
             
             <http://www.w3.org/ns/locn#postCode> "1500";

--- a/config/migrations/2024/20240212141020-onboarding-public-ocmw-associations/20240215140236-import-public-ocmw-association-contact-details.sparql
+++ b/config/migrations/2024/20240212141020-onboarding-public-ocmw-associations/20240215140236-import-public-ocmw-association-contact-details.sparql
@@ -1554,31 +1554,3 @@
             ?contact <http://schema.org/contactType> "Primary" .
           }
         }
-      
-
-        INSERT {
-          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-            ?contact <http://schema.org/telephone> "tel:+3256674504" .
-            ?contact <http://xmlns.com/foaf/0.1/page> "https://www.wielsbeke.be/producten/woonzorgcentrum-ter-lembeek" .
-            ?contact <http://schema.org/email> "ouderenhuisvesting@wielsbeke.be" .
-          }
-        }
-        WHERE {
-          GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
-            ?adminUnit <http://www.w3.org/ns/adms#identifier> ?id ;
-              <http://www.w3.org/ns/org#hasPrimarySite> ?primarySite .
-            ?id <http://www.w3.org/2004/02/skos/core#notation> "KBO nummer" ;
-              <https://data.vlaanderen.be/ns/generiek#gestructureerdeIdentificator>/<https://data.vlaanderen.be/ns/generiek#lokaleIdentificator> "" .
-
-            ?primarySite <http://www.w3.org/ns/org#siteAddress> ?contact .
-
-            ?contact <http://schema.org/contactType> "Primary" .
-          }
-        }
-      
-
-
-
-
-
-

--- a/config/migrations/2024/20240603115300-correct-agb-address-and-contact-data/20240603115306-fix-agb-address-data.sparql
+++ b/config/migrations/2024/20240603115300-correct-agb-address-and-contact-data/20240603115306-fix-agb-address-data.sparql
@@ -1,0 +1,35 @@
+PREFIX adres: <https://data.vlaanderen.be/ns/adres#>
+PREFIX locn: <http://www.w3.org/ns/locn#>
+
+# Remove incorrect address triples
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?address adres:Adresvoorstelling.huisnummer "15" ;
+      locn:postCode "8710" ;
+      locn:adminUnitL2 "West-Vlaanderen" ;
+      locn:thoroughfare "Hernieuwenstraat" ;
+      locn:fullAddress "Hernieuwenstraat 15, 8710 Wielsbeke, België" ;
+      adres:gemeentenaam "Wielsbeke" .
+  }
+} WHERE {
+  VALUES ?address {
+    <http://data.lblod.info/id/adressen/5ab4e6f7-d793-4262-81b6-b84f867c18ae> # AGB LEUVEN (Parkeerbedrijf)
+    <http://data.lblod.info/id/adressen/76a69cd2-f447-4372-8dd5-79c917d0040d> # AGB MECHELEN (Exploitatie)
+    <http://data.lblod.info/id/adressen/af5d342d-0b4c-46fb-bee3-ce46dee74d1f> # AGB MECHELEN (Patrimonium)
+    <http://data.lblod.info/id/adressen/63c85a14-4ee4-4299-b0c1-b3a907ff1ebf> # AGB Renov'O
+    <http://data.lblod.info/id/adressen/df102cb4-8abb-4588-a199-1ce22c211812> # AGB STEKENE
+    <http://data.lblod.info/id/adressen/6cff33b8-6aff-436c-aa34-e9d32d446934> # Vrijetijdsbedrijf Knokke-Heist AG
+  }
+}
+
+# Insert the correct the provinces
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    <http://data.lblod.info/id/adressen/5ab4e6f7-d793-4262-81b6-b84f867c18ae> locn:adminUnitL2 "Vlaams-Brabant" . # AGB LEUVEN (Parkeerbedrijf)
+    <http://data.lblod.info/id/adressen/76a69cd2-f447-4372-8dd5-79c917d0040d> locn:adminUnitL2 "Antwerpen" . # AGB MECHELEN (Exploitatie)
+    <http://data.lblod.info/id/adressen/af5d342d-0b4c-46fb-bee3-ce46dee74d1f> locn:adminUnitL2 "Antwerpen" . # AGB MECHELEN (Patrimonium)
+    <http://data.lblod.info/id/adressen/63c85a14-4ee4-4299-b0c1-b3a907ff1ebf> locn:adminUnitL2 "West-Vlaanderen" . # AGB Renov'O (located in Oostende)
+    <http://data.lblod.info/id/adressen/df102cb4-8abb-4588-a199-1ce22c211812> locn:adminUnitL2 "Oost-Vlaanderen" . # AGB STEKENE
+    <http://data.lblod.info/id/adressen/6cff33b8-6aff-436c-aa34-e9d32d446934> locn:adminUnitL2 "West-Vlaanderen" . # Vrijetijdsbedrijf Knokke-Heist AG
+  }
+}

--- a/config/migrations/2024/20240603115300-correct-agb-address-and-contact-data/20240603133736-fix-agb-contact-data.sparql
+++ b/config/migrations/2024/20240603115300-correct-agb-address-and-contact-data/20240603133736-fix-agb-contact-data.sparql
@@ -1,0 +1,19 @@
+PREFIX schema: <http://schema.org/>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?contactPoint schema:telephone "tel:+3256674504" ;
+      foaf:page "https://www.wielsbeke.be/producten/woonzorgcentrum-ter-lembeek" ;
+      schema:email "ouderenhuisvesting@wielsbeke.be" .
+  }
+} WHERE {
+  VALUES ?contactPoint {
+    <http://data.lblod.info/id/contact-punten/f5df2649-afba-4cbb-8e97-b3a46e0f5c88> # AGB LEUVEN (Parkeerbedrijf)
+    <http://data.lblod.info/id/contact-punten/58aa2df7-2c48-4dc8-ba60-da72748bcff1> # AGB MECHELEN (Exploitatie)
+    <http://data.lblod.info/id/contact-punten/0a3a1313-511d-41a9-a1f3-32f41f2e613c> # AGB MECHELEN (Patrimonium)
+    <http://data.lblod.info/id/contact-punten/82e65e70-2c3b-4e3c-8f39-ce6f05ec42ea> # AGB Renov'O
+    <http://data.lblod.info/id/contact-punten/364d8e1a-cb18-4970-aeaf-5f6f307370ad> # AGB STEKENE
+    <http://data.lblod.info/id/contact-punten/0d680616-e2a3-41af-bfeb-c76992552c5c> # Vrijetijdsbedrijf Knokke-Heist AG
+  }
+}


### PR DESCRIPTION
OP-3252

## Summary
The two migrations introduced in #379 that import address and contact data for
public OCMW associations contained a faulty query matching on an empty KBO
number. Consequently, incorrect address and contact data was associated with
some AGB that do not have a KBO number either.

## Proposed solution
Since the original migrations only inserted new data, the original data is still
present in the triplestore. Therefore, the migrations simply remove the
incorrect data. Additionally, for addresses the correct value for
`locn:adminUnitL2` is (re-)inserted as these was overwritten.

## Useful SPARQL queries

Some SPARQL queries I used while analysing the problem and to verify whether the migrations work as expected:

Get the address information for the primary site of the affected AGBs.
``` sparql
$prefixes
SELECT DISTINCT ?name ?addr ?p ?o
WHERE {
  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
    ?org mu:uuid ?uuid ;
      skos:prefLabel ?name ;
      org:hasPrimarySite ?site .
    ?site organisatie:bestaatUit ?addr .
    ?addr ?p ?o .
  }
  VALUES ?uuid {
    "b25f4408-0b7c-46d0-a234-0936cac4eb7c" # AGB LEUVEN (Parkeerbedrijf)
    "b206763c-d8d2-45bd-ba1b-b5462bdd823c" # AGB MECHELEN (Exploitatie)
    "3deaa042-58f3-474f-abc2-9cb3e15f4221" # AGB MECHELEN (Patrimonium)
    "8d6609b4-1a20-46b8-97ed-150c6d53acd6" # AGB Renov'O
    "f4228a39-de89-4a50-925f-d5d8d5109e79" # AGB STEKENE
    "b81fdc5f-d1ba-49f2-831f-ed549ad94394" # Vrijetijdsbedrijf Knokke-Heist AG
  }
} ORDER BY ?name
```

Get the primary contact point information for the affected AGBs.

``` sparql
$prefixes
SELECT DISTINCT ?name ?cp ?p ?o
WHERE {
  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
    ?org mu:uuid ?uuid ;
      skos:prefLabel ?name ;
      org:hasPrimarySite ?site .
    ?site org:siteAddress ?cp .
    ?cp schema:contactType "Primary" ;
      ?p ?o .
  }
  VALUES ?uuid {
    "b25f4408-0b7c-46d0-a234-0936cac4eb7c" # AGB LEUVEN (Parkeerbedrijf)
    "b206763c-d8d2-45bd-ba1b-b5462bdd823c" # AGB MECHELEN (Exploitatie)
    "3deaa042-58f3-474f-abc2-9cb3e15f4221" # AGB MECHELEN (Patrimonium)
    "8d6609b4-1a20-46b8-97ed-150c6d53acd6" # AGB Renov'O
    "f4228a39-de89-4a50-925f-d5d8d5109e79" # AGB STEKENE
    "b81fdc5f-d1ba-49f2-831f-ed549ad94394" # Vrijetijdsbedrijf Knokke-Heist AG
  }
} ORDER BY ?name ?cp
```

List all organisations without a KBO number, used to check whether there were
other organisations impacted than those mentioned in the ticket. Note, this only works as expected on production data, in DEV and QA empty literals are already removed by the migration introduced in #413.

``` sparql
$prefixes
SELECT DISTINCT ?name ?s
WHERE {
  GRAPH ?g {
    ?s adms:identifier ?id ;
      skos:prefLabel ?name .
    ?id skos:notation ?notation ;
      generiek:gestructureerdeIdentificator/generiek:lokaleIdentificator "" .
    FILTER(?notation IN ("KBO nummer", "KBO nummer"@nl))
  }
  VALUES ?g {
    <http://mu.semte.ch/graphs/administrative-unit>
    <http://mu.semte.ch/graphs/worship-service>
   }
}
```

## Notes
- Requires a reindex to update the information shown in the "Gemeente"
  (municipality) column in the index table.
- I also removed the faulty queries from the original migrations, to prevent
  reinserting the data should these be executed again at some point for some
  reason.
- The faulty data was already propagated to CLB's DEV and QA. If your stack is
  consuming CLB's data the results of these migrations will be partially undone
  as the incorrect data will be consumer again from CLB.