### PR TITLE
feat: added classification code for associations and corporations

### DIFF
--- a/config/migrations/2024/20240529155230-add-other-classification-codes.sparql
+++ b/config/migrations/2024/20240529155230-add-other-classification-codes.sparql
@@ -1,0 +1,22 @@
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX concept: <http://data.vlaanderen.be/id/concept/GeregistreerdeOrganisatieClassificatieCode/>
+
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    concept:3e5c8e30-95a7-47b0-b0a4-210d5bd440a7 a ext:GeregistreerdeOrganisatieClassificatieCode ;
+      a ext:OrganizationClassificationCode ;
+      mu:uuid "3e5c8e30-95a7-47b0-b0a4-210d5bd440a7" ;
+      skos:prefLabel "Vereniging" .
+  }
+}
+;
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    concept:b9ed22af-3661-4c3e-b07f-b641d80ebf61 a ext:GeregistreerdeOrganisatieClassificatieCode ;
+      a ext:OrganizationClassificationCode ;
+      mu:uuid "b9ed22af-3661-4c3e-b07f-b641d80ebf61" ;
+      skos:prefLabel "Vennootschap" .
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -258,7 +258,7 @@ services:
     restart: always
     logging: *default-logging
   construct-organization-relationships:
-    image: lblod/construct-organization-relationships-service:1.0.0
+    image: lblod/construct-organization-relationships-service:1.0.1
     environment:
       START_DATE_WORSHIP_GOVERNING_BODY: "2023-04-01T00:00:00"
       END_DATE_WORSHIP_GOVERNING_BODY: "2026-03-31T00:00:00"


### PR DESCRIPTION
Related to OP-3023

Add classifications for new types of organizations: associations (*nl. verenigingen*) and corporations (*nl. vennootschappen*). These classifications are intended for internal use in OP to allow extending the app with these new organizations without having the fundamentally revise it. Our frontend, for instance, heavily uses classifications to show the correct fields in forms etc.

## Related PRs
- frontend: https://github.com/lblod/frontend-organization-portal/pull/628
- construct-organization-relationships-service: https://github.com/lblod/construct-organization-relationships-service/pull/14