### PR TITLE
fix: remove `org:memberOf` triples with KBO organizations as object

### DIFF
--- a/config/migrations/20240619123310-remove-kbo-organizations-from-participation-relation.sparql
+++ b/config/migrations/20240619123310-remove-kbo-organizations-from-participation-relation.sparql
@@ -1,0 +1,13 @@
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?participant org:memberOf ?association .
+    ?association a ext:KboOrganisatie .
+  }
+}


### PR DESCRIPTION
OP-3286

The migration importing related organizations for public OCMW associations was
incorrect in that it did not exclude resources of type `ext:KboOrganisatie`
being matched. This migration removes all incorrectly inserted triples.

The incorrect migration was originally added in #423 and an initial fix for the
same issue was proposed in #425. The fix was also incorrect as it added a filter
on the participant resource instead of the association resource, which is the
resource that can be of the incorrect type.