### PR TITLE
Bump kalliope-api to 2.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,9 +29,11 @@ DS_STORE
 /config/proxy-https/cert.pem
 /config/proxy-https/key.pem
 
+# Kalliope config files
 source.json
-out.json
-security.yml
+output.json
+security.json
+
 config/proxy-https/proxy_ssl.conf
 /config/search/update-handler.store
 /config/search/dev/update-handler.store

--- a/config/kalliope/security-dev.json
+++ b/config/kalliope/security-dev.json
@@ -1,0 +1,6 @@
+{
+  "enabled": false,
+  "allowedIpAddresses": [],
+  "authSource": "/config/source.json",
+  "authOutput": "/config/output.json"
+}

--- a/config/kalliope/security-dev.yml
+++ b/config/kalliope/security-dev.yml
@@ -1,9 +1,0 @@
-# disabled on dev
-application:
-  security:
-    enabled: false
-spring:
-  autoconfigure:
-    exclude:
-       - org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
-       - org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -25,7 +25,7 @@ services:
     restart: "no"
   kalliope-api:
     environment:
-      SPRING_SECURITY_CONFIG: "/config/security-dev.yml"
+      SECURITY_CONFIG_PATH: "/config/security-dev.json"
     restart: "no"
   deltanotifier:
     restart: "no"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,18 +92,16 @@ services:
     restart: always
     logging: *default-logging
   kalliope-api:
-    image: lblod/jsonld-delta-service:0.5.6
+    image: lblod/jsonld-delta-service:2.0.0
+    environment:
+      LOG_SPARQL_ALL: "false"
+      SECURITY_CONFIG_PATH: "/config/security.json"
+      DUMP_SUBJECT: "http://data.lblod.info/datasets/delta-producer/dumps/OrganizationsCacheGraphDump"
     volumes:
       - ./config/kalliope:/config
       - ./data/files:/share
     links:
       - db:database
-    environment:
-      SERVER_PORT: "80"
-      LOGGING_LEVEL: "INFO"
-      SPARQL_ENDPOINT: "http://db:8890/sparql"
-      LIMIT_SIZE: "10000"
-      MU_AUTH_SUDO: "true"
     labels:
       - "logging=true"
     restart: always


### PR DESCRIPTION
Related to OP-3172

This is a preparation to bump kalliope-api to the new javascript implementation. 

TODO: 
- [x] After Kalliope validation on QA
- [x] merge https://github.com/lblod/jsonld-delta-service/pull/23
- [x] release v2.0.0 