### PR TITLE
feat: import legal and alternative names for worship services

### DIFF
--- a/config/migrations/2024/20240718152515-worship-services-alternative-names-part1.sparql
+++ b/config/migrations/2024/20240718152515-worship-services-alternative-names-part1.sparql
@@ -1,0 +1,7502 @@
+PREFIX regorg: <http://www.w3.org/ns/regorg#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0080cae4685a89c69e96e2054d808c06> skos:altLabel """Sint-Aldegondis - Landen(-Noord)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0080cae4685a89c69e96e2054d808c06> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/024aa0464b3262dec945a5f4dcdcf67b> skos:altLabel """Sint-Pieter - Testelt - Scherpenheuvel-Zichem""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/024aa0464b3262dec945a5f4dcdcf67b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/02e1aafdb0a20b1a73fd8fd093ba6c69> skos:altLabel """Sint-Hubertus - Schaffen - Diest""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/02e1aafdb0a20b1a73fd8fd093ba6c69> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/05e59610adf339bf9ef37ebf3fa5eb71> skos:altLabel """Sint-Lambertus - Nieuwrode - Holsbeek""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/05e59610adf339bf9ef37ebf3fa5eb71> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/05ea215fb4890aa36182708dcd273338> skos:altLabel """Onze-Lieve-Vrouw van de Vrede - Boortmeerbeek""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/05ea215fb4890aa36182708dcd273338> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/065aadd6ee2a20656044d08dc1d24733> skos:altLabel """Sint-Stefaan - Negenmanneke - Sint-Pieters-Leeuw""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/065aadd6ee2a20656044d08dc1d24733> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/06a5d5ff1f1e7042a390380400d8a95b> skos:altLabel """Sint-Joannes Bosco - Kessel-Lo - Leuven""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/06a5d5ff1f1e7042a390380400d8a95b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/08142f2f3b1e2dd83dcb23beaadfa714> skos:altLabel """Sint-Barbara - De Hoek - Sint-Genesius-Rode""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/08142f2f3b1e2dd83dcb23beaadfa714> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/083d2126fbd34c441899aef659a6aff4> skos:altLabel """Sint-Jozef - Droeshout - Opwijk""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/083d2126fbd34c441899aef659a6aff4> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/086a9809bfb18ab50c2e6edb7ccb8035> skos:altLabel """Sint-Maria Magdalena - Eizer - Overijse""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/086a9809bfb18ab50c2e6edb7ccb8035> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0936f8ef18ba997e3d2a7288ba48b371> skos:altLabel """Onze-Lieve-Vrouw Hemelvaart - Nieuwenrode - Kapelle-op-den-Bos""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0936f8ef18ba997e3d2a7288ba48b371> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/095bf63c849f4097f273fa2fac5635c4> skos:altLabel """Sint-Pancratius - Sterrebeek - Zaventem""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/095bf63c849f4097f273fa2fac5635c4> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0b27bc858659ab6af621be8c7c64ddbf> skos:altLabel """Sint-Servatius - Berg - Kampenhout""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0b27bc858659ab6af621be8c7c64ddbf> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0c27c6cc3e4095f975f1caf33e5626fa> skos:altLabel """Onze-Lieve-Vrouw van Altijddurende Bijstand - Heikant - Rotselaar""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0c27c6cc3e4095f975f1caf33e5626fa> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0cf9e2ba13383363a0dafecd18c39fd4> skos:altLabel """Sint-Pieter - Puurs - Sint-Amands""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0cf9e2ba13383363a0dafecd18c39fd4> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0d471211643047cd99a904cf4471d13b> skos:altLabel """Sint-Martinus - Meise""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0d471211643047cd99a904cf4471d13b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0d5b074d16ff678edf1f94c65997ed95> skos:altLabel """Sint-Jan Evangelist - Teralfene - Affligem""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0d5b074d16ff678edf1f94c65997ed95> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0d61ce105baf76cfc3917dbf794f0f77> skos:altLabel """Sint-Martinus - Wilsele - Leuven""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0d61ce105baf76cfc3917dbf794f0f77> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0f7943383f8fc4675a391d32f224aca9> skos:altLabel """Sint-Martinus - Asse""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0f7943383f8fc4675a391d32f224aca9> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0fa59c44ac5701bdcb769aa2846d1d87> skos:altLabel """Sint-Theresia van het Kind Jezus - Dilbeek""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0fa59c44ac5701bdcb769aa2846d1d87> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0fd4c0badf5b842ed04621a08e5ae610> skos:altLabel """Sint-Lambertus - Beersel""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0fd4c0badf5b842ed04621a08e5ae610> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0fe64b45fd3bf68688e130d4cf561660> skos:altLabel """Onze-Lieve-Vrouw - Alsemberg - Beersel""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0fe64b45fd3bf68688e130d4cf561660> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/11fc7394cffb78c600e1d017988b304c> skos:altLabel """Sint-Stefaan - Nederokkerzeel - Kampenhout""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/11fc7394cffb78c600e1d017988b304c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/134265ebd8b14e458dda2dcd3b8057e7> skos:altLabel """Onze-Lieve-Vrouw van Troost - Heverlee - Leuven""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/134265ebd8b14e458dda2dcd3b8057e7> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/14d64cf28989c6efbfa7c1347ac28da9> skos:altLabel """Sint-Joris - Sint-Joris-Weert - Oud-Heverlee""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/14d64cf28989c6efbfa7c1347ac28da9> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/14f5a4cb25cbf9d4ae0668b0a9d7d0bd> skos:altLabel """Sint-Pieter - Itterbeek - Dilbeek""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/14f5a4cb25cbf9d4ae0668b0a9d7d0bd> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/167871f8b5704a234b5e846d711363c2> skos:altLabel """Onze-Lieve-Vrouw - Onze-Lieve-Vrouw-Lombeek - Roosdaal""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/167871f8b5704a234b5e846d711363c2> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/182591317d921cfa90ba4dbfb6fba3ed> skos:altLabel """Sint-Anna - Oud-Heverlee""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/182591317d921cfa90ba4dbfb6fba3ed> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1843868867b553114bc88ef947b358d0> skos:altLabel """Sint-Martinus - Sint-Martens-Bodegem - Dilbeek""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1843868867b553114bc88ef947b358d0> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/19325cd662e542a95691a163b974a113> skos:altLabel """Sint-Pieter - Kwerps - Kortenberg""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/19325cd662e542a95691a163b974a113> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/193d46546f1492623f28f00fb8056fc4> skos:altLabel """Sint-Clemens - Eppegem - Zemst""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/193d46546f1492623f28f00fb8056fc4> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/196f235f7c6a2f30ceac5fe1d8b8f983> skos:altLabel """Sint-Jozef - Molenstede - Diest""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/196f235f7c6a2f30ceac5fe1d8b8f983> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/19ef944358493252d16fb79828b6db0d> skos:altLabel """Sint-Pieter - Sint-Pieters-Rode - Holsbeek""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/19ef944358493252d16fb79828b6db0d> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1a7f237e5a98095e931ec289f5441406> skos:altLabel """Sint-Martinus - Zaventem""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1a7f237e5a98095e931ec289f5441406> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1bcd05359882f4b4d5535f222c2a9b18> skos:altLabel """Sint-Rumoldus - Schepdaal - Dilbeek""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1bcd05359882f4b4d5535f222c2a9b18> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1bce1bb6a07444af1c17b66962c2c770> skos:altLabel """Sint-Catharina - Diegem - Machelen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1bce1bb6a07444af1c17b66962c2c770> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1ccfe6d166b1bfd797fb0f6edb60f96d> skos:altLabel """Maria-Hemelvaart - Winksele - Herent""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1ccfe6d166b1bfd797fb0f6edb60f96d> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1ce3e84e6bc0b7303f45b339b47e8755> skos:altLabel """Goede Herder - Sint-Katelijne-Waver""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1ce3e84e6bc0b7303f45b339b47e8755> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1d54c22ac408f875ce44909b9cf350a7> skos:altLabel """Jan Ruusbroec en Onze-Lieve-Vrouw - Ruisbroek - Sint-Pieters-Leeuw""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1d54c22ac408f875ce44909b9cf350a7> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1dcb4d3843b66543062df6a3e99f650d> skos:altLabel """Sint-Gereon - Akrenbos - Bever""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1dcb4d3843b66543062df6a3e99f650d> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1f4655e84133a11955baf76322f021b1> skos:altLabel """Onze-Lieve-Vrouw - Huldenberg""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1f4655e84133a11955baf76322f021b1> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1fe44f358037550bdae3e2df64b0ffce> skos:altLabel """Sint-Sulpitius - Overhespen - Linter""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1fe44f358037550bdae3e2df64b0ffce> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/201f9772ab7f6aa2ec37ac25bad9e3a9> skos:altLabel """Sint-Veronus - Lembeek - Halle""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/201f9772ab7f6aa2ec37ac25bad9e3a9> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/21063883824405b1a9589fcf55792849> skos:altLabel """Sint-Clemens - Hoeilaart""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/21063883824405b1a9589fcf55792849> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/233550e9a974ad9c31001235595ffefb> skos:altLabel """Sint-Eustachius - Zichem - Scherpenheuvel-Zichem""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/233550e9a974ad9c31001235595ffefb> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/24b9275c4e38ed3d14f8651f3da01e3f> skos:altLabel """Sint-Paulus en Sint-Petrus - Geetbets""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/24b9275c4e38ed3d14f8651f3da01e3f> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/25052fa8ca19d445d1ad31138db07182> skos:altLabel """Onze-Lieve-Vrouw - Herent""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/25052fa8ca19d445d1ad31138db07182> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2581a2b9bbd5dbdc79be0146c8e28baa> skos:altLabel """Onze-Lieve-Vrouw - Kampenhout""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2581a2b9bbd5dbdc79be0146c8e28baa> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2584eb0761bab30464e3dc6932e63b21> skos:altLabel """Sint-Aloysius van Gonzaga - Koningslo - Vilvoorde""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2584eb0761bab30464e3dc6932e63b21> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/25cebdc248a24fe261daec47ecc2bdf6> skos:altLabel """Sint-Dominicus-Savio - Groot-Bijgaarden - Dilbeek""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/25cebdc248a24fe261daec47ecc2bdf6> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/25ddb2177cd7c5c09db0cd99465167a2> skos:altLabel """Sint-Pieter - Rotselaar""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/25ddb2177cd7c5c09db0cd99465167a2> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/27ec30db6b045002104a5c585db65aa1> skos:altLabel """Onze-Lieve-Vrouw - Kortenberg""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/27ec30db6b045002104a5c585db65aa1> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2941f2566cdabb742475e023b0a121cd> skos:altLabel """Onze-Lieve-Vrouw van Goede Bijstand - Gooik""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2941f2566cdabb742475e023b0a121cd> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2d4a3256c9cadbf1c786db427d0fafe3> skos:altLabel """Onze-Lieve-Vrouw van het Hart - Drieslinter - Linter""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2d4a3256c9cadbf1c786db427d0fafe3> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2de903e639fa45aa29111062aba75c6a> skos:altLabel """Sint-Hubertus - Asse-ter-Heide - Asse""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2de903e639fa45aa29111062aba75c6a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/30b1e044f452fffa1aaf1813d8985c08> skos:altLabel """Sint-Amandus - Malderen - Londerzeel""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/30b1e044f452fffa1aaf1813d8985c08> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/30e044192a8067dbf69a866e4e1d22db> skos:altLabel """Heilige Maria (Onze-Lieve-Vrouw Hemelvaart) - Boutersem""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/30e044192a8067dbf69a866e4e1d22db> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/317850da3e42b8c4880533974fbc4d71> skos:altLabel """Sint-Michiel - Keerbergen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/317850da3e42b8c4880533974fbc4d71> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/31973801a2d31ca86185be9948fcb493> skos:altLabel """Sint-Jozef - Moorsel - Tervuren""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/31973801a2d31ca86185be9948fcb493> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3254bf4702813bfa2e2636870f79e5f2> skos:altLabel """Onze-Lieve-Vrouw - Bonheiden""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3254bf4702813bfa2e2636870f79e5f2> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/32946ca6db30ae75f5b2adf7af67ebfc> skos:altLabel """Onze-Lieve-Vrouw Middelares - Nijverseel - Opwijk""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/32946ca6db30ae75f5b2adf7af67ebfc> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/32bd859f85066e48629c68cfe78f3bc4> skos:altLabel """Sint-Jan-Baptist - Ossel - Merchtem""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/32bd859f85066e48629c68cfe78f3bc4> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/345b25a6106a4ca1f7603da10fdb6b98> skos:altLabel """Sint-Martinus - Weerde - Zemst""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/345b25a6106a4ca1f7603da10fdb6b98> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/34e975975f3af207066835921d42811c> skos:altLabel """Onze-Lieve-Vrouw Onbevlekt - Peizegem - Merchtem""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/34e975975f3af207066835921d42811c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/35962e1c848a4244235f76b70aa7d7df> skos:altLabel """Sint-Genesius - Sint-Genesius-Rode""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/35962e1c848a4244235f76b70aa7d7df> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/396fc6469df5250d08331c1f7856dd1a> skos:altLabel """Heilig Hart - Breedhout - Halle""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/396fc6469df5250d08331c1f7856dd1a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3970bb33f0c22e88cf8eb2482afee92c> skos:altLabel """Sint-Niklaas - Liedekerke""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3970bb33f0c22e88cf8eb2482afee92c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3b58164280b7142832cba99ebb0a4481> skos:altLabel """Sint-Catharina - Duisburg - Tervuren""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3b58164280b7142832cba99ebb0a4481> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3b59ef459e973fd5003807d2af730eb2> skos:altLabel """Sint-Gertrudis - Machelen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3b59ef459e973fd5003807d2af730eb2> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3c503606d4cb6598cd1d22281a52a3de> skos:altLabel """Sint-Amandus - Borchtlombeek - Roosdaal""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3c503606d4cb6598cd1d22281a52a3de> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3d035ef06fb05ee0a3389397939eb266> skos:altLabel """Sint-Martinus - Melsbroek - Steenokkerzeel""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3d035ef06fb05ee0a3389397939eb266> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3d480cb84ca5a7a9855e4d342320c85e> skos:altLabel """Sint-Jozef - Zaventem""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3d480cb84ca5a7a9855e4d342320c85e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3da5c66f4b7e6d8e7e23547b68a9a0fb> skos:altLabel """Kana - Kortenaken""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3da5c66f4b7e6d8e7e23547b68a9a0fb> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3defcad9548adce0852e1b514847478c> skos:altLabel """Sint-Augustinus  - Tienen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3defcad9548adce0852e1b514847478c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3e0d4dbea78e2fa221d0be5037c63066> skos:altLabel """Onze-Lieve-Vrouw - Onze-Lieve-Vrouw-Waver - Sint-Katelijne-Waver""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3e0d4dbea78e2fa221d0be5037c63066> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3edb2385b2f08ef89a61f32cc038899a> skos:altLabel """Sint-Jacob - Leuven""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3edb2385b2f08ef89a61f32cc038899a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4080ab6131cda8d6a9cbb6af14c574d3> skos:altLabel """Sint-Joost - Maleizen - Overijse""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4080ab6131cda8d6a9cbb6af14c574d3> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4102347c395bd72631196150507bd740> skos:altLabel """Sint-Pieter - Sint-Pieters-Leeuw""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4102347c395bd72631196150507bd740> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4146b37972fc5bd89c89a7879a8f1318> skos:altLabel """Sint-Ludwina - Zellaar - Bonheiden""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4146b37972fc5bd89c89a7879a8f1318> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/45ebc059a85ad79b69982e662136cbab> skos:altLabel """Sint-Hilarius - Bierbeek""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/45ebc059a85ad79b69982e662136cbab> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4686996a2d500ec8c47bb2eebbe4e5fd> skos:altLabel """Sint-Amandus - Strombeek-Bever - Grimbergen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4686996a2d500ec8c47bb2eebbe4e5fd> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/483caa3b16526d2811611d0ef977b483> skos:altLabel """Lieve-Vrouw - Mechelen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/483caa3b16526d2811611d0ef977b483> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/497796049c8737aa9dac48d9976a3d65> skos:altLabel """Onze-Lieve-Vrouw van Goede Wil - Duffel""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/497796049c8737aa9dac48d9976a3d65> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4c7e70eb6d6ea9ed20193de7410f1ae1> skos:altLabel """Heilig Hart  - Bekkevoort""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4c7e70eb6d6ea9ed20193de7410f1ae1> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4ce6326e2b6595e7b24290f35149760a> skos:altLabel """Heilig Hart - Verbrande Brug - Grimbergen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4ce6326e2b6595e7b24290f35149760a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4e1b626990c6d36f46cd1f79c11561fe> skos:altLabel """Sint-Rumoldus - Steenokkerzeel""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4e1b626990c6d36f46cd1f79c11561fe> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4e827b9c46e8028fea0b87b4f603fc2b> skos:altLabel """Sint-Kwinten - Leuven""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4e827b9c46e8028fea0b87b4f603fc2b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4f19f5c15b39ed5d2abd905f72131ed9> skos:altLabel """Sint-Cornelius en Sint-Niklaas -Gelrode-Rillaar - Aarschot""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4f19f5c15b39ed5d2abd905f72131ed9> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4ffc6016e38ce3c2872dd1ce5325b4e3> skos:altLabel """Sint-Donatus - Tielt - Tielt-Winge""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4ffc6016e38ce3c2872dd1ce5325b4e3> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/514220d61bca9dcf6264d5882d3f4de8> skos:altLabel """Onze-Lieve-Vrouw van Hanswijk - Mechelen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/514220d61bca9dcf6264d5882d3f4de8> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/52ef7b207ff3a11277b42bdc064b745c> skos:altLabel """Sint-Augustinus - Beert - Pepingen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/52ef7b207ff3a11277b42bdc064b745c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/53d16253102143453c27a1383547de70> skos:altLabel """Sint-Germanus - Tienen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/53d16253102143453c27a1383547de70> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/54c6e8e4af0958094b259de1e05a61f5> skos:altLabel """Onze-Lieve-Vrouw - Bellingen - Pepingen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/54c6e8e4af0958094b259de1e05a61f5> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/57db751ddf80b396baaf043df294387c> skos:altLabel """Onze-Lieve-Vrouw ten Hemel Opgenomen - Vlezenbeek - Sint-Pieters-Leeuw""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/57db751ddf80b396baaf043df294387c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/57eb9fd873b380f1bcece0e3f962ce95> skos:altLabel """Sint-Maurus - Holsbeek""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/57eb9fd873b380f1bcece0e3f962ce95> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/58b2df550518c90386d7a58fe0137ca3> skos:altLabel """Sint-Franciscus - Glabbeek""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/58b2df550518c90386d7a58fe0137ca3> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/590f4f0b8d5957504ddc10df0788812f> skos:altLabel """Sint-Dominicus - Kraainem""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/590f4f0b8d5957504ddc10df0788812f> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/59bdc85df723acfe44c548f8972449f6> skos:altLabel """Sint-Lambertus - Leefdaal - Bertem""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/59bdc85df723acfe44c548f8972449f6> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5c03da8c997d5ec9d0384e799a612c13> skos:altLabel """Sint-Foillanus - Neerlinter - Linter""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5c03da8c997d5ec9d0384e799a612c13> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5c38eaee1ccfe70a4c2aba25b1775237> skos:altLabel """Sint-Gaugericus - Pamel - Roosdaal""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5c38eaee1ccfe70a4c2aba25b1775237> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5c7f1ac6d681230e30fa2fc26acf853c> skos:altLabel """Sint-Michiel - Leuven""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5c7f1ac6d681230e30fa2fc26acf853c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/62ed00087694ecdc5db96b396cecd790> skos:altLabel """Heilige Joannes Bosco - Buizingen - Halle""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/62ed00087694ecdc5db96b396cecd790> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/635ca9068a52e609f1ea778b8cf0f7fc> skos:altLabel """Onze-Lieve-Vrouw - Vlierbeek - Leuven""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/635ca9068a52e609f1ea778b8cf0f7fc> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6418670e8e116a798850975c4d83c825> skos:altLabel """Sint-Pieter - Orsmaal - Linter""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6418670e8e116a798850975c4d83c825> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/64288982932ebbd2884d6e2537aecfe6> skos:altLabel """Sint-Pieter - Zemst""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/64288982932ebbd2884d6e2537aecfe6> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/64406548fe10bb0366cef8471c851edb> skos:altLabel """Catharina - Mechelen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/64406548fe10bb0366cef8471c851edb> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/650deb7d76c405ce244b3938ba5f9fc7> skos:altLabel """Sint-Bavo - Zellik - Asse""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/650deb7d76c405ce244b3938ba5f9fc7> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/65a0d709ee9e968a62e2802ef1c03c6c> skos:altLabel """Sint-Michiel - Terlanen - Overijse""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/65a0d709ee9e968a62e2802ef1c03c6c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/66cc782e3da65341ab6a5bc465929de9> skos:altLabel """Sint-Antonius - Houtem - Vilvoorde""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/66cc782e3da65341ab6a5bc465929de9> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/679f8180f253d5613f554392a0290e2a> skos:altLabel """Sint-Antonius - Loonbeek - Huldenberg""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/679f8180f253d5613f554392a0290e2a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/68e2f96a567a3d61b2bc6f6a9aad7b6d> skos:altLabel """Sint-Lutgardis - Zuun - Sint-Pieters-Leeuw""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/68e2f96a567a3d61b2bc6f6a9aad7b6d> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/69127b04660f02eb75d66ffafa893daa> skos:altLabel """Sint-Bernardus - Tombeek - Overijse""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/69127b04660f02eb75d66ffafa893daa> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6a7c46068855eda6368c61361cecf78f> skos:altLabel """Sint-Kwinten - Sint-Kwintens-Lennik - Lennik""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6a7c46068855eda6368c61361cecf78f> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6aff8414d5b3b8a687bfa6d94e4da128> skos:altLabel """Sint-Pieters-Banden - Mazenzele - Opwijk""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6aff8414d5b3b8a687bfa6d94e4da128> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6be88677571d7bf7272e10f3d76a5b6e> skos:altLabel """Sint-Augustinus - Elzestraat - Sint-Katelijne-Waver""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6be88677571d7bf7272e10f3d76a5b6e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6ca06cf7ab90296cb3af55d836833c9d> skos:altLabel """Sint-Jan-Baptist - Binkom - Lubbeek""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6ca06cf7ab90296cb3af55d836833c9d> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6ce77cbd4e2c2af25385cc14efda3f7f> skos:altLabel """Sint-Gertrudis - Leuven""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6ce77cbd4e2c2af25385cc14efda3f7f> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6dc84f2f7f48b430d34e23813854ac3e> skos:altLabel """Sint-Gertrudis - Pede - Dilbeek""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6dc84f2f7f48b430d34e23813854ac3e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6e88e1eed7eff912d2d178ff3b26b84e> skos:altLabel """Allerheiligste Verlosser - Borgt - Grimbergen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6e88e1eed7eff912d2d178ff3b26b84e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6f27e528e1275e782d276ecad8f90da9> skos:altLabel """Sint-Gaugericus - Kobbegem - Asse""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6f27e528e1275e782d276ecad8f90da9> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6f4cfd9964c7b313b3a4499c9d8fa201> skos:altLabel """Sint-Martinus en Sint-Lodewijk - Everberg - Kortenberg""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6f4cfd9964c7b313b3a4499c9d8fa201> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6fb1a61e20c84e5df2db3c0873764d21> skos:altLabel """Sint-Ulrik - Sint-Ulriks-Kapelle - Dilbeek""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6fb1a61e20c84e5df2db3c0873764d21> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/710dda336ca6a0b987bc4ffb9f39ca52> skos:altLabel """Sint-Gertrudis - Landen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/710dda336ca6a0b987bc4ffb9f39ca52> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/720d04e65be9bfb90b8adaa6dd0607d0> skos:altLabel """Sint-Catharina - Hoegaarden""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/720d04e65be9bfb90b8adaa6dd0607d0> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/72632f075101b80598f2f86ba36bf2bb> skos:altLabel """Sint-Antonius - Meerbeek - Kortenberg""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/72632f075101b80598f2f86ba36bf2bb> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/741d3b9092fb87b55a1de864c0c868e4> skos:altLabel """Sint-Amandus - Erps - Kortenberg""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/741d3b9092fb87b55a1de864c0c868e4> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/741df1ab11597216261f60a588d2593c> skos:altLabel """Sint-Lambertus - Nossegem - Zaventem""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/741df1ab11597216261f60a588d2593c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/751f5d42151b4e0b448a69cce04638af> skos:altLabel """Sint-Martinus - Kester - Gooik""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/751f5d42151b4e0b448a69cce04638af> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/754805692007b70311b6bccc9a5a1480> skos:altLabel """Sint-Pieter - Pellenberg - Lubbeek""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/754805692007b70311b6bccc9a5a1480> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/75721bdee347f6a9dfd7a808f862169b> skos:altLabel """Sint-Pieter in Banden - Oudenaken - Sint-Pieters-Leeuw""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/75721bdee347f6a9dfd7a808f862169b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/763db9435b08a276baecd65f149ea18d> skos:altLabel """Sint-Martinus - Duffel - Duffel""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/763db9435b08a276baecd65f149ea18d> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7658294b5480304e14de210e6efa48bc> skos:altLabel """Onze-Lieve-Vrouw van Goede Hoop - Vilvoorde""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7658294b5480304e14de210e6efa48bc> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7738292ac4dd1dbee3ab7ee3bb41fec8> skos:altLabel """Sint-Martinus - Halle""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7738292ac4dd1dbee3ab7ee3bb41fec8> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/77ab72f78cc15710cbd9635daa9024e1> skos:altLabel """Sint-Jan-Baptist - Relegem - Asse""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/77ab72f78cc15710cbd9635daa9024e1> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/77c335bd79e855f0ec7651f61e2f8829> skos:altLabel """Sint-Martinus - Ramsdonk - Kapelle o/d Bos""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/77c335bd79e855f0ec7651f61e2f8829> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7a030b8c13b594250f0b4f9562fd334b> skos:altLabel """Sint-Martinus - Lubbeek""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7a030b8c13b594250f0b4f9562fd334b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7b5f6fa6ba4cf0750f74d77b072accd1> skos:altLabel """Heilige Familie - Groot-Bijgaarden - Dilbeek""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7b5f6fa6ba4cf0750f74d77b072accd1> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7b8ffebc579523c9c5cef7f2d92395fc> skos:altLabel """Onze-Lieve-Vrouw - Kokejane - Herne""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7b8ffebc579523c9c5cef7f2d92395fc> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7b9a4037bca285077a6cbf349433c2b7> skos:altLabel """Sint-Rumoldus - Mechelen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7b9a4037bca285077a6cbf349433c2b7> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7bb3ca907c34cd0066dac874ea731aa6> skos:altLabel """Sint-Pancratius - Kraainem""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7bb3ca907c34cd0066dac874ea731aa6> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7bd74c4237b3e204a47eaeac636bbd4f> skos:altLabel """Sint-Jozef - Leuven""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7bd74c4237b3e204a47eaeac636bbd4f> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7da4d7d22a9428e8c8e6bd22ecafd329> skos:altLabel """Onze-Lieve-Vrouw - Gaasbeek - Lennik""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7da4d7d22a9428e8c8e6bd22ecafd329> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7dc298d9ec876e5aa9031b86e7abfa97> skos:altLabel """Sint-Franciscus van Sales - Mijlstraat - Duffel""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7dc298d9ec876e5aa9031b86e7abfa97> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7fb805b33dd0154c98a9769aeb24d5e4> skos:altLabel """Sint-Niklaas - Ottenburg - Huldenberg""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7fb805b33dd0154c98a9769aeb24d5e4> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/80146c1aa11bb140fbb36740261b9240> skos:altLabel """Sint-Bernardus - Lubbeek""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/80146c1aa11bb140fbb36740261b9240> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/802566e70a9d4aa1f63089a7355c7d82> skos:altLabel """Sint-Hubertus - Elewijt - Zemst""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/802566e70a9d4aa1f63089a7355c7d82> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/819f1bb12ac62cf130339ef0033fcbde> skos:altLabel """Sint-Michiel - Beisem - Herent""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/819f1bb12ac62cf130339ef0033fcbde> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/81ece4dc5b6c6217a6d3c228f3bf0c1f> skos:altLabel """Sint-Bartholomeus - Korbeek-Dijle - Bertem""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/81ece4dc5b6c6217a6d3c228f3bf0c1f> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8204ba739b5eb6e50b4d3586c5e978bb> skos:altLabel """Onze-Lieve-Vrouw aan de Schelde""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8204ba739b5eb6e50b4d3586c5e978bb> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/82403cb5a370bfd22076bd561c515dd8> skos:altLabel """Sint-Genoveva - Steenhuffel - Londerzeel""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/82403cb5a370bfd22076bd561c515dd8> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8252dd1d96f328aa4a412a972353fe54> skos:altLabel """Onze-Lieve-Vrouw Oorzaak onzer Blijdschap - Middenhut - Sint-Genesius-Rode""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8252dd1d96f328aa4a412a972353fe54> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/85e4a1647130ceb2cf5b138999584a5b> skos:altLabel """Sint-Pieter - Sint-Pieters-Kapelle - Herne""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/85e4a1647130ceb2cf5b138999584a5b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/86f8c3a43a64f838882ebb0483679022> skos:altLabel """Sint-Martinus - Peutie - Vilvoorde""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/86f8c3a43a64f838882ebb0483679022> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/87679a79a68b3e15e266505a1bc7ec48> skos:altLabel """Sint-Jozef en Sint-Antonius van Padua - Schoonderbuken - Scherpenheuvel-Zichem""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/87679a79a68b3e15e266505a1bc7ec48> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/87a6d1f23be7f83e97c0bd58fa4e0254> skos:altLabel """Sint-Rochus - Halle""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/87a6d1f23be7f83e97c0bd58fa4e0254> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8885d901c2740839ee4269fb076fcf1c> skos:altLabel """Sint-Martinus - Overijse""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8885d901c2740839ee4269fb076fcf1c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8a033a87351ec26df1d5146840ecdb63> skos:altLabel """Sint-Niklaas - Gooik""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8a033a87351ec26df1d5146840ecdb63> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8a2686db4deef9662c8d017782dc6bc8> skos:altLabel """Sint-Mauritius - Neerhespen - Linter""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8a2686db4deef9662c8d017782dc6bc8> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8a38df5547af1e94c0c4e98c8ba37923> skos:altLabel """Sint-Laurentius - Wolvertem - Meise""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8a38df5547af1e94c0c4e98c8ba37923> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8dafd10139c19392284ed39105f8d6cc> skos:altLabel """Heilige Michaël en Heilige Jozef - Oppem - Wezembeek-Oppem""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8dafd10139c19392284ed39105f8d6cc> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8de60a8ad3a6af3195804bad13b490de> skos:altLabel """Onze-Lieve-Vrouw Bezoeking - Essene - Affligem""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8de60a8ad3a6af3195804bad13b490de> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9009bf333d5bf831d0aa7032e323d391> skos:altLabel """Sint-Martinus - Dormaal - Zoutleeuw""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9009bf333d5bf831d0aa7032e323d391> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/90a5c36d556e152b93e860ee552b49fc> skos:altLabel """Sint-Servaas - Grimbergen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/90a5c36d556e152b93e860ee552b49fc> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/90ee648f83d149570d9530674b33a1f6> skos:altLabel """Sint-Ursula - Eizeringen - Lennik""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/90ee648f83d149570d9530674b33a1f6> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9222f5c5557cb2ca0c07873fbaf02da7> skos:altLabel """Sint-Engelbertus en Sint-Bernardus - Laar - Zemst""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9222f5c5557cb2ca0c07873fbaf02da7> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9241e45e77f4e9499b0b5d7fb98f3225> skos:altLabel """Sint-Jan-Baptist - Huizingen - Beersel""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9241e45e77f4e9499b0b5d7fb98f3225> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9265225b028e2e95e4fc73fa48acbf1e> skos:altLabel """Sint-Antonius - Bollebeek - Asse""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9265225b028e2e95e4fc73fa48acbf1e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/92b6a60b204fe6300b7bb0664ba69483> skos:altLabel """Sint-Jan-Evangelist - Blanden - Oud-Heverlee""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/92b6a60b204fe6300b7bb0664ba69483> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/93700592ea8c6594f83ad1195e0930fc> skos:altLabel """Sint-Pancratius - Waasmont - Landen(-Zuid)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/93700592ea8c6594f83ad1195e0930fc> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/93f64b106aade540900a835e3598b000> skos:altLabel """Sint-Engelbertus - Deurne - Diest""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/93f64b106aade540900a835e3598b000> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9604b1cbee79bb8da623db08411f906a> skos:altLabel """Sint-Cyriacus - Budingen - Zoutleeuw""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9604b1cbee79bb8da623db08411f906a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/964f0c15219d1aad9c75172f4f3ed9ea> skos:altLabel """Sint-Pieter en Sint-Pauwel - Neerijse - Huldenberg""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/964f0c15219d1aad9c75172f4f3ed9ea> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/974280ddf1af1fb36c4637891760c269> skos:altLabel """Sint-Michiel - Messelbroek - Scherpenheuvel-Zichem""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/974280ddf1af1fb36c4637891760c269> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/98fecf09e89f742bc1eb170fe84e7561> skos:altLabel """Sint-Lambertus - Heverlee - Leuven""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/98fecf09e89f742bc1eb170fe84e7561> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9b0c72ac159f54efaa6979fcd8d50dff> skos:altLabel """Sint-Jozef - Londerzeel""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9b0c72ac159f54efaa6979fcd8d50dff> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9d1ac9a9fb3c11ee015d4797a697a8a7> skos:altLabel """Onze-Lieve-Vrouw - Aarschot""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9d1ac9a9fb3c11ee015d4797a697a8a7> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9d20c8834fdd481e3a899c04618a1f05> skos:altLabel """Sint-Niklaas - Herfelingen - Herne""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9d20c8834fdd481e3a899c04618a1f05> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9de888da3628fefef78408bd8193af66> skos:altLabel """Sint-Pieter - Bertem""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9de888da3628fefef78408bd8193af66> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9ede0567700264eb36b76fa015dee583> skos:altLabel """Sint-Jan-Baptist - Averbode - Scherpenheuvel-Zichem""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9ede0567700264eb36b76fa015dee583> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9fec9f25ef06ec60f0019355a6aa2981> skos:altLabel """Sint-Egidius - Groot-Bijgaarden - Dilbeek""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9fec9f25ef06ec60f0019355a6aa2981> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a07c7fcf647f916425886f36e479b4bd> skos:altLabel """Sint-Agatha - Putkapel - Leuven""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a07c7fcf647f916425886f36e479b4bd> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a11e976d68b93902f9b9e58fb590dcf8> skos:altLabel """Sint-Agatha - Sint-Agatha-Rode - Huldenberg""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a11e976d68b93902f9b9e58fb590dcf8> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a1e919241435239f8be31ccde11aa2f5> skos:altLabel """Sint-Bartholomeus - Halle - Zoutleeuw""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a1e919241435239f8be31ccde11aa2f5> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a27fba620add85a77e9b9cacf7003b04> skos:altLabel """Sint-Ambrosius - Dilbeek""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a27fba620add85a77e9b9cacf7003b04> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a2b045ae912c310b24100d31c11f3873> skos:altLabel """Sint-Paulus - Vollezele - Galmaarden""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a2b045ae912c310b24100d31c11f3873> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a3b5e999497fafa33c502224cb347c41> skos:altLabel """Sint-Martinus - Rijmenam - Bonheiden""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a3b5e999497fafa33c502224cb347c41> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a5065f34d3390dbd68158555bb15061e> skos:altLabel """Sint-Anna - Baal - Tremelo""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a5065f34d3390dbd68158555bb15061e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a54bbc5fc0692ed06f890c42fad45f1a> skos:altLabel """Sint-Jan Evangelist - Tervuren""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a54bbc5fc0692ed06f890c42fad45f1a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a5c7ca7bf41a118e838391bd9b3d24de> skos:altLabel """Heilige Familie - Bovenlo - Leuven""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a5c7ca7bf41a118e838391bd9b3d24de> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a6a39efc861a1384443b666501ebec0f> skos:altLabel """Sint-Niklaas - Perk - Steenokkerzeel""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a6a39efc861a1384443b666501ebec0f> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a76b7529aeea054b79f15ee16fc20cb9> skos:altLabel """Sint-Servatius - Wemmel""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a76b7529aeea054b79f15ee16fc20cb9> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a7c6b652a5ced61ef69f8d006d162109> skos:altLabel """Sint-Jozef - Vilvoorde""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a7c6b652a5ced61ef69f8d006d162109> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a8c3d20762143b4fa8412e7469743d57> skos:altLabel """Sint-Amandus - Elingen - Pepingen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a8c3d20762143b4fa8412e7469743d57> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a929be491f7a901af38c43dc794a9b7b> skos:altLabel """Sint-Jozef en Sint-Franciscus - Essenbeek - Halle""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a929be491f7a901af38c43dc794a9b7b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a98b179115cd692722c16f216c2604bb> skos:altLabel """Sint-Antonius - Buken - Kampenhout""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a98b179115cd692722c16f216c2604bb> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/aa4596055b491e2524b5286eebda6454> skos:altLabel """Sint-Pieter - Leerbeek - Gooik""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/aa4596055b491e2524b5286eebda6454> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/aa6aff345478927f30f8075000d16202> skos:altLabel """Sint-Niklaas - Willebroek""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/aa6aff345478927f30f8075000d16202> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/af3e7ea6ed8ab1545ca18df8cd9f6e7d> skos:altLabel """Sint-Carolus - Attenhoven - Holsbeek""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/af3e7ea6ed8ab1545ca18df8cd9f6e7d> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/af7dab9ce1565fa0ab074f5907758aa7> skos:altLabel """Sint-Stefaan - Sint-Stevens-Woluwe - Zaventem""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/af7dab9ce1565fa0ab074f5907758aa7> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b09aa33ec9809bb0ea9099e6fa569d2a> skos:altLabel """Heilige Damiaan van Molokai - Ninde - Tremelo""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b09aa33ec9809bb0ea9099e6fa569d2a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b1864507d935acae2879f1cc5eb96508> skos:altLabel """Onze-Lieve-Vrouw - Merchtem""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b1864507d935acae2879f1cc5eb96508> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b1fc475eaf3e3fa849d1172c05082e7b> skos:altLabel """Heilig Hart - Blauwput - Leuven""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b1fc475eaf3e3fa849d1172c05082e7b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b25f679b93e0e5ed178b4b405cdb2107> skos:altLabel """Onze-Lieve-Vrouw Boodschap - Liedekerke""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b25f679b93e0e5ed178b4b405cdb2107> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b3e77ba4c6e059e071e8934af6898141> skos:altLabel """Sint-Martinus - Bever""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b3e77ba4c6e059e071e8934af6898141> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b4333d14bc3c0b393cf8392dbe1e32c7> skos:altLabel """Sint-Niklaas - Kapelle-op-den-Bos""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b4333d14bc3c0b393cf8392dbe1e32c7> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b488ac72d72ffde490fea911ea037d47> skos:altLabel """Sint-Kwinten - Linden - Lubbeek""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b488ac72d72ffde490fea911ea037d47> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b555097bc8f966dcb05cf9a0cee545bd> skos:altLabel """H.H. Maria, Pieter en Antonius - Aarschot""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b555097bc8f966dcb05cf9a0cee545bd> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b5a694fc51d23d9939335cf8c8d23866> skos:altLabel """Sint-Jozef - Keiberg - Scherpenheuvel-Zichem""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b5a694fc51d23d9939335cf8c8d23866> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b6be6a8e78d1e2ac65e20c14ad394786> skos:altLabel """Sint-Sebastiaan - Linkebeek""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b6be6a8e78d1e2ac65e20c14ad394786> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b6f1d0df716c464acaa5107be67f07cb> skos:altLabel """Sint-Leonardus - Zoutleeuw""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b6f1d0df716c464acaa5107be67f07cb> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b732317954cb33bc14843f7f8d57b65b> skos:altLabel """Sint-Jozef - Relst - Kampenhout""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b732317954cb33bc14843f7f8d57b65b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b8c09116f9e603ff109b4f80ba960475> skos:altLabel """Onze-Lieve-Vrouw - Haasrode - Oud-Heverlee""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b8c09116f9e603ff109b4f80ba960475> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bd50c4c4246f428b5c70abff91a6b167> skos:altLabel """Sint-Pancratius - Melkwezer - Linter""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bd50c4c4246f428b5c70abff91a6b167> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bd83077d097c67bf6a131ac4dabadfc3> skos:altLabel """Heilige Familie - Vleugt - Diest""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bd83077d097c67bf6a131ac4dabadfc3> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/be7d0ccc17990db58e9ddf968e774cea> skos:altLabel """Sint-Jan Berchmans - Diest""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/be7d0ccc17990db58e9ddf968e774cea> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/be8664e360eb11fab90beebb642a4d9d> skos:altLabel """Sint-Rumoldus - Humbeek - Grimbergen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/be8664e360eb11fab90beebb642a4d9d> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c2c9a7731cb4ae92d53e669acac2c3fd> skos:altLabel """Sint-Martinus - Strijtem - Roosdaal""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c2c9a7731cb4ae92d53e669acac2c3fd> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c406fe24ac25853e52c5cc8f7cef2f25> skos:altLabel """Goddelijke Zaligmaker - Hakendover - Tienen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c406fe24ac25853e52c5cc8f7cef2f25> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c69e72851dbd1cfed9a749a49045d498> skos:altLabel """Sint-Theodardus - Bogaarden - Pepingen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c69e72851dbd1cfed9a749a49045d498> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c6a4a15fa70011951b60e7ce042b2d54> skos:altLabel """Sint-Vincentius - Buizingen - Halle""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c6a4a15fa70011951b60e7ce042b2d54> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c7c8cca60660962d86eb9d00c0d47871> skos:altLabel """Sint-Cornelius - Molenveld - Grimbergen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c7c8cca60660962d86eb9d00c0d47871> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c84125fe08133575c20f7aff5c44464d> skos:altLabel """Onze-Lieve-Vrouw - Scherpenheuvel - Scherpenheuvel-Zichem""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c84125fe08133575c20f7aff5c44464d> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c860ca1b28d6c306732287657108e552> skos:altLabel """Sint-Martinus - Sint-Martens-Lennik - Lennik""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c860ca1b28d6c306732287657108e552> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cc56be7189892df24850e94abd616498> skos:altLabel """Emmaüs - Mechelen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cc56be7189892df24850e94abd616498> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cde29b4d0fb913c452e73e3450f6d04e> skos:altLabel """Sint-Gaugericus - Dworp - Beersel""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cde29b4d0fb913c452e73e3450f6d04e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ce1c76eab7e5010efaa95c2f950091fb> skos:altLabel """Sint-Paulus - Vossem - Tervuren""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ce1c76eab7e5010efaa95c2f950091fb> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cf149ee6070cee8f6c884e707edec175> skos:altLabel """Sint-Stefaan - Mollem - Asse""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cf149ee6070cee8f6c884e707edec175> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cfd38a53ab164acae99989c6272b6cee> skos:altLabel """Sint-Martinus - Wezemaal - Rotselaar""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cfd38a53ab164acae99989c6272b6cee> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d0ca56799aa9a5914b23996e92f557d6> skos:altLabel """Sint-Hadrianus - Wijgmaal - Leuven""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d0ca56799aa9a5914b23996e92f557d6> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d1fa5ec9a27907a91639f2ea336799b5> skos:altLabel """Onze-Lieve-Vrouw - Jezus-Eik - Overijse""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d1fa5ec9a27907a91639f2ea336799b5> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d264e200ccd91eb41f794efc98380f7c> skos:altLabel """Sint-Catharina - Sint-Katelijne-Waver""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d264e200ccd91eb41f794efc98380f7c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d4e6b0d171fff9ba1c156b6e4388a350> skos:altLabel """Onze-Lieve-Vrouw van Bijstand - Tremelo""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d4e6b0d171fff9ba1c156b6e4388a350> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d7b54854d4d2eddcf7717ca941c25062> skos:altLabel """Sint-Jan Evangelist - Park - Leuven""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d7b54854d4d2eddcf7717ca941c25062> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d7d98ada0caba8cf8b3e3485f4a99ea2> skos:altLabel """Sint-Catharina - Sint-Katherina-Lombeek - Ternat""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d7d98ada0caba8cf8b3e3485f4a99ea2> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/da112a67a62940bc45fcc020bd139786> skos:altLabel """Sint-Pieter - Leuven""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/da112a67a62940bc45fcc020bd139786> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/dbfb6bdb2f55203055f5beb06a0550af> skos:altLabel """Onbevlekt Hart van Maria - Terbank - Leuven""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/dbfb6bdb2f55203055f5beb06a0550af> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/de830b218711180d21cc7937d5428b6c> skos:altLabel """Sint-Jan-Baptist - Werchter - Rotselaar""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/de830b218711180d21cc7937d5428b6c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/de8d15f534b78ef8a941f84bc2250136> skos:altLabel """Sint-Petrus en Sint-Paulus - Herne""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/de8d15f534b78ef8a941f84bc2250136> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/dfcd3567e691da6426f9473562a23b06> skos:altLabel """Sint-Michiel - Hekelgem - Affligem""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/dfcd3567e691da6426f9473562a23b06> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e14f825b7542b0d861ed2f586701951a> skos:altLabel """Sint-Paulus - Opwijk""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e14f825b7542b0d861ed2f586701951a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e1a7207ccf880d7835e4fe8fe4984489> skos:altLabel """Heilig Hart en Sint-Antonius van Padua - Okselaar - Scherpenheuvel-Zichem""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e1a7207ccf880d7835e4fe8fe4984489> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e4b2a63c9b7c8cc6cc68eec36015f999> skos:altLabel """Onze-Lieve-Vrouw - Beigem - Grimbergen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e4b2a63c9b7c8cc6cc68eec36015f999> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e5e3cb7a6f0935d863ce313b6c426541> skos:altLabel """Sint-Michiel en Sint-Reneldis - Egenhoven - Leuven""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e5e3cb7a6f0935d863ce313b6c426541> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e5e92cc5c08da7e4d7b3dadb41996af4> skos:altLabel """Sint-Ursmarus - Oetingen - Gooik""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e5e92cc5c08da7e4d7b3dadb41996af4> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e62b01dbd504de13262f69520bd69e9b> skos:altLabel """Sint-Gertrudis - Ternat""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e62b01dbd504de13262f69520bd69e9b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e81cb6e710658ff05b3748072e73ee04> skos:altLabel """Sint-Catharina - Humelgem - Steenokkerzeel""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e81cb6e710658ff05b3748072e73ee04> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e8ae6fe025ef9633f1b17741d21eab28> skos:altLabel """Sint-Remigius - Wambeek - Ternat""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e8ae6fe025ef9633f1b17741d21eab28> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ea58cc073dac7e4717c2363b19cd1e05> skos:altLabel """Sint-Martinus - Tollembeek - Galmaarden""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ea58cc073dac7e4717c2363b19cd1e05> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ece3ff12e1fdba111ce2bf3d5edf7c0e> skos:altLabel """Sint-Apollonia - Ledeberg-Pamel - Roosdaal""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ece3ff12e1fdba111ce2bf3d5edf7c0e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/eed25706f5e1d34f6de39369a6e5f022> skos:altLabel """Onze-Lieve-Vrouw van Goede Bijstand - Hofstade - Zemst""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/eed25706f5e1d34f6de39369a6e5f022> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ef8290e07b647bf7600129256b651eb5> skos:altLabel """De Goede Herder - Haacht""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ef8290e07b647bf7600129256b651eb5> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f0ddc0a3d2ce4de423cfc628bf2c27cb> skos:altLabel """Sint-Kwinten - Wommersom - Linter""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f0ddc0a3d2ce4de423cfc628bf2c27cb> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f1842496bfae84b7ecbb66fd1e178027> skos:altLabel """Sint-Catharina - Kortrijk-Dutsel - Holsbeek""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f1842496bfae84b7ecbb66fd1e178027> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f3ad5302cc2ef1b422d0f704ce9d6137> skos:altLabel """Sint-Jozef - Oppem - Wezembeek-Oppem""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f3ad5302cc2ef1b422d0f704ce9d6137> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f4ad3bf65dc806d265cebe883e5fdf2b> skos:altLabel """Sint-Pieter - Galmaarden""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f4ad3bf65dc806d265cebe883e5fdf2b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f50134d00899bd038a5604866f442103> skos:altLabel """Sint-Antonius van Padua - Heverlee - Leuven""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f50134d00899bd038a5604866f442103> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f70a419bf533dfed9fb53fd1538a4694> skos:altLabel """Sint-Godardus - Bekkerzeel - Asse""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f70a419bf533dfed9fb53fd1538a4694> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f7469f02979c44f0f9fe1573690af95f> skos:altLabel """Sint-Franciscus van Assisië - Heverlee - Leuven""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f7469f02979c44f0f9fe1573690af95f> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fa0a3d3bdca3d5ca2a6f89635956d374> skos:altLabel """Sint-Kristoffel - Londerzeel""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fa0a3d3bdca3d5ca2a6f89635956d374> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/faa4ef5d73172605da666a283dfa9ddc> skos:altLabel """Sint-Jozef - Sint-Katherina-Lombeek - Ternat""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/faa4ef5d73172605da666a283dfa9ddc> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fc7ae492d0384fedec7804a279d8fe6e> skos:altLabel """Sint-Laurentius en Sint-Lucia - Begijnendijk""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fc7ae492d0384fedec7804a279d8fe6e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fed2ed3a65993012a7e768f1d75be8bc> skos:altLabel """Sint-Bernardus - Heikruis - Pepingen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fed2ed3a65993012a7e768f1d75be8bc> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fefc3240f1fa62ccb5a6837d5ef317a6> skos:altLabel """Sint-Niklaas - Drogenbos""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fefc3240f1fa62ccb5a6837d5ef317a6> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ffdbb8d1dcebc3fd6b1ba0e0c4ffe46b> skos:altLabel """Sint-Martinus - Pepingen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ffdbb8d1dcebc3fd6b1ba0e0c4ffe46b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a7164f51e0e68820b9d2d4d53aaf48f9> skos:altLabel """Anglicaanse Kerk Saint-John's van Gent""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a7164f51e0e68820b9d2d4d53aaf48f9> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a57ce399c9020f6f1a3f976c2510976e> skos:altLabel """Anglicaanse Kerk Sint-Boniface van Antwerpen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a57ce399c9020f6f1a3f976c2510976e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cb69c277a4021bf71a8c7cacc22bd9bc> skos:altLabel """Anglicaanse Kerk English Church van Oostende""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cb69c277a4021bf71a8c7cacc22bd9bc> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a596850e9aa27969a25f73137d300306> skos:altLabel """Anglicaanse Kerk Saint Paul's Church van Tervuren""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a596850e9aa27969a25f73137d300306> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/42adfc9a7b2cfa0e6ead719da03406b5> skos:altLabel """Anglicaanse Kerk Saint-George's van Ieper""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/42adfc9a7b2cfa0e6ead719da03406b5> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/46b8da1347c6bcab415ad53a1b94da26> skos:altLabel """Anglicaanse Kerk Saint George's van Knokke-Heist""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/46b8da1347c6bcab415ad53a1b94da26> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e2eea8a352821c9c1f1827f1cfde9f24> skos:altLabel """Anglicaanse Kerk Saint Martha and Mary's van Leuven""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e2eea8a352821c9c1f1827f1cfde9f24> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0277a5125962d8d5f0f00606d200be9a> skos:altLabel """Onbevlekt Hart van Maria""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0277a5125962d8d5f0f00606d200be9a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4f951a28ddd714d5c4ccd9fa0bc246a6> skos:altLabel """St.-Leonardus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4f951a28ddd714d5c4ccd9fa0bc246a6> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9fd455336c29d3e7cca7a64e504ba538> skos:altLabel """St.-Lambertus (Dam)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9fd455336c29d3e7cca7a64e504ba538> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/93eb944162bd07a899a7564614ee1052> skos:altLabel """St.-Catharina (Kiel)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/93eb944162bd07a899a7564614ee1052> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/da9babfb43190b6a245f4a6dc0907cf0> skos:altLabel """St.-Carolus Borromeus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/da9babfb43190b6a245f4a6dc0907cf0> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/aa7a4b1277b6c66e2aa880880318ca1e> skos:altLabel """St.-Anna-ten-Drieën (Linkeroever)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/aa7a4b1277b6c66e2aa880880318ca1e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bd119b637d57cf50b7aa96a263521a1d> skos:altLabel """H. Hart""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bd119b637d57cf50b7aa96a263521a1d> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/04d3f07aa7a35bf03923fa80286d74ae> skos:altLabel """St.-Laurentius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/04d3f07aa7a35bf03923fa80286d74ae> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/299fbc34dd76744f808c2c330e04ffab> skos:altLabel """Christus Koning""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/299fbc34dd76744f808c2c330e04ffab> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1eb680904f436ec22767b9cb6d4cedf7> skos:altLabel """St.-Bernardus (Kiel)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1eb680904f436ec22767b9cb6d4cedf7> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4680f6876be6fdf1ced2b051459c7aa1> skos:altLabel """St.-Jacob de Meerdere""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4680f6876be6fdf1ced2b051459c7aa1> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8fdf7785c1302ef90a76951b6091c6ff> skos:altLabel """St.-Paulus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8fdf7785c1302ef90a76951b6091c6ff> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e1379eb8c87776415c27f8d9419eadd1> skos:altLabel """St.-Walburgis""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e1379eb8c87776415c27f8d9419eadd1> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/763824c2a04742f4855a03d556413763> skos:altLabel """St.-Norbertus (Zurenborg)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/763824c2a04742f4855a03d556413763> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cb5e3a4ea7901d83468627fe70bd02f9> skos:altLabel """Kathedrale kerkfabriek O.-L.-Vrouw ten Hemel Opgenomen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cb5e3a4ea7901d83468627fe70bd02f9> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c6aa706f74ab289b184d0060c3fbd77f> skos:altLabel """St.-Amandus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c6aa706f74ab289b184d0060c3fbd77f> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fb2c0f065c5ed4ea5a0e9fdfa84d3cfb> skos:altLabel """St.-Willibrordus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fb2c0f065c5ed4ea5a0e9fdfa84d3cfb> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2f693f46511b5bf702e8cf4e202ca764> skos:altLabel """St.-Laurentius (Schoonbroek-Rozemaai)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2f693f46511b5bf702e8cf4e202ca764> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/523453693ba3f69951ff51bad67e6097> skos:altLabel """O.-L.-Vrouw Boodschap (Luchtbal)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/523453693ba3f69951ff51bad67e6097> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/811741291e01d04750c4c343eadcb19a> skos:altLabel """St.-Michiel en St.-Pieter""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/811741291e01d04750c4c343eadcb19a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/174e2d6ad0594f8b34d9ae85b34a3c8b> skos:altLabel """St.-Antonius van Padua""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/174e2d6ad0594f8b34d9ae85b34a3c8b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2d2e15e6203dc61baf9386bd5cb565f3> skos:altLabel """St.-Eligius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2d2e15e6203dc61baf9386bd5cb565f3> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bc371a8be7b30a45324a14a87ceaac45> skos:altLabel """St.-Gertrudis (Zandvliet)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bc371a8be7b30a45324a14a87ceaac45> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7168160262e5b5bc1ea4eb8a8d73d39b> skos:altLabel """H. Geest""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7168160262e5b5bc1ea4eb8a8d73d39b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/65080cef056396c940336e244436b756> skos:altLabel """St.-Jan de Doper""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/65080cef056396c940336e244436b756> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b0bc855a515b225f0baab9114c75b32f> skos:altLabel """St.-Andries""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b0bc855a515b225f0baab9114c75b32f> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/02e1752a007ff7a7c4a5a8b56149bd11> skos:altLabel """St.-Joris""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/02e1752a007ff7a7c4a5a8b56149bd11> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/313a420642155b6518564251937fd582> skos:altLabel """St.-Jozef (Voorheide)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/313a420642155b6518564251937fd582> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2a5f07159de845042ae86c5b383e0c82> skos:altLabel """O.-L.-Vrouw ten Hemel Opgenomen en St.-Job""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2a5f07159de845042ae86c5b383e0c82> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8c1c97624c270b287afceecbfa0216f8> skos:altLabel """St.-Rumoldus (Zondereigen)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8c1c97624c270b287afceecbfa0216f8> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/886e952da1d60eb2f74c11660eb13107> skos:altLabel """St.-Remigius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/886e952da1d60eb2f74c11660eb13107> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/164148b526cfebbcfce596da708592e7> skos:altLabel """O.-L.-Vrouw van Altijddurende Bijstand (Rosselaar)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/164148b526cfebbcfce596da708592e7> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a27bd489754f5b42696cd0f4fb6ad647> skos:altLabel """St.-Andries""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a27bd489754f5b42696cd0f4fb6ad647> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4a5d354b44f73bc443a02ebc857a9689> skos:altLabel """St.-Willibrordus (Olmen)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4a5d354b44f73bc443a02ebc857a9689> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/af802c229e0f5c4b0c589016c54f6673> skos:altLabel """St.-Hubertus (Hulsen)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/af802c229e0f5c4b0c589016c54f6673> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e0c2505bf10bb92443fbfc676d91ba6e> skos:altLabel """O.-L.-Vrouw van Altijddurende Bijstand (Den Hout)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e0c2505bf10bb92443fbfc676d91ba6e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5aa4c9290f872808c354ec7a60558b29> skos:altLabel """St.-Quirinus (Vlimmeren)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5aa4c9290f872808c354ec7a60558b29> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/885f8c22202b38b97427394272a7d7bf> skos:altLabel """St.-Lambertus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/885f8c22202b38b97427394272a7d7bf> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a58d4b985bb4c7a6fcb68c8c61411b65> skos:altLabel """H. Sacrament (Groenenhoek)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a58d4b985bb4c7a6fcb68c8c61411b65> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7589c80988a5f2f3147db92bec1a80b9> skos:altLabel """O.-L.-Vrouw Middelares en St.-Lodewijk""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7589c80988a5f2f3147db92bec1a80b9> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2c6b436af393a84978e4cc9ec0a03eb6> skos:altLabel """H. Drievuldigheid""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2c6b436af393a84978e4cc9ec0a03eb6> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d15631efae523550fccaaab972652690> skos:altLabel """St.-Willibrordus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d15631efae523550fccaaab972652690> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bf53e675dd1116b387061ae46227b6d9> skos:altLabel """St.-Theresia van het Kind Jezus (Luithagen)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bf53e675dd1116b387061ae46227b6d9> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/43f25c037de1b0199703a6d7e9dccc61> skos:altLabel """De Verrezen Heer (Rooi)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/43f25c037de1b0199703a6d7e9dccc61> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/16f2550968bfb6506584b5923f6b7fd4> skos:altLabel """O.-L.-Vrouw""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/16f2550968bfb6506584b5923f6b7fd4> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c36ccfeb7b9457f472940347bd6b5a4c> skos:altLabel """St.-Lambertus (Gestel)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c36ccfeb7b9457f472940347bd6b5a4c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3d19bea71429b990675271a55ea2351e> skos:altLabel """St.-Pieter""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3d19bea71429b990675271a55ea2351e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c779e5f2fb4fafb43aa1701bffb770c1> skos:altLabel """St.-Rumoldus (Heikant)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c779e5f2fb4fafb43aa1701bffb770c1> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bebd915085c3d3d9e9bcdce5de05cd1c> skos:altLabel """St.-Jan in de Olie (Vremde)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bebd915085c3d3d9e9bcdce5de05cd1c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a8ea34fe8cd9806bb7680aa58e2710ff> skos:altLabel """St.-Bavo""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a8ea34fe8cd9806bb7680aa58e2710ff> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/51d78113d0d6eb28f3a43d85a0bc1d93> skos:altLabel """H. Hart""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/51d78113d0d6eb28f3a43d85a0bc1d93> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1c7e392b81f822e4889071e232974ac1> skos:altLabel """O.-L.-Vrouw""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1c7e392b81f822e4889071e232974ac1> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b895fb7257d81b4f464eafa7f3aca9aa> skos:altLabel """St.-Franciscus Xaverius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b895fb7257d81b4f464eafa7f3aca9aa> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/13f472c4ba0f6052bb6dc562ce62d677> skos:altLabel """O.-L.-Vrouw van het H. Hart (Stenenbrug)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/13f472c4ba0f6052bb6dc562ce62d677> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1160114a0001f84d882a2901ba672412> skos:altLabel """O.-L.-Vrouw ter Sneeuw""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1160114a0001f84d882a2901ba672412> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fcad9de64e77ce9b40245bbd7053afc0> skos:altLabel """St.-Jan Berchmans""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fcad9de64e77ce9b40245bbd7053afc0> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5067425ea6e68577b0e6dba6ea60799f> skos:altLabel """St.-Jacobus de Meerdere""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5067425ea6e68577b0e6dba6ea60799f> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d8754dbb50c123a6fa8f16e3fad9d759> skos:altLabel """H. Hart (Donk)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d8754dbb50c123a6fa8f16e3fad9d759> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/79c69957417e2f68cc039f12925bdca3> skos:altLabel """St.-Jozef (Driehoek)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/79c69957417e2f68cc039f12925bdca3> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0c4e08baf664fb70aa7a31bd78d5f144> skos:altLabel """St.-Antonius Abt""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0c4e08baf664fb70aa7a31bd78d5f144> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2ef4640206399c7317a24a6d8f4d88a8> skos:altLabel """Goddelijk Kind Jezus (Bethanië)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2ef4640206399c7317a24a6d8f4d88a8> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/699853630cc32cf838901733e3a8a8ae> skos:altLabel """H. Familie (Rustoord-Kaart)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/699853630cc32cf838901733e3a8a8ae> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fa52334e0709c0250c637c7af41f53c2> skos:altLabel """O.-L.-Vrouw Onbevlekt Ontvangen (Maria-ter-Heide)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fa52334e0709c0250c637c7af41f53c2> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3cb0eda9974f3f130e4046c35ef3bb9a> skos:altLabel """St.-Michiel""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3cb0eda9974f3f130e4046c35ef3bb9a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/196ef60b5c1512fdef3a3c1d1991c2bb> skos:altLabel """St.-Willibrordus (Overbroek)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/196ef60b5c1512fdef3a3c1d1991c2bb> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bffd9fc31addaaa0a9cd2ddc9412e9ea> skos:altLabel """O.-L.-Vrouw van Lourdes (Lochtenberg, Sint-Job-in-'t-Goor)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bffd9fc31addaaa0a9cd2ddc9412e9ea> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f064d497d71a7aae990d95800b49689e> skos:altLabel """St.-Leonardus (Sint-Lenaarts)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f064d497d71a7aae990d95800b49689e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5f9aab6e3d0b0983f1b8ee7cf7f07038> skos:altLabel """St.-Job (Sint-Job-in-'t-Goor)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5f9aab6e3d0b0983f1b8ee7cf7f07038> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/dfe8e28d14e10b693a347a3e79f0cb0e> skos:altLabel """St.-Niklaas""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/dfe8e28d14e10b693a347a3e79f0cb0e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5e9c7bb7cbfb0a2b551a490c63c121c5> skos:altLabel """H. Familie (Witgoor)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5e9c7bb7cbfb0a2b551a490c63c121c5> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9745a1b32545e01267324f1b1d80d01d> skos:altLabel """St.-Jozef""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9745a1b32545e01267324f1b1d80d01d> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c46ea4a106a11ae4c1ccde606cccb2dc> skos:altLabel """St.-Paulus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c46ea4a106a11ae4c1ccde606cccb2dc> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/25c1042045948ff51b530b9a77860397> skos:altLabel """O.-L.-Vrouw van Altijddurende Bijstand""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/25c1042045948ff51b530b9a77860397> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b27c38169db5b23829006737c348cb74> skos:altLabel """St.-Fredegandus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b27c38169db5b23829006737c348cb74> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fb4383227b5a035cfc78353dd09987cb> skos:altLabel """H. Familie (Kronenburg)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fb4383227b5a035cfc78353dd09987cb> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a47a5a23b19cdba2cb632f1aa3a351a1> skos:altLabel """St.-Rochus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a47a5a23b19cdba2cb632f1aa3a351a1> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9c8d6d2c1817d8d10cd77abfc8826fe7> skos:altLabel """H. Lodewijk van Montfort""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9c8d6d2c1817d8d10cd77abfc8826fe7> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/879aed9dbc9d61c353a3fc0d326d185a> skos:altLabel """H. Pius X""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/879aed9dbc9d61c353a3fc0d326d185a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/075d0bc6645e69d772ee5cd31ac4e1a6> skos:altLabel """De Blijde Boodschap""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/075d0bc6645e69d772ee5cd31ac4e1a6> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/815e81552501687c9e59ea851132389c> skos:altLabel """Emmanuelparochie""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/815e81552501687c9e59ea851132389c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9685475fc6590a1f3d5b6992fccf8aab> skos:altLabel """H. Familie (Elsdonk)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9685475fc6590a1f3d5b6992fccf8aab> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e108375bcc4632abaabd2caab36529cc> skos:altLabel """O.-L.-Vrouw van Lourdes en St.-Antonius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e108375bcc4632abaabd2caab36529cc> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5d77a0f8a8af3f5d6ec909602633b908> skos:altLabel """St.-Jozef""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5d77a0f8a8af3f5d6ec909602633b908> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4a1909fe6624df6c7e0429e822e3bbd4> skos:altLabel """St.-Theresia van het Kind Jezus (Bunt)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4a1909fe6624df6c7e0429e822e3bbd4> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/386c49f09c7f3849f5a7a42a73b8dc41> skos:altLabel """O.-L.-Vrouw van Gedurige Bijstand (St.-Mariaburg)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/386c49f09c7f3849f5a7a42a73b8dc41> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bd1f1bc5f8a14486b2fa31de8e7c21f1> skos:altLabel """St.-Lambertus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bd1f1bc5f8a14486b2fa31de8e7c21f1> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/400225adc43acf9ecad38409aaaa560f> skos:altLabel """St.-Antonius van Padua (Station)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/400225adc43acf9ecad38409aaaa560f> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2b8009fac2d54fa09f7f552d1f9a920e> skos:altLabel """O.-L.-Vrouw Geboorte""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2b8009fac2d54fa09f7f552d1f9a920e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a93c8cceb1799b65b8d022cb0ce29f74> skos:altLabel """St.-Vincentius a Paulo (Horendonk)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a93c8cceb1799b65b8d022cb0ce29f74> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/28626977291daa26090b9e0842d835f2> skos:altLabel """St.-Jan Baptist (Wildert)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/28626977291daa26090b9e0842d835f2> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/408cd868c50403b9acc7a58649460f14> skos:altLabel """St.-Pieter (Hoek)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/408cd868c50403b9acc7a58649460f14> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/03aedfef02f389c043acb315e80cd29a> skos:altLabel """St.-Laurentius (Zammel)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/03aedfef02f389c043acb315e80cd29a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2e2e8d10097445b223b053146501a51b> skos:altLabel """St.-Lucia (Oosterlo)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2e2e8d10097445b223b053146501a51b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/271368d2cd3eacace3f90cf72fad3859> skos:altLabel """St.-Apollonia (Stelen)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/271368d2cd3eacace3f90cf72fad3859> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7a0c7817abe7193d0d1947248b4cd4eb> skos:altLabel """St.-Hubertus (Ten Aard)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7a0c7817abe7193d0d1947248b4cd4eb> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f93eb1e2c656085f80c01b7572b1da4e> skos:altLabel """H. Hart (Winkelomheide)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f93eb1e2c656085f80c01b7572b1da4e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8d32c5298ea8d3b673f4410db4c490fd> skos:altLabel """St.-Lambertus (Bel)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8d32c5298ea8d3b673f4410db4c490fd> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1ab5215a69b40aa930b4f849c6d260c6> skos:altLabel """St.-Dimpna""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1ab5215a69b40aa930b4f849c6d260c6> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/79534a3a1842272a2f402a07019cecb3> skos:altLabel """St.-Jozef (Holven)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/79534a3a1842272a2f402a07019cecb3> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/25bd035b41f2f7ebe8f34122f4277c82> skos:altLabel """St.-Amandus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/25bd035b41f2f7ebe8f34122f4277c82> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/dec6f4bfddae8e28890181c24c0a81bc> skos:altLabel """St.-Franciscus van Assisi (Elsum)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/dec6f4bfddae8e28890181c24c0a81bc> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c3ce1195edb96ad73c109d4ecf95e9d0> skos:altLabel """O.-L.-Vrouw ten Hemel Opgenomen (Bouwel)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c3ce1195edb96ad73c109d4ecf95e9d0> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4bafd12e53d6aaa218d74446202dc2ed> skos:altLabel """St.-Lambertus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4bafd12e53d6aaa218d74446202dc2ed> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2465fbe7482b4e50efec0c04f9f084dd> skos:altLabel """O.-L.-Vrouw Koningin van de Vrede (Zonderschot)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2465fbe7482b4e50efec0c04f9f084dd> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5e20a06484b267aac944931d0f2dcd37> skos:altLabel """St.-Alfonsus (Goor)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5e20a06484b267aac944931d0f2dcd37> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3ace8ab4dd27af151359ceb597f068cb> skos:altLabel """H. Hart""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3ace8ab4dd27af151359ceb597f068cb> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2f4cf2989463eb7f4dc5786fb3a2890c> skos:altLabel """St.-Lambertus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2f4cf2989463eb7f4dc5786fb3a2890c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/84e24f46db48383c03f01651de6885e8> skos:altLabel """St.-Guibertus (Itegem)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/84e24f46db48383c03f01651de6885e8> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cf0943d286056ca0c7ca795614634d1f> skos:altLabel """St.-Jan Baptist (Wiekevorst)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cf0943d286056ca0c7ca795614634d1f> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/46eb78a8651d8e244cfb5e22609193f4> skos:altLabel """St.-Jan Baptist (Schriek)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/46eb78a8651d8e244cfb5e22609193f4> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bc2f106698d624859de4d476b73c8049> skos:altLabel """H. Naam Jezus (Grootlo)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bc2f106698d624859de4d476b73c8049> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c3e8451760f1da1cb7b01881ba1b0be7> skos:altLabel """O.-L.-Vrouw en St.-Jozef (Pijpelheide)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c3e8451760f1da1cb7b01881ba1b0be7> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d3592ca6fb308a0c8aecdd25b84d6368> skos:altLabel """St.-Salvator (Booischot)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d3592ca6fb308a0c8aecdd25b84d6368> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d7cc95c52b384b0376fedc038323c4c3> skos:altLabel """O.-L.-Vrouw van Altijddurende Bijstand (Hallaar)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d7cc95c52b384b0376fedc038323c4c3> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/168d5fec5ee04be393c30d5d5bc88074> skos:altLabel """St.-Niklaas""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/168d5fec5ee04be393c30d5d5bc88074> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0dd9ab1424c898077f18846c9fe264c0> skos:altLabel """St.-Niklaas (Morkhoven)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0dd9ab1424c898077f18846c9fe264c0> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/522e9269bcfc1a1ed64f3a67e10ce7cf> skos:altLabel """St.-Antonius van Padua""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/522e9269bcfc1a1ed64f3a67e10ce7cf> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/812fb6038fac7ca2d7ddcd424780e030> skos:altLabel """O.-L.-Vrouw""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/812fb6038fac7ca2d7ddcd424780e030> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/764e4bf35b1b7986cd7f9a1033190fba> skos:altLabel """St.-Waldetrudis (Bovenkerk)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/764e4bf35b1b7986cd7f9a1033190fba> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cb0b1d1b1de0d56f84c9a9808672140c> skos:altLabel """St.-Jan de Doper (Molekens)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cb0b1d1b1de0d56f84c9a9808672140c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/af5fe432ebe1c7b6237ec953e9530e7c> skos:altLabel """St.-Bavo (Noorderwijk)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/af5fe432ebe1c7b6237ec953e9530e7c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2005b15a1531013932f9cf23080f1862> skos:altLabel """SS. Pieter en Pauwel""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2005b15a1531013932f9cf23080f1862> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cdbac3728fb5d3b3474a2e9d44044cc2> skos:altLabel """O.-L.-Vrouw ten Hemel Opgenomen (Bergom)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cdbac3728fb5d3b3474a2e9d44044cc2> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e8538e0b43d3897db3ba0ac450f40d55> skos:altLabel """St.-Hubertus (Ramsel)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e8538e0b43d3897db3ba0ac450f40d55> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f4bcc60d3c188b645ea329b78ed26dd0> skos:altLabel """O.-L.-Vrouw Onbevlekt Ontvangen (Blauberg)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f4bcc60d3c188b645ea329b78ed26dd0> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/911544cbfc0b189b1e846d6168d4cd7f> skos:altLabel """St.-Servatius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/911544cbfc0b189b1e846d6168d4cd7f> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/154432b521c74769aed58e525f637577> skos:altLabel """St.-Jozef (Moretusburg)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/154432b521c74769aed58e525f637577> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/37f266312d66a6caa77b06ec00cbd08f> skos:altLabel """H. Familie""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/37f266312d66a6caa77b06ec00cbd08f> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0cbf2797cfbc4a5cf92696b800e43d77> skos:altLabel """H. Hart (De Wegel-Zwaantjes)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0cbf2797cfbc4a5cf92696b800e43d77> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9ede003314ceca5c3dacae11f3922283> skos:altLabel """O.-L.-Vrouw Geboorte""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9ede003314ceca5c3dacae11f3922283> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/deac23c4d21648f3f1f9f7762eff4e12> skos:altLabel """O.-L.-Vrouw Bezoeking (Meer)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/deac23c4d21648f3f1f9f7762eff4e12> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6cd5efbac29d5eec1f0794464ac3387c> skos:altLabel """Allerheiligste Verlosser (Meerle)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6cd5efbac29d5eec1f0794464ac3387c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4aea782f46397948eaa3b667177032c7> skos:altLabel """St.-Clemens (Minderhout)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4aea782f46397948eaa3b667177032c7> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c9142ee2b76cacb1e3f078864035a4d6> skos:altLabel """St.-Jan Evangelist (Begijnhof)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c9142ee2b76cacb1e3f078864035a4d6> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f3c5c5a8f37ac65702ff0746261d55d7> skos:altLabel """St.-Katharina""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f3c5c5a8f37ac65702ff0746261d55d7> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1cf672aa1766420b894dbd1d4e6ed776> skos:altLabel """St.-Jan Baptist (Wortel)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1cf672aa1766420b894dbd1d4e6ed776> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/015f1380535ad059d824465dddfc4072> skos:altLabel """St.-Jozef""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/015f1380535ad059d824465dddfc4072> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/edb8f5f4a77f3a1a9d7d4318425ffaf2> skos:altLabel """St.-Laurentius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/edb8f5f4a77f3a1a9d7d4318425ffaf2> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/78b17b7b9f41a8eb45479a283ee5507c> skos:altLabel """St.-Adriaan (Houtvenne)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/78b17b7b9f41a8eb45479a283ee5507c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6db3df6946040aa6c90a475020f01657> skos:altLabel """St.-Mattheus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6db3df6946040aa6c90a475020f01657> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9f89cc95fb431bbbd199a56a15f1bc89> skos:altLabel """St.-Michiel (Westmeerbeek)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9f89cc95fb431bbbd199a56a15f1bc89> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4765c8f45f038a58c919c9d39966b653> skos:altLabel """H. Hart (Heuvel)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4765c8f45f038a58c919c9d39966b653> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3ba3198d29af4fd2eb8286c08537e023> skos:altLabel """St.-Jozef (Heide)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3ba3198d29af4fd2eb8286c08537e023> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/35fe4582827b2c45204c1c5e3d6e6b88> skos:altLabel """O.-L.-Vrouw Bezoeking en van Bijstand (Achterbroek)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/35fe4582827b2c45204c1c5e3d6e6b88> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e7792bc4064af3f7b62e19d6324d64bc> skos:altLabel """O.-L.-Vrouw (Centrum)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e7792bc4064af3f7b62e19d6324d64bc> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a59522b75d860f48bcecf17cdc36cdcd> skos:altLabel """O.-L.-Vrouw ten Hemel Opgenomen (Nieuwmoer)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a59522b75d860f48bcecf17cdc36cdcd> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fc71af47c0fe655e5a77f76290ef9e18> skos:altLabel """St.-Jozef (Hoogboom)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fc71af47c0fe655e5a77f76290ef9e18> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3419e402555ada8afb1d687a2367106a> skos:altLabel """Onbevlekte Ontvangenis van Maria (Zilverenhoek)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3419e402555ada8afb1d687a2367106a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cdc9ed419484c78dcc5f30aa0dbda3df> skos:altLabel """St.-Dionysius (Putte)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cdc9ed419484c78dcc5f30aa0dbda3df> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ee3ca11ba9ddae99765b562943f841d1> skos:altLabel """St.-Jacob de Meerdere""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ee3ca11ba9ddae99765b562943f841d1> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/57c0785e80984ce21dd66e1f3934b50a> skos:altLabel """St.-Willibrordus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/57c0785e80984ce21dd66e1f3934b50a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/004399d3fe8de429aac8c0a91ffe71b6> skos:altLabel """St.-Margarita (Tielen)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/004399d3fe8de429aac8c0a91ffe71b6> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f14f53e391054cc5964e3a9e674f6042> skos:altLabel """O.-L.-Vrouw (Lichtaart)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f14f53e391054cc5964e3a9e674f6042> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/dc3c6a83d2119a16dc5b76a64e44953d> skos:altLabel """O.-L.-Vrouw Onbevlekt Ontvangen (Station-Kazerne)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/dc3c6a83d2119a16dc5b76a64e44953d> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4e495dce1eb25860310a9241fb889463> skos:altLabel """St.-Rita""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4e495dce1eb25860310a9241fb889463> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/af7c902d43933388aecdf27d2a4f81d9> skos:altLabel """St.-Michaël (Waarloos)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/af7c902d43933388aecdf27d2a4f81d9> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9ef98dda6165b3cd08da8fd568cda3c9> skos:altLabel """St.-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9ef98dda6165b3cd08da8fd568cda3c9> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c54217c7afa82334c80ef8e2a69d0423> skos:altLabel """St.-Lambertus (Eindhout)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c54217c7afa82334c80ef8e2a69d0423> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1cb46a4b3b5b074411701c20a060463a> skos:altLabel """O.-L.-Vrouw en St.-Jozef (Veerle)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1cb46a4b3b5b074411701c20a060463a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bda19bd051021cd04755b6645eeb1576> skos:altLabel """St.-Gertrudis (Vorst)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bda19bd051021cd04755b6645eeb1576> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/714f93ca6146ff7bc82d22a6e1c7608f> skos:altLabel """St.-Niklaas (Meerlaar)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/714f93ca6146ff7bc82d22a6e1c7608f> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/609659dc1dfc2636eb384512bb584bde> skos:altLabel """H. Familie""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/609659dc1dfc2636eb384512bb584bde> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c119ac0537b93e4c10452298b6efdff0> skos:altLabel """O.-L.-Vrouw Onbevlekt (Lachenen)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c119ac0537b93e4c10452298b6efdff0> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d66db9c7cb6b2f3e15c306b9df2b0f30> skos:altLabel """H. Hart""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d66db9c7cb6b2f3e15c306b9df2b0f30> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fd820f30157ba45271135784fe29aa65> skos:altLabel """H. Kruis (Karthuizers)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fd820f30157ba45271135784fe29aa65> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ca33dfe510518167b156bfca7f7c56b6> skos:altLabel """St.-Jan Evangelist (Koningshooikt)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ca33dfe510518167b156bfca7f7c56b6> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fc8c44ad9fca21fb12ca3e66565fb4a1> skos:altLabel """St.-Gummarus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fc8c44ad9fca21fb12ca3e66565fb4a1> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/58b84abe9a68e24a6cf1a91059686abc> skos:altLabel """SS. Jozef en Bernardus (Lisp)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/58b84abe9a68e24a6cf1a91059686abc> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7de6b46bcb3610bf7e333febee377f23> skos:altLabel """St.-Amelberga (Wechelderzande)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7de6b46bcb3610bf7e333febee377f23> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c558de4b7cd061a46c77186eb03fd88d> skos:altLabel """St.-Pieter""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c558de4b7cd061a46c77186eb03fd88d> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ff081226b11f3a1b19622b269e2ed826> skos:altLabel """O.-L.-Vrouw Geboorte (Gierle)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ff081226b11f3a1b19622b269e2ed826> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/69c32af4176163ec2cf316ae5485bc5f> skos:altLabel """St.-Jan Baptist (Poederlee)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/69c32af4176163ec2cf316ae5485bc5f> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a0012083d266ed0775f907c6982fbb78> skos:altLabel """O.-L.-Vrouw Geboorte""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a0012083d266ed0775f907c6982fbb78> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/892ad7697dc689a85e0578f598a1a5d7> skos:altLabel """St.-Laurentius (Oostmalle)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/892ad7697dc689a85e0578f598a1a5d7> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9b9cabfda7f81979da9df9805ac9d06b> skos:altLabel """St.-Martinus (Westmalle)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9b9cabfda7f81979da9df9805ac9d06b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/77d02012c76be2317185052ef583fb59> skos:altLabel """St.-Paulus (Westmalle)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/77d02012c76be2317185052ef583fb59> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e7e7064d8153fecefe97cc9eaef18051> skos:altLabel """St.-Bavo (Zittaart)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e7e7064d8153fecefe97cc9eaef18051> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/149465ddfad0d38279e6b0978040f3bf> skos:altLabel """O.-L.-Vrouw (Gestel)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/149465ddfad0d38279e6b0978040f3bf> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cbfaee5615249a5c2a376f8c2ad66ece> skos:altLabel """St.-Trudo""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cbfaee5615249a5c2a376f8c2ad66ece> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9f92cfc61deb74913f70d45e3f67b774> skos:altLabel """St.-Jozef (Berg)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9f92cfc61deb74913f70d45e3f67b774> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/31cb93220c231372a352b3001c2f14d8> skos:altLabel """H. Sacrament (Lambrechtshoeken)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/31cb93220c231372a352b3001c2f14d8> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d17cb9c3913b3bee99bf1cfbf2b84669> skos:altLabel """St.-Jozef""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d17cb9c3913b3bee99bf1cfbf2b84669> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6fc575d29964338687f7a6a02592f258> skos:altLabel """St.-Franciscus van Assisi""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6fc575d29964338687f7a6a02592f258> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f1dbb3c84dd466ef6c0a67d291af6e4f> skos:altLabel """St.-Bartholomeus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f1dbb3c84dd466ef6c0a67d291af6e4f> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/54df6920de879255db1c89cb161f7725> skos:altLabel """O.-L.-Vrouw van Smarten""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/54df6920de879255db1c89cb161f7725> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a0726dbc5afaba1c28852652ae021c3f> skos:altLabel """St.-Willibrordus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a0726dbc5afaba1c28852652ae021c3f> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6bf3789680299d387f7ee02900eb7db0> skos:altLabel """O.-L.-Vrouw Onbevlekt (Gompel)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6bf3789680299d387f7ee02900eb7db0> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1ca57b0e59f2b2bd7b1435ea5502b997> skos:altLabel """St.-Willibrordus (Ezaart)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1ca57b0e59f2b2bd7b1435ea5502b997> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/650f5b501636965a21996a22ad756bcc> skos:altLabel """St.-Odrada (Millegem)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/650f5b501636965a21996a22ad756bcc> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6cf00027d7307073add83ff3a8fb6e59> skos:altLabel """SS. Pieter en Pauwel""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6cf00027d7307073add83ff3a8fb6e59> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a65aca3e0c8072b81d6123845997a537> skos:altLabel """St.-Jozef (Wezel)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a65aca3e0c8072b81d6123845997a537> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/28e35401f47046c63a02e07b8bad1fe4> skos:altLabel """St.-Bernardus (Sluis)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/28e35401f47046c63a02e07b8bad1fe4> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7458a6506b2a6a89bbaa45d9ebdc335d> skos:altLabel """St.-Niklaas (Postel)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7458a6506b2a6a89bbaa45d9ebdc335d> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5c4e7db527c1b34c86c4756c6e0ffc0d> skos:altLabel """St.-Carolus Borromeus (Rauw)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5c4e7db527c1b34c86c4756c6e0ffc0d> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/44a8d4ef111691195b31d69ed476a4ad> skos:altLabel """St.-Benedictus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/44a8d4ef111691195b31d69ed476a4ad> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5352663c8c3d87977bf2aa0b0384dd5c> skos:altLabel """H. Bernadette""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5352663c8c3d87977bf2aa0b0384dd5c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/584a3e7cbf2728e78d5be25166762072> skos:altLabel """H. Kruis (Oude God)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/584a3e7cbf2728e78d5be25166762072> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0065bfddaf9a547aea1a414534a94475> skos:altLabel """St.-Jozef""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0065bfddaf9a547aea1a414534a94475> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b8965f166ec5d89fe78644673f206673> skos:altLabel """St.-Lodewijk (Station)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b8965f166ec5d89fe78644673f206673> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fbc35ac021271600c442e31e628050a1> skos:altLabel """O.-L.-Vrouw Geboorte""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fbc35ac021271600c442e31e628050a1> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/01ec2fa7bae7de8236de23673b9c7a63> skos:altLabel """O.-L.-Vrouw Koningin van de Vrede (Kessel-Station)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/01ec2fa7bae7de8236de23673b9c7a63> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7e80534e1b1c1b7b349ae6f5e37c4059> skos:altLabel """St.-Willibrordus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7e80534e1b1c1b7b349ae6f5e37c4059> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e806d9dba58a23afd8b9b5f0a706e60a> skos:altLabel """O.-L.-Vrouw""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e806d9dba58a23afd8b9b5f0a706e60a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2ffb2691514d2d4c5a6513749102f0b4> skos:altLabel """St.-Lambertus (Kessel)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2ffb2691514d2d4c5a6513749102f0b4> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/100cfb1668b71ea5b0165ab7d80eb9ea> skos:altLabel """O.-L.-Vrouw ten Hemel Opgenomen (Bevel)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/100cfb1668b71ea5b0165ab7d80eb9ea> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3643b7a1d05216546748777ee07b7d6e> skos:altLabel """St.-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3643b7a1d05216546748777ee07b7d6e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9c19e12671b674fc56b56d77a3dcf37d> skos:altLabel """St.-Bavo""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9c19e12671b674fc56b56d77a3dcf37d> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9962fc107d4120b0681e7a209b6a1ad6> skos:altLabel """St.-Antonius Abt (Oosthoven)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9962fc107d4120b0681e7a209b6a1ad6> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/198489f0e877c9e9532fef69c2a54367> skos:altLabel """Onbevlekt Hart van Maria Koningin der Wereld (Zwaneven)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/198489f0e877c9e9532fef69c2a54367> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/97d01350ec28eb321d1c12d8e7f5ac82> skos:altLabel """St.-Niklaas""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/97d01350ec28eb321d1c12d8e7f5ac82> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/664291a30886815979210fcf278caf6c> skos:altLabel """St.-Gerardus Majella (Grasheide)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/664291a30886815979210fcf278caf6c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0d6f1ec8b17b6bb708ffe6c8b77112a7> skos:altLabel """St.-Remigius (Beerzel)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0d6f1ec8b17b6bb708ffe6c8b77112a7> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d112b24e30528365a668f0f4d4a8f8db> skos:altLabel """St.-Jozef (Peulis)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d112b24e30528365a668f0f4d4a8f8db> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/81a9554334cc23d3976bd6c5f1015967> skos:altLabel """O.-L.-Vrouw Geboorte (Broechem)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/81a9554334cc23d3976bd6c5f1015967> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/55e38c9fca975db383dccfc875d17f24> skos:altLabel """St.-Pancratius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/55e38c9fca975db383dccfc875d17f24> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cebf35a3f2853e108f9e25ea75da3780> skos:altLabel """O.-L.-Vrouw ten Hemel Opgenomen (Oelegem)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cebf35a3f2853e108f9e25ea75da3780> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b94dd66239b3aff442b85cd832f94c7c> skos:altLabel """St.-Gummarus (Emblem)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b94dd66239b3aff442b85cd832f94c7c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b3835cfe1803e310b022d2a3c85abe56> skos:altLabel """St.-Jan Baptist (De Straat)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b3835cfe1803e310b022d2a3c85abe56> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cd87ac7554f47814d2f9b972d98a7662> skos:altLabel """St.-Michiel (Weelde)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cd87ac7554f47814d2f9b972d98a7662> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8fe7fbd6d53964a08f8b63fd77ee76ae> skos:altLabel """St.-Valentinus (Poppel)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8fe7fbd6d53964a08f8b63fd77ee76ae> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ef7374b5f6be12d1f4329d333fd7be53> skos:altLabel """St.-Adrianus (Eel)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ef7374b5f6be12d1f4329d333fd7be53> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4657e022bc06252905eb38df96fda358> skos:altLabel """St.-Servatius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4657e022bc06252905eb38df96fda358> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b1dbb9effdedef39bc4f0c8d96197cfd> skos:altLabel """O.-L.-Vrouw van de H. Rozenkrans (Weelde-Station)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b1dbb9effdedef39bc4f0c8d96197cfd> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c892b395c3d26d515af5b80ec8ecc6c3> skos:altLabel """St.-Job (Schoonbroek)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c892b395c3d26d515af5b80ec8ecc6c3> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/30a9f13f37c4f60d6b19c66bca6f16db> skos:altLabel """St.-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/30a9f13f37c4f60d6b19c66bca6f16db> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1774d01b94c0f7a8825a6d1470775cb1> skos:altLabel """St.-Willibrordus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1774d01b94c0f7a8825a6d1470775cb1> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/08ba76a60273bb344e0ed16d68b7c701> skos:altLabel """St.-Jozef""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/08ba76a60273bb344e0ed16d68b7c701> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f5e77144d8dbb09ddd8099b8549b778c> skos:altLabel """H. Familie (Vosberg)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f5e77144d8dbb09ddd8099b8549b778c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c7cdbb0fe12806f3e841658778f685ed> skos:altLabel """St.-Pieter""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c7cdbb0fe12806f3e841658778f685ed> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7fb0534fa94ba79d70ec6192313616e1> skos:altLabel """H. Maria Magdalena (Reet)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7fb0534fa94ba79d70ec6192313616e1> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/53d82660f0e55b75a953cce3cab77d6e> skos:altLabel """SS. Petrus en Paulus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/53d82660f0e55b75a953cce3cab77d6e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3c60eeab47e6acbd150a011d50fedf68> skos:altLabel """St.-Guibertus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3c60eeab47e6acbd150a011d50fedf68> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c64dfee83d317765935f7c75e30645a2> skos:altLabel """H. Familie""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c64dfee83d317765935f7c75e30645a2> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b60140401f076799700f17109b8cd59e> skos:altLabel """St.-Filippus (De Horst)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b60140401f076799700f17109b8cd59e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/026551a7d19807909f72cc0b96e4acf4> skos:altLabel """H. Hart (Deuzeld)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/026551a7d19807909f72cc0b96e4acf4> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b57ffa756e0603932ab4be0d7c9a529a> skos:altLabel """St.-Cordula (Centrum)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b57ffa756e0603932ab4be0d7c9a529a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/87317930a2c5cf060a1fffd65c60a248> skos:altLabel """O.-L.-Vrouw Koningin van Alle Heiligen (Koningshof-Berkenrode)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/87317930a2c5cf060a1fffd65c60a248> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/be35e96f4c3a8cfcde4bc7553c723d33> skos:altLabel """O.-L.-Vrouw Geboorte (Hoevenen)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/be35e96f4c3a8cfcde4bc7553c723d33> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6951e8e6ad692dec609a17cd27413de7> skos:altLabel """St.-Catharina""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6951e8e6ad692dec609a17cd27413de7> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2b871d9f7cf6bec8c2732a8901f23788> skos:altLabel """St.-Pieter""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2b871d9f7cf6bec8c2732a8901f23788> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ea6bba30a3240b39fbedf0b8e7468da4> skos:altLabel """O.-L.-Vrouw Middelares""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ea6bba30a3240b39fbedf0b8e7468da4> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7cda7075b19abd47ea524231732a8004> skos:altLabel """Pinksterkerk (Stokt)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7cda7075b19abd47ea524231732a8004> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5ae4245e6a2557dd34489ccae18e6914> skos:altLabel """Emmaüsparochie""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5ae4245e6a2557dd34489ccae18e6914> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/40d08394b75e7d0a84301016e2defc1b> skos:altLabel """Goddelijk Kind Jezus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/40d08394b75e7d0a84301016e2defc1b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ae42285f8293f9ca78efa9c4c7e2a36a> skos:altLabel """St.-Pieter""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ae42285f8293f9ca78efa9c4c7e2a36a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ad3c2bd1e1def7343b849e0607791b6a> skos:altLabel """O.-L.-Vrouw""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ad3c2bd1e1def7343b849e0607791b6a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/62b670ba7abbcf31cbd73204279af0f5> skos:altLabel """St.-Michiel (Oevel)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/62b670ba7abbcf31cbd73204279af0f5> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/94e27a69759cef20a50c16a8f7735f85> skos:altLabel """St.-Lambertus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/94e27a69759cef20a50c16a8f7735f85> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4dce1a2c5693de45fc75822e745aef19> skos:altLabel """St.-Carolus Borromeus (Heultje)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4dce1a2c5693de45fc75822e745aef19> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cdb82cf7a53921392dc3baa2abb91eb9> skos:altLabel """O.-L.-Vrouw ten Hemel Opgenomen (Voortkapel)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cdb82cf7a53921392dc3baa2abb91eb9> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4bcd124e0bfd2518d1ac0a4ee7d20d4e> skos:altLabel """St.-Niklaas (Zoerle-Parwijs)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4bcd124e0bfd2518d1ac0a4ee7d20d4e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/94f11ac0c528b02fd13eccea74b3d11e> skos:altLabel """St.-Anna (Tongerlo)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/94f11ac0c528b02fd13eccea74b3d11e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4364d28eacd6fd8a497bd4d7c0223f40> skos:altLabel """O.-L.-Vrouw Bezoeking (Oosterwijk)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4364d28eacd6fd8a497bd4d7c0223f40> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a7d2572807a67cd2efde77a06e428e28> skos:altLabel """O.-L.-Vrouw van de Bloeiende Wijngaard""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a7d2572807a67cd2efde77a06e428e28> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/667344c9af0f83632eb76596c2d7d2a5> skos:altLabel """St.-Bavo""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/667344c9af0f83632eb76596c2d7d2a5> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0d366ab0046dfa9b88f58c75a8309032> skos:altLabel """St.-Jan-Maria Vianney""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0d366ab0046dfa9b88f58c75a8309032> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d8f5d3ce9511da8d83b971e84f998058> skos:altLabel """St.-Jan Evangelist (Valaar)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d8f5d3ce9511da8d83b971e84f998058> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/caa6e03721eb86a52cea1aaacd385fb8> skos:altLabel """H. Pius X (Oosterveld)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/caa6e03721eb86a52cea1aaacd385fb8> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0a4ec20172225b704d2a7094d347317b> skos:altLabel """O.-L.-Vrouw Boodschap (Kandonklaar)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0a4ec20172225b704d2a7094d347317b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/34865ae16dc44f10ec58f06c695ccc8e> skos:altLabel """SS. Petrus en Paulus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/34865ae16dc44f10ec58f06c695ccc8e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/12bacaa7835a4b7b3a8647cfedca2731> skos:altLabel """O.-L.-Vrouw ten Hemel Opgenomen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/12bacaa7835a4b7b3a8647cfedca2731> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ad56faa974a3a1e65165b9d597f6dba1> skos:altLabel """SS. Pieter en Pauwel (Loenhout)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ad56faa974a3a1e65165b9d597f6dba1> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8f0ad348639c197a232b986b1771da44> skos:altLabel """St.-Jozef (Gooreind)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8f0ad348639c197a232b986b1771da44> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9556dbaee6bd57713f133493114e9529> skos:altLabel """St.-Willibrordus (Viersel)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9556dbaee6bd57713f133493114e9529> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c40b51380fabde48e6d9e4e958b79b7f> skos:altLabel """St.-Stefaan (Massenhoven)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c40b51380fabde48e6d9e4e958b79b7f> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0ff5e0763bf277b535506f8c9799b524> skos:altLabel """St.-Amelberga""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0ff5e0763bf277b535506f8c9799b524> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8665dff940b90959d3747f29f9923227> skos:altLabel """O.-L.-Vrouw ten Hemel Opgenomen (Pulderbos)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8665dff940b90959d3747f29f9923227> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d00446765cb419c06c29b07d6ec5ef9d> skos:altLabel """SS. Pieter en Pauwel (Pulle)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d00446765cb419c06c29b07d6ec5ef9d> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d6033485699112406ca2a034d5fd9c55> skos:altLabel """St.-Antonius Abt (Sint-Antonius)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d6033485699112406ca2a034d5fd9c55> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4e02eb4ca525e59456c53cc6fb67841c> skos:altLabel """St.-Elisabeth""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4e02eb4ca525e59456c53cc6fb67841c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/87763811081ef6c783a98717e651ce01> skos:altLabel """St.-Martinus (Halle)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/87763811081ef6c783a98717e651ce01> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0053710a21095585bee1bb9c7ab91ad1> skos:altLabel """O.L.V.-Hemelvaart""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0053710a21095585bee1bb9c7ab91ad1> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0094bb112c3d70cd40d6855df6b89110> skos:altLabel """Sint-Rita""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0094bb112c3d70cd40d6855df6b89110> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/00ec4ea8de5a933dab442fa99ef629b0> skos:altLabel """Sint-Donatianus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/00ec4ea8de5a933dab442fa99ef629b0> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0148de69ec91ad7e2f3238614bf36917> skos:altLabel """O.L.V-Hemelvaart""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0148de69ec91ad7e2f3238614bf36917> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/020aa46099c4049830cab05ec3165ed9> skos:altLabel """Sint-Vedastus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/020aa46099c4049830cab05ec3165ed9> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/02e74af66a2eee9ed87f0806b96c76ec> skos:altLabel """Sint-Bavo""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/02e74af66a2eee9ed87f0806b96c76ec> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/03302c79c985e66762f9a034c17f9c37> skos:altLabel """Sint-Walburga""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/03302c79c985e66762f9a034c17f9c37> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0599e0e145d9f531939a1f741e939c2f> skos:altLabel """Onze-Lieve-Vrouw""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0599e0e145d9f531939a1f741e939c2f> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/05a30bd9ef80fbea2e0b4d2bc3fc86e2> skos:altLabel """Sint-Pieter""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/05a30bd9ef80fbea2e0b4d2bc3fc86e2> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/05f98c8db61f94535e5dd7c8ebd7baec> skos:altLabel """O.L.V.-Hemelvaart""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/05f98c8db61f94535e5dd7c8ebd7baec> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/06019a00b8ba375500652f05dff2c9a0> skos:altLabel """Sint-Jacob-de-Meerdere""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/06019a00b8ba375500652f05dff2c9a0> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/06532f9691920d706600ff7f54cb0c58> skos:altLabel """Sint-Antonius van Padua""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/06532f9691920d706600ff7f54cb0c58> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0a6e94bc3a471f448688a016afe5d52f> skos:altLabel """Sint-Blasius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0a6e94bc3a471f448688a016afe5d52f> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0ba4e756d887c12474b75fbe0b6e9b31> skos:altLabel """Sint-Brixius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0ba4e756d887c12474b75fbe0b6e9b31> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0ba89544e73f170096f5657a00a3959f> skos:altLabel """Sint-Willibrordus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0ba89544e73f170096f5657a00a3959f> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0c93f7d1b8adc59bac482a75b0c8f7b1> skos:altLabel """Sint-Pieter""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0c93f7d1b8adc59bac482a75b0c8f7b1> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0cfc2efb3df3259f8b33e7ff391d2960> skos:altLabel """Sint-Jan ter Biezen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0cfc2efb3df3259f8b33e7ff391d2960> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0d1025307e21615ad6ae601a8690bdbe> skos:altLabel """Sint-Medardus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0d1025307e21615ad6ae601a8690bdbe> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0d160e603c9f12c8acf3860f570e3e44> skos:altLabel """Sint-Niklaas""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0d160e603c9f12c8acf3860f570e3e44> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0d63d32299e9cb098ab4adb7e323a0c1> skos:altLabel """Sint-Michiel""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0d63d32299e9cb098ab4adb7e323a0c1> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0e1debb10346a87ac258b3f15e90ac90> skos:altLabel """O.L.V.-Middelares""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0e1debb10346a87ac258b3f15e90ac90> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0e33e28461f6aaf4058c3eb8b9bf307a> skos:altLabel """Sint-Petrus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0e33e28461f6aaf4058c3eb8b9bf307a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0e45f3344317b2d8f07d8d30b18672b4> skos:altLabel """Sint-Stefanus en Sint-Theodoricus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0e45f3344317b2d8f07d8d30b18672b4> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0ea96cbab45f7572b01932aef142eb12> skos:altLabel """Sint-Victor""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0ea96cbab45f7572b01932aef142eb12> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0f8e331784fd73cb14e45c56edb4a1e7> skos:altLabel """Sint-Audomarus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0f8e331784fd73cb14e45c56edb4a1e7> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0fd84e598beec77012c21e1515643d6b> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0fd84e598beec77012c21e1515643d6b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1067988c4cee4e5ea2e3a299de6b54a2> skos:altLabel """Sint-Blasius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1067988c4cee4e5ea2e3a299de6b54a2> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/109b51647bf8c4801db1169ddf053032> skos:altLabel """Sint-Lambertus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/109b51647bf8c4801db1169ddf053032> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1235aa6284594365a86767df95429b70> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1235aa6284594365a86767df95429b70> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1376e96d930c8ae4b9e5c3b9e8eec58c> skos:altLabel """Sint-Eutropius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1376e96d930c8ae4b9e5c3b9e8eec58c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1388c83b14325d81be224a6bc1cd6590> skos:altLabel """Sint-Jan-Baptist""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1388c83b14325d81be224a6bc1cd6590> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/13c0eb83eb7e9930b55657aef1c6c73e> skos:altLabel """Sint-Amandus en Sint-Lucia""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/13c0eb83eb7e9930b55657aef1c6c73e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/13c1d57195390c147efd24b9f763e056> skos:altLabel """Onze-Lieve-Vrouw""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/13c1d57195390c147efd24b9f763e056> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/14318572033f0284b985ac4c686d9f92> skos:altLabel """Sint-Antonius en Sint-Rochus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/14318572033f0284b985ac4c686d9f92> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/147b7a11eab7ee5a4e357647f7378729> skos:altLabel """Sint-Gillis""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/147b7a11eab7ee5a4e357647f7378729> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1548a5e5985dbe6c5072795bcfb560f7> skos:altLabel """Sint-Niklaas""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1548a5e5985dbe6c5072795bcfb560f7> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/15c3063b3b2af7cff90996ef282ead20> skos:altLabel """Heilige Kruisverheffing""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/15c3063b3b2af7cff90996ef282ead20> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1819ded89f5464bf335c6ca90c66bd94> skos:altLabel """Sint-Rafaël""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1819ded89f5464bf335c6ca90c66bd94> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/189688fb7ce55774895e5c6c0d20154b> skos:altLabel """O.L.V. Onbevlekt Ontvangen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/189688fb7ce55774895e5c6c0d20154b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/18b2c164a341bc2b24405f5bbd4d0608> skos:altLabel """Sint-Jozef""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/18b2c164a341bc2b24405f5bbd4d0608> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1978c46294e65f6e3cb340c0f6742b4e> skos:altLabel """Sint-Vedastus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1978c46294e65f6e3cb340c0f6742b4e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1a45d17afc8a2daa605567be482601ce> skos:altLabel """Sint-Petrus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1a45d17afc8a2daa605567be482601ce> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1a645fa9e8e42b01eb54be0ec03dbe5f> skos:altLabel """Sint-Jozef""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1a645fa9e8e42b01eb54be0ec03dbe5f> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1bae8f6ff42422bb3671721d210c4ee8> skos:altLabel """Sint-Vedastus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1bae8f6ff42422bb3671721d210c4ee8> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1ca3b3372350cf044549046e531173b8> skos:altLabel """Sint-Laurentius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1ca3b3372350cf044549046e531173b8> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1cb4309bdcdc24cecfd36ecc0ab0563e> skos:altLabel """Sint-Antonius Abt""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1cb4309bdcdc24cecfd36ecc0ab0563e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1d3f812843e9dfa39f51d4c3fa6035e8> skos:altLabel """Sint-Henricus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1d3f812843e9dfa39f51d4c3fa6035e8> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/212ccbe390948748303bcefd8548eae0> skos:altLabel """Sint-Dionysius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/212ccbe390948748303bcefd8548eae0> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/21957342262e8accee574dd177b9c231> skos:altLabel """Sint-Anna""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/21957342262e8accee574dd177b9c231> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/23073a8215df00ce8d15e70798694097> skos:altLabel """Sint-Petrus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/23073a8215df00ce8d15e70798694097> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/23da1f56877f849fe400a507a7fbfd52> skos:altLabel """Sint-Dionysius en Sint-Genesius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/23da1f56877f849fe400a507a7fbfd52> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/24af352aa399bcc034c3136c56e89c1f> skos:altLabel """O.L.V. Onbevlekt Ontvangen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/24af352aa399bcc034c3136c56e89c1f> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/24c16b1fed4199b126709fa5ccbc001d> skos:altLabel """Sint-Michiel""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/24c16b1fed4199b126709fa5ccbc001d> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/264268c7d72d3f56aed9f123b1f5e35f> skos:altLabel """Sint-Petrus en Sint-Paulus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/264268c7d72d3f56aed9f123b1f5e35f> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/288473d9927747d9c61dbeac5efebf44> skos:altLabel """Sint-Pharaïldis""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/288473d9927747d9c61dbeac5efebf44> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/29058f752cce3e7b501989ff93d7e5ea> skos:altLabel """Sint-Katharina""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/29058f752cce3e7b501989ff93d7e5ea> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2a235a50e8db0c332fc1fd525e91a4fd> skos:altLabel """Sint-Jan Onthoofding""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2a235a50e8db0c332fc1fd525e91a4fd> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2b904e3d1917f80a6c53efc32970b9da> skos:altLabel """Sint-Pieters-in-de-banden""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2b904e3d1917f80a6c53efc32970b9da> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2c51fe3a09cef1e923a0e21ced5f1051> skos:altLabel """Heilig Hart van Jezus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2c51fe3a09cef1e923a0e21ced5f1051> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2d0e86890c05ddd7be2a3622b2994265> skos:altLabel """Sint-Rictrudis""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2d0e86890c05ddd7be2a3622b2994265> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2e14b0a599a05565950be1153d850c0e> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2e14b0a599a05565950be1153d850c0e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2fee0b05787eb427ff1c7c6bdbbc5253> skos:altLabel """Sint-Andreas""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2fee0b05787eb427ff1c7c6bdbbc5253> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/30e0597bcec328a18de0eb98374ba69d> skos:altLabel """Sint-Eligius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/30e0597bcec328a18de0eb98374ba69d> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/30e33fc5235621e65771bbca4f5d7859> skos:altLabel """Onze-Lieve-Vrouw""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/30e33fc5235621e65771bbca4f5d7859> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3169781944e61987c0d2f49225442f19> skos:altLabel """Sint-Petrus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3169781944e61987c0d2f49225442f19> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/32f53934d03917b0e8e3a21aae38d4d0> skos:altLabel """Sint-Eligius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/32f53934d03917b0e8e3a21aae38d4d0> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3382ff3ee26a0d04d0976d883ca63fb5> skos:altLabel """Sint-Petrus en Sint-Catharina""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3382ff3ee26a0d04d0976d883ca63fb5> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/33bb6fb1c9ba13b7687febfec423f7c2> skos:altLabel """Sint-Eligius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/33bb6fb1c9ba13b7687febfec423f7c2> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/33ffc683442a68ff0c2d4419947906c9> skos:altLabel """Sint-Bartholomeus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/33ffc683442a68ff0c2d4419947906c9> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/35a3ea29d38861b7d779cfdf206431e5> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/35a3ea29d38861b7d779cfdf206431e5> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/35aad3c690c7dd23651173540bd90dcd> skos:altLabel """Sint-Pieter""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/35aad3c690c7dd23651173540bd90dcd> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/35ce811f8341f41def0ce41832869153> skos:altLabel """Sint-Hilonius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/35ce811f8341f41def0ce41832869153> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/37167cf1cc6b0de56369bf09fa2442a6> skos:altLabel """Heilige Familie""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/37167cf1cc6b0de56369bf09fa2442a6> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/37b666c0ca3d425672dcf5ad72efe977> skos:altLabel """Sint-Godelieve""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/37b666c0ca3d425672dcf5ad72efe977> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/37e9ab15f50dd974275756dbb19d779a> skos:altLabel """Sint-Eligius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/37e9ab15f50dd974275756dbb19d779a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/389c6845201d1245fac9d769d6e43c5d> skos:altLabel """O.L.V.-Hemelvaart""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/389c6845201d1245fac9d769d6e43c5d> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/392610edd9a76e0e8c0cb2cba35bd6ac> skos:altLabel """Sint-Amandus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/392610edd9a76e0e8c0cb2cba35bd6ac> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/39797382a1e831b4bf669dca2788dfac> skos:altLabel """Sint-Margareta""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/39797382a1e831b4bf669dca2788dfac> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3a7a8b3ae6b8344341966a6ff915ff99> skos:altLabel """Sint-Petrus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3a7a8b3ae6b8344341966a6ff915ff99> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3b4564cf2c3617e4e889fe9a3c03fcf9> skos:altLabel """O.L.V.-ter-Duinen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3b4564cf2c3617e4e889fe9a3c03fcf9> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3e79ca72f40a9a9e913fae54b9f721b2> skos:altLabel """Sint-Anna""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3e79ca72f40a9a9e913fae54b9f721b2> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3ed47566faa76daac62f8798a2074af2> skos:altLabel """Sint-Jozef""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3ed47566faa76daac62f8798a2074af2> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3f4c6dfcae740753f1f0feca080e629c> skos:altLabel """Sint-Audomarus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3f4c6dfcae740753f1f0feca080e629c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3fae30539d958f1d28255c558fbbfdc1> skos:altLabel """Heilige Monica""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3fae30539d958f1d28255c558fbbfdc1> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/41234908330097633331c3a49ccef1b9> skos:altLabel """Sint-Katharina""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/41234908330097633331c3a49ccef1b9> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/42512354698a92364840b5b386bae8b0> skos:altLabel """Sint-Amandus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/42512354698a92364840b5b386bae8b0> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4371b728e5280826368fd6c912a02cc2> skos:altLabel """Sint-Jozef en Karel de Goede""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4371b728e5280826368fd6c912a02cc2> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/439d6d52e8a74d310d535b80c0091a09> skos:altLabel """Onze-Lieve-Vrouw en Sint-Stefanus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/439d6d52e8a74d310d535b80c0091a09> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/43db43010890e2aa0408b46814f5c724> skos:altLabel """Sint-Dionysius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/43db43010890e2aa0408b46814f5c724> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/446ab2d351913948556e40b9819dae62> skos:altLabel """Onze-Lieve-Vrouw""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/446ab2d351913948556e40b9819dae62> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/44e0a7165bed4fc4996dde6e374b47c9> skos:altLabel """Sint-Salvator""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/44e0a7165bed4fc4996dde6e374b47c9> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/46b1d3b08dc7c9eb936f6c0851b60e7b> skos:altLabel """Sint-Juliaan""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/46b1d3b08dc7c9eb936f6c0851b60e7b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/46cf42710d1bc2635c5c51928bb72e21> skos:altLabel """Sint-Laurentius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/46cf42710d1bc2635c5c51928bb72e21> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4807d585b12686c55ea368bc66d6974a> skos:altLabel """Sint-Michiel""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4807d585b12686c55ea368bc66d6974a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4811db81442292628f5eb79abfbdcd5d> skos:altLabel """Sint-Eligius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4811db81442292628f5eb79abfbdcd5d> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4846d98d34ae1cb06ec2e8a1b1877537> skos:altLabel """Sint-Pieter""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4846d98d34ae1cb06ec2e8a1b1877537> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/48ccf9ca9284d36a0a8999ecd6595d35> skos:altLabel """Sint-Georgius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/48ccf9ca9284d36a0a8999ecd6595d35> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/48f3ddc52cdf7f75e8a2d6998c7c2c2e> skos:altLabel """Sint-Audomarus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/48f3ddc52cdf7f75e8a2d6998c7c2c2e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/495af6cc73269e2a679d72459e8f8182> skos:altLabel """Sint-Andreas""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/495af6cc73269e2a679d72459e8f8182> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/49b272d6a8e34a143a580f28744747ed> skos:altLabel """Sint-Bavo""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/49b272d6a8e34a143a580f28744747ed> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4a7e935c2dae9e5369de150a18483b8a> skos:altLabel """O.L.V.-Geboorte""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4a7e935c2dae9e5369de150a18483b8a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4b9dbfcdaddf1f3f33d8f537f94019ed> skos:altLabel """Sint-Rictrudis""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4b9dbfcdaddf1f3f33d8f537f94019ed> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4bbba7bffaf2e121d45bf458bbf91ae7> skos:altLabel """Sint-Rita""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4bbba7bffaf2e121d45bf458bbf91ae7> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4c4906d7d875b6070cf7b9c2fa2633e9> skos:altLabel """Sint-Jozef""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4c4906d7d875b6070cf7b9c2fa2633e9> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4d12914ca8edd4819fdef61c08661bbd> skos:altLabel """Sint-Jacob""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4d12914ca8edd4819fdef61c08661bbd> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4deb4a58e8ea70f1c9daf874b75cee57> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4deb4a58e8ea70f1c9daf874b75cee57> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4f462ff54b82b63a18212d3089b25a88> skos:altLabel """Heilige Magdalena en Heilige Catharina""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4f462ff54b82b63a18212d3089b25a88> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/507f577e12f5459199727ec377adc757> skos:altLabel """Sint-Petrus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/507f577e12f5459199727ec377adc757> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/50e9d00f6d77883e9ff1ac4b1f9179aa> skos:altLabel """Heilige Familie""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/50e9d00f6d77883e9ff1ac4b1f9179aa> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/510ebd4e649fd4d16dcf7e324a22496f> skos:altLabel """Sint-Jan-Baptist""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/510ebd4e649fd4d16dcf7e324a22496f> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/52a69a4ffd013bfd7ca08372c9b40aac> skos:altLabel """Onze-Lieve-Vrouw""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/52a69a4ffd013bfd7ca08372c9b40aac> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5357ebc715336c37d407b27c0cc8f16f> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5357ebc715336c37d407b27c0cc8f16f> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/548707185a7212e24d859bc14404efea> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/548707185a7212e24d859bc14404efea> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/54fb85f488e3fa5af28a34c29d6e980b> skos:altLabel """Sint-Catharina""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/54fb85f488e3fa5af28a34c29d6e980b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/551002305fbabfd1ba7922614059e010> skos:altLabel """Heilige Pastoor van Ars""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/551002305fbabfd1ba7922614059e010> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5556f03ea5b97a40fad0ad13ec0e2adb> skos:altLabel """Onbevlekt Hart van Maria""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5556f03ea5b97a40fad0ad13ec0e2adb> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/559106ac796830d769370ce5a67f9137> skos:altLabel """Sint-Jan-Baptist""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/559106ac796830d769370ce5a67f9137> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/563a12fe828b47585a79780fa7bb0e2e> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/563a12fe828b47585a79780fa7bb0e2e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/57156d8d9dd8066cdb598f7c2fbdf577> skos:altLabel """Sint-Quintinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/57156d8d9dd8066cdb598f7c2fbdf577> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/579e47b7c00beeb50009275ba6787f32> skos:altLabel """Sint-Antonius Abt""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/579e47b7c00beeb50009275ba6787f32> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/57a45189d3317e284dc0b50256eb445f> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/57a45189d3317e284dc0b50256eb445f> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/581339561847fa49364b325343c5a3b8> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/581339561847fa49364b325343c5a3b8> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/58fd7f3ef20d549ef6ec1127aafd0368> skos:altLabel """Sint-Audomarus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/58fd7f3ef20d549ef6ec1127aafd0368> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/596f0ac4b2dca19954bb68002271193b> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/596f0ac4b2dca19954bb68002271193b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5acd1d54f5b131014940efd4db2b6f02> skos:altLabel """Sint-Machutus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5acd1d54f5b131014940efd4db2b6f02> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5c27fdd84e9400f92b121dc00bbda10d> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5c27fdd84e9400f92b121dc00bbda10d> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5d1920ea41bdd9aa37b7e37f05ea73a4> skos:altLabel """Sint-Amandus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5d1920ea41bdd9aa37b7e37f05ea73a4> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5d1cbad66ff811dc2e1f595c6a5eb7d1> skos:altLabel """Sint-Maria Bernarda""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5d1cbad66ff811dc2e1f595c6a5eb7d1> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5ea79952d3a57432b65164662fd424d8> skos:altLabel """Sint-Petrus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5ea79952d3a57432b65164662fd424d8> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6078bb679c39d0fbf6eefe466eeadb8c> skos:altLabel """Sint-Andries en Sint-Anna""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6078bb679c39d0fbf6eefe466eeadb8c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6168683fe3fb5c01e0b2a403b58842a3> skos:altLabel """Sint-Blasius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6168683fe3fb5c01e0b2a403b58842a3> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6315ca377a95b37913078619d94d0590> skos:altLabel """Sint-Margareta""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6315ca377a95b37913078619d94d0590> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/639ccf4e751e209598973192432e9d74> skos:altLabel """Sint-Kristoffel""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/639ccf4e751e209598973192432e9d74> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/645655742996a3eed7908b8f3e232864> skos:altLabel """Sint-Baafs""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/645655742996a3eed7908b8f3e232864> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/64dcd5e9b8cda2be33b6298c911cc964> skos:altLabel """Heilig Hart""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/64dcd5e9b8cda2be33b6298c911cc964> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/650bb73fdff250d69e4c3b6282d9e9cf> skos:altLabel """Sint-Idesbald""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/650bb73fdff250d69e4c3b6282d9e9cf> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/65747d40c3ce422ee4b5bee365ba225c> skos:altLabel """O.L.V.-ten-Hemelopneming""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/65747d40c3ce422ee4b5bee365ba225c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/66bccfffbaa31a0d88547bee99f3abfb> skos:altLabel """O.L.V. Bezoeking""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/66bccfffbaa31a0d88547bee99f3abfb> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/67443b33fa7f4741b398767e3eb56b00> skos:altLabel """Sint-Willibrordus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/67443b33fa7f4741b398767e3eb56b00> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6789efd82f3d34c0bbd5387e5c1db08c> skos:altLabel """Sint-Jozef Arbeider""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6789efd82f3d34c0bbd5387e5c1db08c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/67cf50699f395aa18b9743824061fa2f> skos:altLabel """Sint-Jan-Baptist en Sint-Eligius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/67cf50699f395aa18b9743824061fa2f> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/68438b1d5f92249a1761620683a2becd> skos:altLabel """O.L.V.-Geboorte""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/68438b1d5f92249a1761620683a2becd> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/693553f08cf725893688ee11aa715440> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/693553f08cf725893688ee11aa715440> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/69e3f24709b6cb13765b6199d138aab1> skos:altLabel """Sint-Vincentius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/69e3f24709b6cb13765b6199d138aab1> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6a3088d13ec5c4994f42d20246c3f57f> skos:altLabel """Sint-Theresia""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6a3088d13ec5c4994f42d20246c3f57f> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6a8c5c5609c13260f52cec3fa3775ccc> skos:altLabel """Sint-Petrus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6a8c5c5609c13260f52cec3fa3775ccc> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6b9147d21435d18e7bab25f928681e86> skos:altLabel """Sint-Michiel""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6b9147d21435d18e7bab25f928681e86> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6be19cd353c3165efca0bbd0b2ce0938> skos:altLabel """Heilig Hart""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6be19cd353c3165efca0bbd0b2ce0938> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6ca6c1be31265fe4243cbb0776083a2f> skos:altLabel """Onze-Lieve-Vrouw""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6ca6c1be31265fe4243cbb0776083a2f> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6d1c6409f4e69c98b81629b017fd3e6c> skos:altLabel """Sint-Jan-Baptist""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6d1c6409f4e69c98b81629b017fd3e6c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6d8f1dad89c107185532380723283a75> skos:altLabel """Sint-Jan-Baptist""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6d8f1dad89c107185532380723283a75> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6fef0f5b8dc7e8af42b2f35d19507779> skos:altLabel """Sint-Jozef""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6fef0f5b8dc7e8af42b2f35d19507779> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/711d25b5ab21a2443dbf99b5465917b1> skos:altLabel """Sint-Niklaas""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/711d25b5ab21a2443dbf99b5465917b1> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/726b3772f46b9bec14afb636a21d6c76> skos:altLabel """O.L.V.-ten-Hemel-Opgenomen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/726b3772f46b9bec14afb636a21d6c76> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7288380ba54311d8150eb6d8f813743f> skos:altLabel """Sint-Michiel""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7288380ba54311d8150eb6d8f813743f> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/74ebe68b4976b65429e50e8f103ba9a8> skos:altLabel """Onze-Lieve-Vrouw""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/74ebe68b4976b65429e50e8f103ba9a8> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/755cbe5f41ce372300c574638136cf80> skos:altLabel """Onze-Lieve-Vrouw""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/755cbe5f41ce372300c574638136cf80> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/76d8ad170f8bd45e6cb7bb88ba90b9a9> skos:altLabel """Sint-Laurentius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/76d8ad170f8bd45e6cb7bb88ba90b9a9> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/776d796e7d8792076d74590709692e87> skos:altLabel """Onbevlekt Hart van Maria en Sint-Margaretha""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/776d796e7d8792076d74590709692e87> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/77980043691a6bf1432d1839eba478c1> skos:altLabel """Christus Koning""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/77980043691a6bf1432d1839eba478c1> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/78fac071f2ab4686f8aff76b84ed0b13> skos:altLabel """Sint-Bernardus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/78fac071f2ab4686f8aff76b84ed0b13> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7a11b0db7ac9cfb28d7b1ea310ff5b35> skos:altLabel """Sint-Jacob-de-Meerdere""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7a11b0db7ac9cfb28d7b1ea310ff5b35> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7c10ef04cd04cf4fac0967219ef0cd0b> skos:altLabel """Onze-Lieve-Vrouw""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7c10ef04cd04cf4fac0967219ef0cd0b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7c23f9c91bc0e790b3898a7c31ecfc0c> skos:altLabel """Sint-Leo de Grote""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7c23f9c91bc0e790b3898a7c31ecfc0c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7c67ec53cc3e96f3b9673a6e74b2115c> skos:altLabel """Sint-Amandus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7c67ec53cc3e96f3b9673a6e74b2115c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7d1599f762f4f02b8af609d6a2d0ad7b> skos:altLabel """Sint-Laurentius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7d1599f762f4f02b8af609d6a2d0ad7b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7e5dcac73b5679ae3e2a281f40789f5c> skos:altLabel """Onze-Lieve-Vrouw""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7e5dcac73b5679ae3e2a281f40789f5c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7ed34673716bcd198e619c60ff1aa319> skos:altLabel """Sint-Godelieve""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7ed34673716bcd198e619c60ff1aa319> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7fe5b98cbd69cfd07ab74e7973792f8f> skos:altLabel """Sint-Jan-Baptist""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7fe5b98cbd69cfd07ab74e7973792f8f> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8181a693464834168a5839d3a48bf83e> skos:altLabel """Sint-Amandus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8181a693464834168a5839d3a48bf83e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/826dc062d5f837ca4c6b2ef12d97a3b1> skos:altLabel """O.L.V.-Madonna""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/826dc062d5f837ca4c6b2ef12d97a3b1> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8314e8f775d7b2783745e976927100fa> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8314e8f775d7b2783745e976927100fa> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8421901f5a9a0df0827954861a7ee3a2> skos:altLabel """Sint-Eligius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8421901f5a9a0df0827954861a7ee3a2> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/84350381311d302de9f348fc4ee2813a> skos:altLabel """Heilig Hart""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/84350381311d302de9f348fc4ee2813a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/848125abb7ce38aa968de376fb2e4012> skos:altLabel """Onze-Lieve-Vrouw""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/848125abb7ce38aa968de376fb2e4012> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/849e6246ad220528db6cfc61acb57eaf> skos:altLabel """Sint-Elisabeth""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/849e6246ad220528db6cfc61acb57eaf> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8603d1bd14793c510d9b433581c64c33> skos:altLabel """Heilige Godelieve""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8603d1bd14793c510d9b433581c64c33> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/86d91bcc6cd18c2ce4c85bdfcda8d579> skos:altLabel """Sint-Eligius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/86d91bcc6cd18c2ce4c85bdfcda8d579> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/87d6ba1f0622462017e10a0d4130016a> skos:altLabel """Sint-Germanus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/87d6ba1f0622462017e10a0d4130016a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/88b5ff86330eceeefc906cfd88654d5c> skos:altLabel """O.L.V.-Hemelvaart""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/88b5ff86330eceeefc906cfd88654d5c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8935e5a7c77d958c92651fde6b2814dd> skos:altLabel """Sint-Bavo""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8935e5a7c77d958c92651fde6b2814dd> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/89cf081ee7ea22f48639d793dfd6aff3> skos:altLabel """Sint-Henricus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/89cf081ee7ea22f48639d793dfd6aff3> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8a50be298f4e5869be771734b4e21765> skos:altLabel """Sint-Jan-Baptist""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8a50be298f4e5869be771734b4e21765> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8bfb49883a81550c448bb5bddbb0d111> skos:altLabel """Sint-Jacob-de-Meerdere""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8bfb49883a81550c448bb5bddbb0d111> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8c2b662b66abeb1dcca0ed7488932864> skos:altLabel """Sint-Antonius van Padua""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8c2b662b66abeb1dcca0ed7488932864> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8d30d6b5831653256923fc36280a1883> skos:altLabel """Christus Koning""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8d30d6b5831653256923fc36280a1883> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8e562fe4e8fa6b7fd1f13c7af8e2467e> skos:altLabel """Sint-Laurentius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8e562fe4e8fa6b7fd1f13c7af8e2467e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/903b64c21dded0abf76590f1449aed52> skos:altLabel """Sint-Brixius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/903b64c21dded0abf76590f1449aed52> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/91bdc39afe8c0d8497c89bd9fe55bfae> skos:altLabel """Sint-Amandus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/91bdc39afe8c0d8497c89bd9fe55bfae> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/920e347f8a8c0b17594f07300ffea1ce> skos:altLabel """Heilige Pius X""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/920e347f8a8c0b17594f07300ffea1ce> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/92e00e72ade4a7a46dd0a957a206ac81> skos:altLabel """Sint-Arnoldus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/92e00e72ade4a7a46dd0a957a206ac81> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/937165883950cad23a3f448294a3a64e> skos:altLabel """Sint-Andreas""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/937165883950cad23a3f448294a3a64e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/93846709d469e6cd3037e259de4f3499> skos:altLabel """O.L.V.-Geboorte""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/93846709d469e6cd3037e259de4f3499> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/93ac27e4cbb2bf7b1d2a6ace53f7e268> skos:altLabel """Sint-Jan-Baptist""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/93ac27e4cbb2bf7b1d2a6ace53f7e268> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/956f77d3f02b1beb2486760da0e91a6e> skos:altLabel """Heilige Theresia""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/956f77d3f02b1beb2486760da0e91a6e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/958d6dc3da0fe33a1a0b28ef20220c37> skos:altLabel """Sint-Pieter""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/958d6dc3da0fe33a1a0b28ef20220c37> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/96e3c35f1fea6baa2a50300bdbbf72a1> skos:altLabel """Sint-Niklaas""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/96e3c35f1fea6baa2a50300bdbbf72a1> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9701c36d0ab4439c7df6ae5a96bce4e7> skos:altLabel """Sint-Pietersbanden""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9701c36d0ab4439c7df6ae5a96bce4e7> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/974f87c6b0377993b4368f50bd7629df> skos:altLabel """O.L.V. Onbevlekt Ontvangen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/974f87c6b0377993b4368f50bd7629df> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/97f3e7e34c0efc158c211169339bed6b> skos:altLabel """Sint-Aldegondis""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/97f3e7e34c0efc158c211169339bed6b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9a3e2cb2a1c204b490f64b9b310ec452> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9a3e2cb2a1c204b490f64b9b310ec452> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9a9a1f8e502755e6376f0c88e4ba0d25> skos:altLabel """O.L.V.-Hemelvaart""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9a9a1f8e502755e6376f0c88e4ba0d25> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9bdab3d744a72f705fdaccdf7dd0c5c6> skos:altLabel """Sint-Petrus en Sint-Paulus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9bdab3d744a72f705fdaccdf7dd0c5c6> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9c18ed7af90c26f2e3f973909d92879e> skos:altLabel """Sint-Audomarus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9c18ed7af90c26f2e3f973909d92879e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9c25ea3d93638b47a915abc24f4bfd7a> skos:altLabel """Heilige Drievuldigheid en Sint-Christianus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9c25ea3d93638b47a915abc24f4bfd7a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9e3b45dc710574f49eb1aa21840220d3> skos:altLabel """Sint-Eligius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9e3b45dc710574f49eb1aa21840220d3> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9ee03b91948008cf52862129e9113476> skos:altLabel """Sint-Amandus en Sint-Blasius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9ee03b91948008cf52862129e9113476> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9ee63c93a2ce3bd4261e5f5cc0d76734> skos:altLabel """Sint-Augustinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9ee63c93a2ce3bd4261e5f5cc0d76734> skos:prefLabel ?prefLabel .
+  }
+}

--- a/config/migrations/2024/20240718152515-worship-services-legal-names.sparql
+++ b/config/migrations/2024/20240718152515-worship-services-legal-names.sparql
@@ -1,0 +1,996 @@
+PREFIX regorg: <http://www.w3.org/ns/regorg#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a7164f51e0e68820b9d2d4d53aaf48f9> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a7164f51e0e68820b9d2d4d53aaf48f9> regorg:legalName """Anglicaanse Kerkfabriek Saint John""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a7164f51e0e68820b9d2d4d53aaf48f9> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a57ce399c9020f6f1a3f976c2510976e> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a57ce399c9020f6f1a3f976c2510976e> regorg:legalName """Anglicaanse Kerkfabriek Sint-Bonifacius""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a57ce399c9020f6f1a3f976c2510976e> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cb69c277a4021bf71a8c7cacc22bd9bc> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cb69c277a4021bf71a8c7cacc22bd9bc> regorg:legalName """Anglicaanse Kerkfabriek te Oostende""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cb69c277a4021bf71a8c7cacc22bd9bc> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a596850e9aa27969a25f73137d300306> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a596850e9aa27969a25f73137d300306> regorg:legalName """The Anglican Chaplaincy of Saint Paul's Church""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a596850e9aa27969a25f73137d300306> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/42adfc9a7b2cfa0e6ead719da03406b5> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/42adfc9a7b2cfa0e6ead719da03406b5> regorg:legalName """Anglicaanse Kerkfabriek Saint George""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/42adfc9a7b2cfa0e6ead719da03406b5> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/46b8da1347c6bcab415ad53a1b94da26> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/46b8da1347c6bcab415ad53a1b94da26> regorg:legalName """Anglicaanse Kerkfabriek Saint George te Knokke""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/46b8da1347c6bcab415ad53a1b94da26> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e2eea8a352821c9c1f1827f1cfde9f24> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e2eea8a352821c9c1f1827f1cfde9f24> regorg:legalName """Anglicaanse Kerkfabriek Saint Martha and Mary's""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e2eea8a352821c9c1f1827f1cfde9f24> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/24ff08070bc1e47b498ab8139b9d3792> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/24ff08070bc1e47b498ab8139b9d3792> regorg:legalName """Heusden-Zolder Selimiye Camii""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/24ff08070bc1e47b498ab8139b9d3792> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7b0d877894765abf5052e12c7bed553e> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7b0d877894765abf5052e12c7bed553e> regorg:legalName """Beraat""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7b0d877894765abf5052e12c7bed553e> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a8faa182c59167da7551f40979dc5022> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a8faa182c59167da7551f40979dc5022> regorg:legalName """Yavuz Sultan Selim""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a8faa182c59167da7551f40979dc5022> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/db46915e77fbf8f083e9861c802b2b13> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/db46915e77fbf8f083e9861c802b2b13> regorg:legalName """Mehmet Akif""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/db46915e77fbf8f083e9861c802b2b13> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4fd6da5f1e1ea6e60f611abc4df28456> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4fd6da5f1e1ea6e60f611abc4df28456> regorg:legalName """Culturele en Islamitische Vereniging Badr""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4fd6da5f1e1ea6e60f611abc4df28456> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/619a5721094b28807dca8d04de69e3e0> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/619a5721094b28807dca8d04de69e3e0> regorg:legalName """Yunus Emre""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/619a5721094b28807dca8d04de69e3e0> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7e3fb673922f9495c48251f316c5c4ff> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7e3fb673922f9495c48251f316c5c4ff> regorg:legalName """Yesil Camii""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7e3fb673922f9495c48251f316c5c4ff> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/adeaab8a02815bf2c5816165a45ad4c5> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/adeaab8a02815bf2c5816165a45ad4c5> regorg:legalName """Sultan Ahmet""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/adeaab8a02815bf2c5816165a45ad4c5> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c1c334a2cc56ac501badce5e879aec65> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c1c334a2cc56ac501badce5e879aec65> regorg:legalName """Hicret Camii""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c1c334a2cc56ac501badce5e879aec65> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c7d6827eb88cd977146e72583461071b> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c7d6827eb88cd977146e72583461071b> regorg:legalName """Ensar""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c7d6827eb88cd977146e72583461071b> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ca0daee18a29e187017bf236e26f1ec2> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ca0daee18a29e187017bf236e26f1ec2> regorg:legalName """Marokkaanse Islamitische en Culturele Vereniging Winterslag Hassan Ebno Tabit""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ca0daee18a29e187017bf236e26f1ec2> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f95b761af55091b491fd62bd6bed11dc> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f95b761af55091b491fd62bd6bed11dc> regorg:legalName """Al Ihsaan""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f95b761af55091b491fd62bd6bed11dc> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b540096ac8be2c9c72dafd59e61080c5> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b540096ac8be2c9c72dafd59e61080c5> regorg:legalName """Tevhid Camii""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b540096ac8be2c9c72dafd59e61080c5> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0f2a4604a962926d67518bb3846af1c9> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0f2a4604a962926d67518bb3846af1c9> regorg:legalName """Yildirim Beyazit Camii""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0f2a4604a962926d67518bb3846af1c9> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/58d6bea16bd86c7df65caa9625af97aa> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/58d6bea16bd86c7df65caa9625af97aa> regorg:legalName """Mevlana Camii""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/58d6bea16bd86c7df65caa9625af97aa> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a6e0531c6c4b5885552604163cfabfbc> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a6e0531c6c4b5885552604163cfabfbc> regorg:legalName """Selimiye Camii""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a6e0531c6c4b5885552604163cfabfbc> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a8880f3d8b482788c5f3adbf58f01b4f> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a8880f3d8b482788c5f3adbf58f01b4f> regorg:legalName """Al Mouhsinine""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a8880f3d8b482788c5f3adbf58f01b4f> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ef77bb3094fdc4a7ed7e09551500acfe> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ef77bb3094fdc4a7ed7e09551500acfe> regorg:legalName """Attaqwa""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ef77bb3094fdc4a7ed7e09551500acfe> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8c46fc84fb7a11cca44bde007a0c081c> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8c46fc84fb7a11cca44bde007a0c081c> regorg:legalName """Innerlijke Vrede""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8c46fc84fb7a11cca44bde007a0c081c> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/928335b5a7b1cb7850c7cc98574e9ec9> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/928335b5a7b1cb7850c7cc98574e9ec9> regorg:legalName """Fatih Moskee""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/928335b5a7b1cb7850c7cc98574e9ec9> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/934cb872a84a86ceb9a9e10abb1d08fa> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/934cb872a84a86ceb9a9e10abb1d08fa> regorg:legalName """Barmhartig""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/934cb872a84a86ceb9a9e10abb1d08fa> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fd4ae252fffca29852354b12ef37b086> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fd4ae252fffca29852354b12ef37b086> regorg:legalName """Assounah""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fd4ae252fffca29852354b12ef37b086> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a8d9f1a45c11c6761306bdf680349593> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a8d9f1a45c11c6761306bdf680349593> regorg:legalName """Ensarija""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a8d9f1a45c11c6761306bdf680349593> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/62B968EDD7779543F777954A> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/62B968EDD7779543F777954A> regorg:legalName """Tauhid""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/62B968EDD7779543F777954A> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/62C427EBD7779543F777959E> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/62C427EBD7779543F777959E> regorg:legalName """El Mouslimine""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/62C427EBD7779543F777959E> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/104a6b6eabd0192afdeb70d3b517aef1> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/104a6b6eabd0192afdeb70d3b517aef1> regorg:legalName """Kevser Moskee""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/104a6b6eabd0192afdeb70d3b517aef1> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b798c1a0e56ace342d225a503dcc384c> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b798c1a0e56ace342d225a503dcc384c> regorg:legalName """Moeder Gods, Troosteres der Bedroefden""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b798c1a0e56ace342d225a503dcc384c> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6c16ba36223ff4e2dd0e76036a0b0d50> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6c16ba36223ff4e2dd0e76036a0b0d50> regorg:legalName """Heilige Barbara""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6c16ba36223ff4e2dd0e76036a0b0d50> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9daaa2917a374a55e3d8ba100bf329e5> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9daaa2917a374a55e3d8ba100bf329e5> regorg:legalName """Heilige Dimitrios""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9daaa2917a374a55e3d8ba100bf329e5> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e0e7121368dfc45d9a809a1a36b65e32> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e0e7121368dfc45d9a809a1a36b65e32> regorg:legalName """Heiligen Konstantijn en Helena""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e0e7121368dfc45d9a809a1a36b65e32> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/eecb5159c45e6e9fa263d6d697f3b446> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/eecb5159c45e6e9fa263d6d697f3b446> regorg:legalName """Heilige Amandus""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/eecb5159c45e6e9fa263d6d697f3b446> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/064d0956f36a54c27e9d93828a34f538> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/064d0956f36a54c27e9d93828a34f538> regorg:legalName """Maria Boodschap""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/064d0956f36a54c27e9d93828a34f538> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1808db0b0ef2934850e3dde50db08f6b> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1808db0b0ef2934850e3dde50db08f6b> regorg:legalName """Heilige Nectarios""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1808db0b0ef2934850e3dde50db08f6b> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/39090eb31b28e111e47e75dc38eaff42> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/39090eb31b28e111e47e75dc38eaff42> regorg:legalName """De Geboorte van Moeder Gods""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/39090eb31b28e111e47e75dc38eaff42> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bb00c66671c9bf05025876eb749d2a02> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bb00c66671c9bf05025876eb749d2a02> regorg:legalName """Heilige Apostel Andreas""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bb00c66671c9bf05025876eb749d2a02> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c821b81409bd4c56b8eb9e32ce09a841> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c821b81409bd4c56b8eb9e32ce09a841> regorg:legalName """Oekraïns-orthodoxe parochie""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c821b81409bd4c56b8eb9e32ce09a841> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c85d82dfc9fcf2ab5857bb9891a6c447> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c85d82dfc9fcf2ab5857bb9891a6c447> regorg:legalName """Orthodoxe parochie Heilige Apostel en Evangelist Mattheos""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c85d82dfc9fcf2ab5857bb9891a6c447> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6b860cbdc90a8952bdd14b707817225e> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6b860cbdc90a8952bdd14b707817225e> regorg:legalName """HH. Kyrillos en Methodios""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6b860cbdc90a8952bdd14b707817225e> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a76be3cc51350736372b1cb61f5a8245> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a76be3cc51350736372b1cb61f5a8245> regorg:legalName """HH. Drie Hiërarchen""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a76be3cc51350736372b1cb61f5a8245> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bba84f42c09cd7c8b2e5a9829a820cf5> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bba84f42c09cd7c8b2e5a9829a820cf5> regorg:legalName """Heilige Johannes de Theoloog""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bba84f42c09cd7c8b2e5a9829a820cf5> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/43fb31ca870d9c3ea47d02f153c8be6f> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/43fb31ca870d9c3ea47d02f153c8be6f> regorg:legalName """Heilige Apostel Andreas en Heilige Materne""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/43fb31ca870d9c3ea47d02f153c8be6f> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/62C40176D7779543F7779593> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/62C40176D7779543F7779593> regorg:legalName """Orthodoxe Parochie Heiligen Georgios en Alena""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/62C40176D7779543F7779593> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/62C584C5D7779543F77795CA> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/62C584C5D7779543F77795CA> regorg:legalName """Orthodoxe Parochie H. Georgios Turnhout""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/62C584C5D7779543F77795CA> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ccc351e0430689ca49e09d77cd074a5d> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ccc351e0430689ca49e09d77cd074a5d> regorg:legalName """Christus' Geboorte""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ccc351e0430689ca49e09d77cd074a5d> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/20667054581bba972a5968d2d47b5ed4> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/20667054581bba972a5968d2d47b5ed4> regorg:legalName """Christelijk Gereformeerde kerk""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/20667054581bba972a5968d2d47b5ed4> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/580873b83ab874b95711ec2db3ca1717> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/580873b83ab874b95711ec2db3ca1717> regorg:legalName """Christengemeente Ichtus""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/580873b83ab874b95711ec2db3ca1717> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e2f5b8e0224b1af556165508195ccb76> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e2f5b8e0224b1af556165508195ccb76> regorg:legalName """Evangelische Christengemeente Houthalen""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e2f5b8e0224b1af556165508195ccb76> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1b8737e8a8870c5edaee0f9edf72a881> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1b8737e8a8870c5edaee0f9edf72a881> regorg:legalName """Evangelische Christengemeente Berchem""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1b8737e8a8870c5edaee0f9edf72a881> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1ddd00f077b747579a58189a2151c05c> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1ddd00f077b747579a58189a2151c05c> regorg:legalName """Philadelphia""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1ddd00f077b747579a58189a2151c05c> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/25364ce478850ac57891a6ea8b4125d6> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/25364ce478850ac57891a6ea8b4125d6> regorg:legalName """Deutschsprachige Evangelische Gemeinde Provinz Antwerpen""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/25364ce478850ac57891a6ea8b4125d6> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/58dfa349109d8725d9b7fb54adfed721> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/58dfa349109d8725d9b7fb54adfed721> regorg:legalName """Evangelische Kerk Leuven""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/58dfa349109d8725d9b7fb54adfed721> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/77fd7b2aeb6bcb3f7d80db6e25a98e41> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/77fd7b2aeb6bcb3f7d80db6e25a98e41> regorg:legalName """De Shelter""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/77fd7b2aeb6bcb3f7d80db6e25a98e41> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7a705f8e2b9cf99d192cd1b1619b3e42> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7a705f8e2b9cf99d192cd1b1619b3e42> regorg:legalName """Pinkstergemeente De Kruispoort""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7a705f8e2b9cf99d192cd1b1619b3e42> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c2740896a4a3c80c7967ddca52887829> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c2740896a4a3c80c7967ddca52887829> regorg:legalName """De Hoeksteen""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c2740896a4a3c80c7967ddca52887829> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e046f7d370958c8822e2bfa241851774> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e046f7d370958c8822e2bfa241851774> regorg:legalName """Bethel""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e046f7d370958c8822e2bfa241851774> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f0acc5869aa714bf445fb29fc0d26c1b> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f0acc5869aa714bf445fb29fc0d26c1b> regorg:legalName """Evangelische Christengemeente Beringen""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f0acc5869aa714bf445fb29fc0d26c1b> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/110aa9cc86de3760f583a9c31b5add39> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/110aa9cc86de3760f583a9c31b5add39> regorg:legalName """Evangelische kerk Bourgoyen""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/110aa9cc86de3760f583a9c31b5add39> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/44329be9ac7054b39adbc583b6203ba2> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/44329be9ac7054b39adbc583b6203ba2> regorg:legalName """Christengemeente Emmanuel""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/44329be9ac7054b39adbc583b6203ba2> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/be87d5a9a250eee7232772dc99401b86> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/be87d5a9a250eee7232772dc99401b86> regorg:legalName """Vrije evangelische Gemeente De Burg""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/be87d5a9a250eee7232772dc99401b86> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c13018155cfdffc26169eae78f1a300d> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c13018155cfdffc26169eae78f1a300d> regorg:legalName """Evangelische gemeente Paulus""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c13018155cfdffc26169eae78f1a300d> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e004568673ac1db1cb3d9c158c520a48> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e004568673ac1db1cb3d9c158c520a48> regorg:legalName """Gereformeerd Kerkcentrum Kerk aan de Leie""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e004568673ac1db1cb3d9c158c520a48> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/622EFE7FB72F9F4B33507E89> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/622EFE7FB72F9F4B33507E89> regorg:legalName """Evangelische Kerk Bilzen""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/622EFE7FB72F9F4B33507E89> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/62C550A8D7779543F77795BF> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/62C550A8D7779543F77795BF> regorg:legalName """Evangelische Gemeente de Pottenbakker""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/62C550A8D7779543F77795BF> regorg:legalName ?existingLegalName .
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f99035f2eca9a50996e719c445d2cfd2> regorg:legalName ?existingLegalName .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f99035f2eca9a50996e719c445d2cfd2> regorg:legalName """Evangelische Kerk Kortrijk Wijkkerk Mariadorp""" .
+  }
+} WHERE {
+   GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f99035f2eca9a50996e719c445d2cfd2> regorg:legalName ?existingLegalName .
+  }
+}

--- a/config/migrations/2024/20240718152516-worship-services-alternative-names-part2.sparql
+++ b/config/migrations/2024/20240718152516-worship-services-alternative-names-part2.sparql
@@ -1,0 +1,8232 @@
+PREFIX regorg: <http://www.w3.org/ns/regorg#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9fb7f2fff70389b493c47fbf11fc632d> skos:altLabel """Sint-Niklaas""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9fb7f2fff70389b493c47fbf11fc632d> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a128f10ca020d7e91137c7e4915eed07> skos:altLabel """Sint-Carolus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a128f10ca020d7e91137c7e4915eed07> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a39d3311bb70e91a02cb10e812293c2e> skos:altLabel """Sint-Medardus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a39d3311bb70e91a02cb10e812293c2e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a77966ced39835a184e10a9c5c24e1a5> skos:altLabel """Sint-Blasius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a77966ced39835a184e10a9c5c24e1a5> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a7dd9e9a0626f083814a195fa658fb5b> skos:altLabel """Sint-Amandus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a7dd9e9a0626f083814a195fa658fb5b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a801e9268b0e45a86453715d6c42fa4f> skos:altLabel """Heilig Hart en Sint-Philippus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a801e9268b0e45a86453715d6c42fa4f> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a9923d7ed997305660beb72fe54782be> skos:altLabel """Sint-Amandus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a9923d7ed997305660beb72fe54782be> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ab60bbfb56d556ce293752647fc5fcf2> skos:altLabel """Sint-Dionysius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ab60bbfb56d556ce293752647fc5fcf2> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/abb5eef2fb6e91dd92460d46147d2925> skos:altLabel """Sint-Jacob""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/abb5eef2fb6e91dd92460d46147d2925> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ac3448216bf4c1300ab6e55ac2c3830b> skos:altLabel """Sint-Niklaas""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ac3448216bf4c1300ab6e55ac2c3830b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ac933f0ccb8e112e4c0fc1fb1912c616> skos:altLabel """Onze-Lieve-Vrouw""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ac933f0ccb8e112e4c0fc1fb1912c616> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/af23cde6ebdf269f1a61307ee130162c> skos:altLabel """Sint-Antonius Abt""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/af23cde6ebdf269f1a61307ee130162c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/aff24ca9294ccd9466d573412a476a4d> skos:altLabel """Sint-Jan-Baptist""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/aff24ca9294ccd9466d573412a476a4d> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b0c5d59938f36cec3d55637b7e741b9d> skos:altLabel """Sint-Katharina""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b0c5d59938f36cec3d55637b7e741b9d> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b13e4d98791a7f411608e510ead8d9ea> skos:altLabel """Sint-Bertinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b13e4d98791a7f411608e510ead8d9ea> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b19b7eafd5c4f029dfa14d4f242865c0> skos:altLabel """Sint-Pieter""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b19b7eafd5c4f029dfa14d4f242865c0> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b44af1efbe9c6fcfa4dd362944b98491> skos:altLabel """Heilig Hart van Jezus en Heilige Amandus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b44af1efbe9c6fcfa4dd362944b98491> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b4901c887f26de267c82a6fd9e21bc83> skos:altLabel """Sint-Jan-Baptist""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b4901c887f26de267c82a6fd9e21bc83> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b492a271d5d54853bb4167f7b4602525> skos:altLabel """Sint-Theresia van het Kind Jezus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b492a271d5d54853bb4167f7b4602525> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b4fd5d52f0bb2f0ffc000e3ff1fb0972> skos:altLabel """Sint-Jozef""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b4fd5d52f0bb2f0ffc000e3ff1fb0972> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b67ae7c5e0767dd5d49c017a752ce058> skos:altLabel """Sint-Maarten""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b67ae7c5e0767dd5d49c017a752ce058> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b6d4aea4b0551b1ad0cbd871a45a2fc6> skos:altLabel """Sint-Laurentius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b6d4aea4b0551b1ad0cbd871a45a2fc6> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b856c306c300c48168c49edb129a71f2> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b856c306c300c48168c49edb129a71f2> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b8f1cc9eb7b06a52f81bb1ef1789be0d> skos:altLabel """Sint-Elooi""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b8f1cc9eb7b06a52f81bb1ef1789be0d> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b93b2739c74f7773abd0999fb8d1fb94> skos:altLabel """Sint-Bartholomeus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b93b2739c74f7773abd0999fb8d1fb94> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b94eb41c3da921f4b1008952130a9736> skos:altLabel """Sint-Martinus en Sint-Christoffel""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b94eb41c3da921f4b1008952130a9736> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b9e3f89fd37ef79fdcaaba81980fc655> skos:altLabel """Sint-Rochus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b9e3f89fd37ef79fdcaaba81980fc655> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ba189b11580a62b1e1d6f8fcd02a8b19> skos:altLabel """Sint-Clemens""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ba189b11580a62b1e1d6f8fcd02a8b19> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ba21d4b543f5c7f8be3cc8f463e52606> skos:altLabel """Sint-Jozef""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ba21d4b543f5c7f8be3cc8f463e52606> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ba3a8383bbc08d643a88343ea9683360> skos:altLabel """Heilig Hart""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ba3a8383bbc08d643a88343ea9683360> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bb459fe1d98298dc6be0543f57503363> skos:altLabel """Sint-Columba""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bb459fe1d98298dc6be0543f57503363> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bca7c39e000eab63afbc376c52904bfb> skos:altLabel """Sint-Pieter""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bca7c39e000eab63afbc376c52904bfb> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bcd49d3a065fbabbf5ae3578472845a5> skos:altLabel """Don Bosco""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bcd49d3a065fbabbf5ae3578472845a5> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bdc3018b175127817b5a8ebd3bcf64aa> skos:altLabel """Heilige Kruisverheffing""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bdc3018b175127817b5a8ebd3bcf64aa> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bdc4e393b299ea78aca679b0bfe4aaca> skos:altLabel """Sint-Bavo""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bdc4e393b299ea78aca679b0bfe4aaca> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/be04ff996c76ef54b741524b82c9ad8a> skos:altLabel """O.L.V. Bezoeking en Sint-Leo""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/be04ff996c76ef54b741524b82c9ad8a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bec0f99ce1841b779f44cc1e24bc0705> skos:altLabel """Sint-Jan""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bec0f99ce1841b779f44cc1e24bc0705> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c22a1685ea55d3a3f8f99b01bf4687bd> skos:altLabel """Sint-Niklaas""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c22a1685ea55d3a3f8f99b01bf4687bd> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c234ffe886761261cb4c6429778420f6> skos:altLabel """Sint-Cornelius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c234ffe886761261cb4c6429778420f6> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c27a79eba6a6f9857e543cb412d5184e> skos:altLabel """Sint-Bavo en Sint-Machutus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c27a79eba6a6f9857e543cb412d5184e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c305b24e8b43f9335632379293f0d865> skos:altLabel """Sint-Leonardus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c305b24e8b43f9335632379293f0d865> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c306556ee0718969b922e31bdf7094b8> skos:altLabel """Sint-Paulus' Bekering""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c306556ee0718969b922e31bdf7094b8> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c31e9c501f9d520f93e10e9af4aca07c> skos:altLabel """Sint-Walburga""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c31e9c501f9d520f93e10e9af4aca07c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c395119a8f6e44e8564706ce7a727fa3> skos:altLabel """Sint-Andreas""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c395119a8f6e44e8564706ce7a727fa3> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c48de2f1364525fa1ec004b5bf5f7268> skos:altLabel """Sint-Michiel""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c48de2f1364525fa1ec004b5bf5f7268> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c492732d9fa005442b42b3e6dc3659d3> skos:altLabel """Sint-Michiel""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c492732d9fa005442b42b3e6dc3659d3> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c53ede212eaa802091df94cb8ab1cb1a> skos:altLabel """O.L.V.-ten-Hemel-Opgenomen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c53ede212eaa802091df94cb8ab1cb1a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c54f2d635622d467882b4e0d6cfeb8cd> skos:altLabel """Onze-Lieve-Vrouw""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c54f2d635622d467882b4e0d6cfeb8cd> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c570e98b621028c9422dc1d44dedb85e> skos:altLabel """Sint-Cornelius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c570e98b621028c9422dc1d44dedb85e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c5bb17eedf321a339004604c1f6b4d3c> skos:altLabel """Sint-Jan-Baptist""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c5bb17eedf321a339004604c1f6b4d3c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c5f24e78e6ba3eb028bbc03e87f269f8> skos:altLabel """Sint-Georgius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c5f24e78e6ba3eb028bbc03e87f269f8> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c6e6624fe5c881114d65c326fc624b8c> skos:altLabel """Sint-Bartholomeus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c6e6624fe5c881114d65c326fc624b8c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c8ab08b36a0a418d417bcae3131a32bd> skos:altLabel """Sint-Joannes Evangelist""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c8ab08b36a0a418d417bcae3131a32bd> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c99085763c2443814a190fc68654d028> skos:altLabel """Sint-Medardus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c99085763c2443814a190fc68654d028> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c9e0402f15849734d2f37d9db660a531> skos:altLabel """Sint-Laurentius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c9e0402f15849734d2f37d9db660a531> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c9e898bbc31acf9f4cf06fb383375be9> skos:altLabel """Sint-Michiel""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c9e898bbc31acf9f4cf06fb383375be9> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/caef27fbf604b4c6a9d2d48b18ec00dd> skos:altLabel """Sint-Bartholomeus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/caef27fbf604b4c6a9d2d48b18ec00dd> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cb0d458312e7349d992cb36f34bceeb2> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cb0d458312e7349d992cb36f34bceeb2> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cc7810daf93e77abcc546b40514d4f41> skos:altLabel """O.L.V. Bezoeking""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cc7810daf93e77abcc546b40514d4f41> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cd7538a8473dd5ddda8c6390ef8cedcb> skos:altLabel """Sint-Hadrianus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cd7538a8473dd5ddda8c6390ef8cedcb> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cdf8d491a586a892f895259fda976b16> skos:altLabel """Sint-Lambertus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cdf8d491a586a892f895259fda976b16> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cfbb3a0372b7dec118a6311808af41b0> skos:altLabel """Heilige Maagd der Armen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cfbb3a0372b7dec118a6311808af41b0> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d02f50badeac0eeccd2e5ce93d5dc35e> skos:altLabel """O.L.V.-Hemelvaart""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d02f50badeac0eeccd2e5ce93d5dc35e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d0dd56917af505bcf48bd0dce8d7a18f> skos:altLabel """Sint-Jozef""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d0dd56917af505bcf48bd0dce8d7a18f> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d1c53f2d1d0d31be9120a0bcc450bfa1> skos:altLabel """Sint-Hilarius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d1c53f2d1d0d31be9120a0bcc450bfa1> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d2c1980fd1a8c4508595269789f7f097> skos:altLabel """Sint-Amandus en Sint-Anna""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d2c1980fd1a8c4508595269789f7f097> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d32e6524422c2dd26c8236e71b90c489> skos:altLabel """Sint-Jozef""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d32e6524422c2dd26c8236e71b90c489> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d41083708c24b43933fba3265e9ce26a> skos:altLabel """Onze-Lieve-Vrouw""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d41083708c24b43933fba3265e9ce26a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d5b3f7a14cc49fb5e4a418193dce7d29> skos:altLabel """Sint-Bertinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d5b3f7a14cc49fb5e4a418193dce7d29> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d7ebcebeeba6e74428cbf3a8af03ff01> skos:altLabel """Sint-Audomarus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d7ebcebeeba6e74428cbf3a8af03ff01> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d85693f86223681c1f21d578f809611f> skos:altLabel """Sint-Niklaas""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d85693f86223681c1f21d578f809611f> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d8f3c990408720ee99fc7eb5674b78bd> skos:altLabel """Sint-Niklaas""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d8f3c990408720ee99fc7eb5674b78bd> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d91cb9db3f434f044d90b7a559b97861> skos:altLabel """Heilige Maria Moeder Gods""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d91cb9db3f434f044d90b7a559b97861> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d94dd10878bf92f6f61287b720b43314> skos:altLabel """Sint-Eligius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d94dd10878bf92f6f61287b720b43314> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d95e08c1ba04dcb21311146d42795fb8> skos:altLabel """Sint-Gerdrudis""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d95e08c1ba04dcb21311146d42795fb8> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/da14d244afbe02e8fe1797bc05b3669c> skos:altLabel """Heilige Mauritius en Gezellen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/da14d244afbe02e8fe1797bc05b3669c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/db7e19cf170860e6f4b18c3e95f4b9c7> skos:altLabel """Onze-Lieve-Vrouw""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/db7e19cf170860e6f4b18c3e95f4b9c7> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/dc47384b603b7ea80d32a96b0b7a2b2d> skos:altLabel """Sint-Antonius Abt""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/dc47384b603b7ea80d32a96b0b7a2b2d> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/dcec31bbdd541860e9fd7c20e00f94e0> skos:altLabel """Sint-Blasius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/dcec31bbdd541860e9fd7c20e00f94e0> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/dcecfbf01d3ed0fcfe6923f9395287b3> skos:altLabel """Onze-Lieve-Vrouw""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/dcecfbf01d3ed0fcfe6923f9395287b3> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ddf937983f29c871fd4355faa7115e78> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ddf937983f29c871fd4355faa7115e78> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/de755efedb17580f04c44db7da14f85a> skos:altLabel """Sint-Salvator, de verrezen Zaligmaker en Sint-Donatianus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/de755efedb17580f04c44db7da14f85a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/de8c4b2664edd0ffbd1ef4cbe71eb11c> skos:altLabel """Sint-Jan-Baptist""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/de8c4b2664edd0ffbd1ef4cbe71eb11c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/dfddaf36f2fa089a879604fbb8cbbb27> skos:altLabel """Sint-Jan Onthoofding""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/dfddaf36f2fa089a879604fbb8cbbb27> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e011527170a53e5cd54ef1675039924d> skos:altLabel """Sint-Wandregesilus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e011527170a53e5cd54ef1675039924d> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e036a2098284965b3ec68f89b7185f52> skos:altLabel """Sint-Amandus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e036a2098284965b3ec68f89b7185f52> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e03cced6dff9b3daff20cb75eca94a73> skos:altLabel """Sint-Audomarus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e03cced6dff9b3daff20cb75eca94a73> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e14bf2effe2c22111e7819bfa2f1cd2f> skos:altLabel """O.L.V.-Geboorte en Sint-Eligius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e14bf2effe2c22111e7819bfa2f1cd2f> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e1bf7cf5bf8bd93dc9300ebe73bb307e> skos:altLabel """Sint-Bavo""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e1bf7cf5bf8bd93dc9300ebe73bb307e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e24c33ec7f77d8f9bbbd25f05f2b38a5> skos:altLabel """Sint-Jan-Baptist""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e24c33ec7f77d8f9bbbd25f05f2b38a5> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e5bb7efabd273e3ac977626b556a2e41> skos:altLabel """Sint-Petrus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e5bb7efabd273e3ac977626b556a2e41> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e6037f8a13cf226d6e3a9ed83a76d5a6> skos:altLabel """Sint-Amandus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e6037f8a13cf226d6e3a9ed83a76d5a6> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e621a052dd9e439a9b9e6e7dc244019a> skos:altLabel """Sint-Godelieve""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e621a052dd9e439a9b9e6e7dc244019a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e7425a6dc305ff4fdf621a3aadc3a2b5> skos:altLabel """Sint-Jozef""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e7425a6dc305ff4fdf621a3aadc3a2b5> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e895819ee3a67d55d49ca3031393503a> skos:altLabel """Sint-Niklaas""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e895819ee3a67d55d49ca3031393503a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e9e29c2c5e4f1509735103ba480bcd39> skos:altLabel """Onze-Lieve-Vrouw""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e9e29c2c5e4f1509735103ba480bcd39> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/eb63515eef41144bb6b81eb62602f382> skos:altLabel """Sint-Pieter""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/eb63515eef41144bb6b81eb62602f382> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/eb72491a0637df3c1048ac252efdf3e6> skos:altLabel """Sint-Franciscus van Assisië""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/eb72491a0637df3c1048ac252efdf3e6> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ecd7219c116e835b61f2be25091e0326> skos:altLabel """Heilige Kruisverheffing en Sint-Jozef""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ecd7219c116e835b61f2be25091e0326> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ed49efcd1dd6ec85e7ac6d15b91fbde5> skos:altLabel """Onze-Lieve-Vrouw en Sint-Audomarus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ed49efcd1dd6ec85e7ac6d15b91fbde5> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ed7580346df360ec121e50a7011aba73> skos:altLabel """Sint-Mattheus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ed7580346df360ec121e50a7011aba73> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ee4847da0f01fda029c91c24c3ce36cf> skos:altLabel """Sint-Georgius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ee4847da0f01fda029c91c24c3ce36cf> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/eed5332cdb5663a194222db4e7bbf2f9> skos:altLabel """Sint-Amatus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/eed5332cdb5663a194222db4e7bbf2f9> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/efab5de3a06236d592c805fb9c6e6d87> skos:altLabel """Sint-Niklaas""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/efab5de3a06236d592c805fb9c6e6d87> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f24ce478c0b353ef4749b96c3e96fd66> skos:altLabel """Sint-Amandus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f24ce478c0b353ef4749b96c3e96fd66> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f25101584651f42573f14b240cd43634> skos:altLabel """Onze-Lieve-Vrouw""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f25101584651f42573f14b240cd43634> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f3cf77a0f00512a1a5e598f941115cd8> skos:altLabel """Sint-Barnabas""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f3cf77a0f00512a1a5e598f941115cd8> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f43fb470cc6158bd2dfce793ad56ef5a> skos:altLabel """Sint-Rikier""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f43fb470cc6158bd2dfce793ad56ef5a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f47d89744239c0e1048204c87eb8dadb> skos:altLabel """Sint-Jacobus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f47d89744239c0e1048204c87eb8dadb> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f6abb1831e284ee3d413fde8fbc341c6> skos:altLabel """Sint-Niklaas en Sint-Katharina""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f6abb1831e284ee3d413fde8fbc341c6> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f6d3cfadf7b82395634d5a510b31b057> skos:altLabel """Sint-Amand""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f6d3cfadf7b82395634d5a510b31b057> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f74fa5d69c2871e524358626de1fa813> skos:altLabel """Sint-Jozef Werkman""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f74fa5d69c2871e524358626de1fa813> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f84d8508028767175d71398e935d4628> skos:altLabel """Sint-Bavo""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f84d8508028767175d71398e935d4628> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f98fac3b5fe94535e57fbefe193dad77> skos:altLabel """Sint-Petrus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f98fac3b5fe94535e57fbefe193dad77> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f9aae71bf255f6b735209478faca4d46> skos:altLabel """Sint-Thomas van Kantelberg""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f9aae71bf255f6b735209478faca4d46> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fa52b01f1e5affb3b443986f0cf1890e> skos:altLabel """Sint-Maarten en Sint-Niklaas""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fa52b01f1e5affb3b443986f0cf1890e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fbe67ec55786dd621def948ebca9e8be> skos:altLabel """Sint-Mildreda""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fbe67ec55786dd621def948ebca9e8be> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fc442ebb2e9e37e16eadc0bfbc30ed90> skos:altLabel """Sint-Jan-Baptist""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fc442ebb2e9e37e16eadc0bfbc30ed90> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fc449366fbb0990e1863521531dc6601> skos:altLabel """Sint-Petrus en Sint-Paulus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fc449366fbb0990e1863521531dc6601> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fc98b4ddca514a3a9ee79abcb2677183> skos:altLabel """Sint-Vedastus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fc98b4ddca514a3a9ee79abcb2677183> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fce045bbe35ed65aa9ac4269f015925b> skos:altLabel """Onze-Lieve-Vrouw""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fce045bbe35ed65aa9ac4269f015925b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fcf2fc7afbfcfac27474b67c99e9b515> skos:altLabel """Sint-Jan-Baptist""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fcf2fc7afbfcfac27474b67c99e9b515> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ff367e819ca3a97745e6dbca1da03d3c> skos:altLabel """Onze-Lieve-Vrouw""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ff367e819ca3a97745e6dbca1da03d3c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ff7671121a06d5920b65ee0638377cc3> skos:altLabel """Heilige Kruisverheffing""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ff7671121a06d5920b65ee0638377cc3> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/002246edbb2285c211aa256a5550b20c> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/002246edbb2285c211aa256a5550b20c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/00b825fd5853836076e60ebd7393e23a> skos:altLabel """Sint-Jozef""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/00b825fd5853836076e60ebd7393e23a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/00dc9abcdbf695f914fc06122d59207c> skos:altLabel """Sint-Gengulphus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/00dc9abcdbf695f914fc06122d59207c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/01126550b7c06154bc72d5d78623fef0> skos:altLabel """Sint-Christoffel""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/01126550b7c06154bc72d5d78623fef0> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/01ba42c33d9c244eea85b065820f31c9> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/01ba42c33d9c244eea85b065820f31c9> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/021d3f5ebae73837543dde4e5f177c16> skos:altLabel """Sint-Jacobus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/021d3f5ebae73837543dde4e5f177c16> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/02874c5681ecd10615c3fa52559e9cf8> skos:altLabel """Heilig Kruis""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/02874c5681ecd10615c3fa52559e9cf8> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/02914967bde245774bde552493794c47> skos:altLabel """Sint-Amandus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/02914967bde245774bde552493794c47> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/05446098762bae61d487a901bc2a1777> skos:altLabel """Sint-Aldegondis""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/05446098762bae61d487a901bc2a1777> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/05dcda29a574f702aeb451c73e4a358d> skos:altLabel """Onze-Lieve-Vrouw Onbevlekt Ontvangen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/05dcda29a574f702aeb451c73e4a358d> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/05f0cefcce12574628392423ed4a3f7a> skos:altLabel """Onze-Lieve-Vrouw""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/05f0cefcce12574628392423ed4a3f7a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/06c79b8f8678ff98bcc3216c3eca812b> skos:altLabel """Sint-Pietersbuiten""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/06c79b8f8678ff98bcc3216c3eca812b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/085d113cf099e0682741237409639f69> skos:altLabel """Onze-Lieve-Vrouw Hemelvaart""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/085d113cf099e0682741237409639f69> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/088e0084f5cbf61f89b1879f54b6d92e> skos:altLabel """Sint-Eligius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/088e0084f5cbf61f89b1879f54b6d92e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/08a217ef1f72b6878203d518b130a24c> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/08a217ef1f72b6878203d518b130a24c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/090948312604bdd5cb40dae90dd254ef> skos:altLabel """Sint-Margriet""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/090948312604bdd5cb40dae90dd254ef> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0a08557a13dc900acbba9ed51db341c8> skos:altLabel """Sint-Amandus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0a08557a13dc900acbba9ed51db341c8> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0a3e4c1e0798f65267f893a2573b915c> skos:altLabel """Heilig Kruis""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0a3e4c1e0798f65267f893a2573b915c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0a5439ebae3c123d60b3a4bd0b0d0807> skos:altLabel """Heilig Kruis""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0a5439ebae3c123d60b3a4bd0b0d0807> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0aa45729067c373d38bbb6b8007dba1c> skos:altLabel """Sint-Vedastus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0aa45729067c373d38bbb6b8007dba1c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0baede0eeae616d76c8a222df38d2b34> skos:altLabel """Sint-Job""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0baede0eeae616d76c8a222df38d2b34> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0be1c9f2e01b6b98137588fc673f8865> skos:altLabel """Sint-Anna""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0be1c9f2e01b6b98137588fc673f8865> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0dce0680f8ce23d23ffe0b384c156f64> skos:altLabel """Onze-Lieve-Vrouw van de Carmel""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0dce0680f8ce23d23ffe0b384c156f64> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0f9055bd4e3ec650678c4be098aa77de> skos:altLabel """Sint-Ursmarus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0f9055bd4e3ec650678c4be098aa77de> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/10f573d765433cff890a01d366528f02> skos:altLabel """Sint-Eligius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/10f573d765433cff890a01d366528f02> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/11633987c7b0b2b3d4321b94fe307ab3> skos:altLabel """Sint-Vincentius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/11633987c7b0b2b3d4321b94fe307ab3> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/12b64ee62f43f622e8795796b2aa683b> skos:altLabel """Sint-Jozef""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/12b64ee62f43f622e8795796b2aa683b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/136412e4d7700f169ed4485f53e4f932> skos:altLabel """Sint-Salvator""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/136412e4d7700f169ed4485f53e4f932> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/153ee90dd7982df53b56cee9c2d6c1c1> skos:altLabel """Sint-Stefanus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/153ee90dd7982df53b56cee9c2d6c1c1> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/157ad5b7205df85d20a7549315066635> skos:altLabel """Sint-Anna""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/157ad5b7205df85d20a7549315066635> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/15e9a9efa8019107993f4bad5a8d133e> skos:altLabel """Sint-Pieter""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/15e9a9efa8019107993f4bad5a8d133e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/16299168fd1574bb75b33784c03d9e4c> skos:altLabel """Sint-Medardus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/16299168fd1574bb75b33784c03d9e4c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/16d3be1bb81c7e8189795318fa9fa940> skos:altLabel """Onze-Lieve-Vrouw""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/16d3be1bb81c7e8189795318fa9fa940> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/16d966ee18e611f00ad66583bf1ca0fa> skos:altLabel """Sint-Jan-Evangelist""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/16d966ee18e611f00ad66583bf1ca0fa> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/178eb57e7144cc07800f4d2ac8dc7b24> skos:altLabel """Onze-Lieve-Vrouw van Troost""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/178eb57e7144cc07800f4d2ac8dc7b24> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/179253d59fa76c793c17b86787a2a3a5> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/179253d59fa76c793c17b86787a2a3a5> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/17bdd4485d5f4733530c95a9d6f7bfc8> skos:altLabel """Sint-Anna""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/17bdd4485d5f4733530c95a9d6f7bfc8> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/18569c84f650cabc830701338cf56210> skos:altLabel """Sint-Walburga""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/18569c84f650cabc830701338cf56210> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/185b103f566c177e40900b761a3c5e3d> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/185b103f566c177e40900b761a3c5e3d> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/195b02a199305e55cbb108ff4f012fa4> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/195b02a199305e55cbb108ff4f012fa4> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1a70e2ef944b5b3f438f1797f353d95c> skos:altLabel """Sint-Amandus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1a70e2ef944b5b3f438f1797f353d95c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1a7ee069ce4c1793e92d74388716b166> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1a7ee069ce4c1793e92d74388716b166> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1ae5888f7eebf62d6d323d655b7b7c00> skos:altLabel """Sint-Lambertus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1ae5888f7eebf62d6d323d655b7b7c00> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1b16577db37a36de68c4724c879fe00b> skos:altLabel """Onze-Lieve-Vrouw Hemelvaart""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1b16577db37a36de68c4724c879fe00b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1c8f262bc59166f376c1b8c02561889e> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1c8f262bc59166f376c1b8c02561889e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1d0d380cd1a096ade357b1df078dff90> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1d0d380cd1a096ade357b1df078dff90> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1e45b87e44a459f3cac6c8d20e261f1f> skos:altLabel """Sint-Antonius Abt""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1e45b87e44a459f3cac6c8d20e261f1f> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1edb49acfed7b8f1d1381a2c9cb8e8f1> skos:altLabel """Onze-Lieve-Vrouw""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1edb49acfed7b8f1d1381a2c9cb8e8f1> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1edbe6ead5c75823e9b81d89397f8ab7> skos:altLabel """Onze-Lieve-Vrouw""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1edbe6ead5c75823e9b81d89397f8ab7> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1ee5594988b397e8eb8c35ee78dc8034> skos:altLabel """Sint-Daniël""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1ee5594988b397e8eb8c35ee78dc8034> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1ef13a5362a77e3dadc2a33fddb4f60b> skos:altLabel """Onze-Lieve-Vrouw""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1ef13a5362a77e3dadc2a33fddb4f60b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/206f7acf5030ace2b5911521c04ea0a6> skos:altLabel """Sint-Egidius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/206f7acf5030ace2b5911521c04ea0a6> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/223df755661743045725cc6892e336a1> skos:altLabel """Sint-Ghislenus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/223df755661743045725cc6892e336a1> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/225dbe52684743202fd6328f0a77853d> skos:altLabel """Sint-Amandus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/225dbe52684743202fd6328f0a77853d> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/22ebeb5b2a5b5e7fd4a5bb476ee627d6> skos:altLabel """Onze-Lieve-Vrouw en Sint-Jan""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/22ebeb5b2a5b5e7fd4a5bb476ee627d6> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/23418d772b0b26732a4d48550d881ca1> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/23418d772b0b26732a4d48550d881ca1> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/235d46eecb406c50c8d9f60ad27179ad> skos:altLabel """Sint-Britius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/235d46eecb406c50c8d9f60ad27179ad> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/238d3a5a19b3952aa14bda2d84860a69> skos:altLabel """Sint-Jan-Evangelist""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/238d3a5a19b3952aa14bda2d84860a69> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/23a63d42fbe9e6bcfbb5721355264063> skos:altLabel """Sint-Petrus en Paulus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/23a63d42fbe9e6bcfbb5721355264063> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/26fdb3a4c2fa3ca0b9881137e30367fb> skos:altLabel """Heilige Familie""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/26fdb3a4c2fa3ca0b9881137e30367fb> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/27ea2a9f1e800d4eba74ad3d0bdab5b3> skos:altLabel """Onze-Lieve-Vrouw Lichtmis""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/27ea2a9f1e800d4eba74ad3d0bdab5b3> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/28967c96911fb109485d6ebd5d44f4c4> skos:altLabel """Sint-Hilarius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/28967c96911fb109485d6ebd5d44f4c4> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/29edb53ff1ef753bf05d97ba68972599> skos:altLabel """Sint-Margriet""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/29edb53ff1ef753bf05d97ba68972599> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2a0723e105987d87006851b46a86d5ef> skos:altLabel """Onze-Lieve-Vrouw""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2a0723e105987d87006851b46a86d5ef> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2a35e8c5cc5dc2c0e68d60a2bd9ce589> skos:altLabel """Sint-Ursmarus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2a35e8c5cc5dc2c0e68d60a2bd9ce589> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2ab1af61121bc138efc9f840bba3fb09> skos:altLabel """Sint-Bavo""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2ab1af61121bc138efc9f840bba3fb09> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2b01a54c5df091db748268c2b2a201e8> skos:altLabel """Sint-Laurentius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2b01a54c5df091db748268c2b2a201e8> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2be549b1cc263776f4c9a770e5fdb50d> skos:altLabel """Onze-Lieve-Vrouw van Zwijveke""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2be549b1cc263776f4c9a770e5fdb50d> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2d05c273ece320c9218ab03528abfe3b> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2d05c273ece320c9218ab03528abfe3b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2e0af01dd31f424596a81b6fe9a7a077> skos:altLabel """Sint-Niklaas""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2e0af01dd31f424596a81b6fe9a7a077> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2e60e8620b540b5488465c3d57892adc> skos:altLabel """Sint-Sebastiaan""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2e60e8620b540b5488465c3d57892adc> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2e6721d92f6015a9cbeac5b70963089e> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2e6721d92f6015a9cbeac5b70963089e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2f66cef9702056f73f509f7f8c9683ea> skos:altLabel """Sint-Pietersbanden""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2f66cef9702056f73f509f7f8c9683ea> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3292a5d26db54a3173eeab234727be29> skos:altLabel """Sint-Petrus en Urbanus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3292a5d26db54a3173eeab234727be29> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/33eda85bbaf6af4bdce8ba567fd18a69> skos:altLabel """Sint-Mauritius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/33eda85bbaf6af4bdce8ba567fd18a69> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/37e70c5874fa0ceb14d1a756c5c4f8fa> skos:altLabel """Sint-Denijs""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/37e70c5874fa0ceb14d1a756c5c4f8fa> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3811902c41a855e68302318f48c4aac5> skos:altLabel """Onze-Lieve-Vrouw van Bijstand""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3811902c41a855e68302318f48c4aac5> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3884e5e97d012024f620c798b22d7963> skos:altLabel """Sint-Agatha""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3884e5e97d012024f620c798b22d7963> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/38b6713551a892fbbbf1134104920394> skos:altLabel """Sint-Petrus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/38b6713551a892fbbbf1134104920394> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/39601a335371cc51c1f00e583e7400aa> skos:altLabel """Onze-Lieve-Vrouw ter Sneeuw""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/39601a335371cc51c1f00e583e7400aa> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3a88ca3f134c780c7cd3c75b48d09d25> skos:altLabel """Heilige Mauritius en gezellen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3a88ca3f134c780c7cd3c75b48d09d25> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3bd15dc3ef6ea46d2effc3de0ff8d165> skos:altLabel """Sint-Bartholomeus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3bd15dc3ef6ea46d2effc3de0ff8d165> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3cf7d81613b9cd1add4c5e081f67af8a> skos:altLabel """Sint-Margriet""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3cf7d81613b9cd1add4c5e081f67af8a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3d11b40d38d919e0001fa179b6d37f57> skos:altLabel """Onze-Lieve-Vrouw Hemelvaart""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3d11b40d38d919e0001fa179b6d37f57> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3d1f0b68ab80366d78b37c52ed8886d0> skos:altLabel """Sint-Laurentius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3d1f0b68ab80366d78b37c52ed8886d0> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3eb06a0b7d616403cf77f0270383e3f1> skos:altLabel """Onze-Lieve-Vrouw Hemelvaart""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3eb06a0b7d616403cf77f0270383e3f1> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3ec3ffeea2d5d5b5727f75b1beeb62df> skos:altLabel """Onze-Lieve-Vrouw""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3ec3ffeea2d5d5b5727f75b1beeb62df> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3f804b47a9836a3086148ffad739a4b1> skos:altLabel """Heilige Drie-Eenheid""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3f804b47a9836a3086148ffad739a4b1> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3ffd96d854de988ab55c7dd3b4bd44a3> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3ffd96d854de988ab55c7dd3b4bd44a3> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/41d9d3e433e7bbe782f75388fad71844> skos:altLabel """Sint-Ursmarus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/41d9d3e433e7bbe782f75388fad71844> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4282871d3f55c4c1aab98106619e3748> skos:altLabel """Onze-Lieve-Vrouw Hemelvaart""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4282871d3f55c4c1aab98106619e3748> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/42e71d5a53dcc9f3a1fcac1ce410e0df> skos:altLabel """Christus-Koning""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/42e71d5a53dcc9f3a1fcac1ce410e0df> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/43677309924cb0054871418c55764f56> skos:altLabel """Sint-Machutus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/43677309924cb0054871418c55764f56> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/43e8f237d5164aa52d685b81214c280c> skos:altLabel """Sint-Pietersbanden""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/43e8f237d5164aa52d685b81214c280c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/441cd8510162183fd87cb3070ac65b97> skos:altLabel """Sint-Pieter""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/441cd8510162183fd87cb3070ac65b97> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4557311db5e1e270bd58d807da81e101> skos:altLabel """Onze-Lieve-Vrouw Geboorte""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4557311db5e1e270bd58d807da81e101> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/45b5efa77f28fc9a4324d0aca96ab2ef> skos:altLabel """Sint-Jacob""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/45b5efa77f28fc9a4324d0aca96ab2ef> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/45de30b303f8bc4488a1878936f4f89a> skos:altLabel """Sint-Gorik""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/45de30b303f8bc4488a1878936f4f89a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/46b3da93dc6518e85d915aaaf2c06975> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/46b3da93dc6518e85d915aaaf2c06975> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/46dd3dd23fcb38137508dfb75a77d5d4> skos:altLabel """Sint-Pieter""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/46dd3dd23fcb38137508dfb75a77d5d4> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/47c131ffd9810c6135d5669dc4863a8a> skos:altLabel """Onze-Lieve-Vrouw Geboorte""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/47c131ffd9810c6135d5669dc4863a8a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/49e79e1323138e042f6483ad0ceabcd1> skos:altLabel """Sint-Lambertus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/49e79e1323138e042f6483ad0ceabcd1> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4a372ec86530fafb0c54f7626bcc6008> skos:altLabel """Sint-Bavo""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4a372ec86530fafb0c54f7626bcc6008> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4af14101ade03547910b603d9da78073> skos:altLabel """Sint-Gorik""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4af14101ade03547910b603d9da78073> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4b7bbaf182fe7eb6dd81a38aa575c1a4> skos:altLabel """Sint-Bartholomeus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4b7bbaf182fe7eb6dd81a38aa575c1a4> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4c2fee27579e26b5d2d519b7547c9690> skos:altLabel """Onze-Lieve-Vrouw Presentatie""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4c2fee27579e26b5d2d519b7547c9690> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4c8631010c43cd9cc8d79395b42cb2c0> skos:altLabel """Sint-Macharius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4c8631010c43cd9cc8d79395b42cb2c0> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4f37fed937c448cdc83e02839d8a86f8> skos:altLabel """Sint-Amandus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4f37fed937c448cdc83e02839d8a86f8> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/501d978aa52118ae9a507ccef059532d> skos:altLabel """Sint-Jan-Baptist""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/501d978aa52118ae9a507ccef059532d> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/515d7c28f8334b953aac51a3f751ab2a> skos:altLabel """Sint-Denijs""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/515d7c28f8334b953aac51a3f751ab2a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/51e611dd0968a86fd65dd39f0fc54998> skos:altLabel """Sint-Aldegonde""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/51e611dd0968a86fd65dd39f0fc54998> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/52f2d17b43c7548e5a74ccf89b39cffb> skos:altLabel """Sint-Antonius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/52f2d17b43c7548e5a74ccf89b39cffb> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/53058acba5132ea87759acaf749a5a03> skos:altLabel """Heilig-Kruis""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/53058acba5132ea87759acaf749a5a03> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/53069e0abb51631600a7c91c18d5a0f1> skos:altLabel """Sint-Katharina""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/53069e0abb51631600a7c91c18d5a0f1> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/53668f9b381a9833490844ee679ba2ed> skos:altLabel """Sint-Petrus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/53668f9b381a9833490844ee679ba2ed> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/53f1d540543ee83de2ed801c69d22048> skos:altLabel """Onze-Lieve-Vrouw Hemelvaart""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/53f1d540543ee83de2ed801c69d22048> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/54c21da60dcd3cc594810d75c32fdf6d> skos:altLabel """Sint-Pietersbanden""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/54c21da60dcd3cc594810d75c32fdf6d> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/54d3c65677ba46235ac7d922e611f015> skos:altLabel """Sint-Jan-Baptist""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/54d3c65677ba46235ac7d922e611f015> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/55080b36bdcf28c5316bb989e915a5eb> skos:altLabel """Onze-Lieve-Vrouw en Sint-Petrus en Paulus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/55080b36bdcf28c5316bb989e915a5eb> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/55dead3d70da2513e83ce1ceee9820d4> skos:altLabel """Sint-Hermes""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/55dead3d70da2513e83ce1ceee9820d4> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/564ce730862f56a6b95c6ff28e3885ac> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/564ce730862f56a6b95c6ff28e3885ac> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/565aa8a49b2baa38dd83842e8b71132a> skos:altLabel """Heilig Kruis""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/565aa8a49b2baa38dd83842e8b71132a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/566f8b6c17b1469acedfc37291b95aee> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/566f8b6c17b1469acedfc37291b95aee> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/567a1bd8a4e2be8817ff8af27c93efbd> skos:altLabel """Onze-Lieve-Vrouw""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/567a1bd8a4e2be8817ff8af27c93efbd> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/57d5b0b82731c5b78c345048205cf2bc> skos:altLabel """Sint-Andreas""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/57d5b0b82731c5b78c345048205cf2bc> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/582a7755138f4a08ef683e561cd2474f> skos:altLabel """Onze-Lieve-Vrouw Hemelvaart""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/582a7755138f4a08ef683e561cd2474f> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/58f2fcbb6d8bd00a928c1e6cfb526e55> skos:altLabel """Sint-Gertrudis""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/58f2fcbb6d8bd00a928c1e6cfb526e55> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/595ac38df06408e816572892f0236412> skos:altLabel """Onze-Lieve-Vrouw van 7 Weeën""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/595ac38df06408e816572892f0236412> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5a04126b0c2c7b04bf3e01f69fffa936> skos:altLabel """Onze-Lieve-Vrouw Hemelvaart""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5a04126b0c2c7b04bf3e01f69fffa936> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5b21627e63d1ae66ac14a9a26995afeb> skos:altLabel """Sint-Amandus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5b21627e63d1ae66ac14a9a26995afeb> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5bbd475b71892674180906bb93531ecb> skos:altLabel """Sint-Cornelius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5bbd475b71892674180906bb93531ecb> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5dc02aade2983d0d5e3a437f268564e5> skos:altLabel """Sint-Willibrordus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5dc02aade2983d0d5e3a437f268564e5> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5fe5c7a2902f9090599cc5c0bd0fb5f3> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5fe5c7a2902f9090599cc5c0bd0fb5f3> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/617AAE56375CFC000A0008DE> skos:altLabel """Sint-Antonius van Padua""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/617AAE56375CFC000A0008DE> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/61864569440e813e46d4bd8ceed5ace9> skos:altLabel """Heilige Kruisverheffing""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/61864569440e813e46d4bd8ceed5ace9> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/61a300a35455ff848a9f77a7201d9e32> skos:altLabel """Sint-Paulus' Bekering""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/61a300a35455ff848a9f77a7201d9e32> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6242cc597744155016c650947176a6fd> skos:altLabel """Sint-Amandus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6242cc597744155016c650947176a6fd> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/62a35712a1fa6fa02f1f328104af9ec9> skos:altLabel """Onze-Lieve-Vrouw Hemelvaart""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/62a35712a1fa6fa02f1f328104af9ec9> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/635599768cf92ca57e4f26ae7a6e7183> skos:altLabel """Sint-Petrus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/635599768cf92ca57e4f26ae7a6e7183> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/66f13a03fcce87b387c29738abec6a81> skos:altLabel """Sint-Pietersbanden""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/66f13a03fcce87b387c29738abec6a81> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/680b4648a1f72b2b58599941fca61073> skos:altLabel """Christus Koning""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/680b4648a1f72b2b58599941fca61073> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/68aff205fad830cae8a34f43abf1155e> skos:altLabel """Onze-Lieve-Vrouw Hemelvaart""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/68aff205fad830cae8a34f43abf1155e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/68e3b049fcb53dbeca9999ab4dbc5f78> skos:altLabel """Sint-Antonius van Padua""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/68e3b049fcb53dbeca9999ab4dbc5f78> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6af519ed9c81fe2ff3ebc2081d2f2553> skos:altLabel """Sint-Blasius en Sint-Margriet""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6af519ed9c81fe2ff3ebc2081d2f2553> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6b635e915301bee7164d5c5b57ec2fca> skos:altLabel """Sint-Ursmarus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6b635e915301bee7164d5c5b57ec2fca> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6bc09d06ca1345095d9c773787bdf5e2> skos:altLabel """Sint-Petrus en Paulus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6bc09d06ca1345095d9c773787bdf5e2> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6fff8d759fa4fb530d50be9468c6f63b> skos:altLabel """Heilig Kruis""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6fff8d759fa4fb530d50be9468c6f63b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/70d0f1bdb9008368028a394c3354b6f9> skos:altLabel """Sint-Petrus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/70d0f1bdb9008368028a394c3354b6f9> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7104481bf199e794f22691399a9917cd> skos:altLabel """Sint-Laurentius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7104481bf199e794f22691399a9917cd> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7226666d42c6db8200295cc081dedfcb> skos:altLabel """Sint-Jan Onthoofding""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7226666d42c6db8200295cc081dedfcb> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/738606c7e54a1e30d73b594f4b805d02> skos:altLabel """Sint-Denijs""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/738606c7e54a1e30d73b594f4b805d02> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/74b994088d38d525210518cff2bfd1ca> skos:altLabel """Onze-Lieve-Vrouw""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/74b994088d38d525210518cff2bfd1ca> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7645016f323af9304c4522cdaa7bde01> skos:altLabel """Sint-Amandus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7645016f323af9304c4522cdaa7bde01> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/78c5bd1b4c2b816f6fea365e75381c77> skos:altLabel """Onze-Lieve-Vrouw Hemelvaart""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/78c5bd1b4c2b816f6fea365e75381c77> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7a541539cb9241aa3c1fead2230ca7a3> skos:altLabel """Sint-Paulus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7a541539cb9241aa3c1fead2230ca7a3> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7c792b331ba827fad94f80c5e17b2be0> skos:altLabel """Sint-Jan-Baptist""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7c792b331ba827fad94f80c5e17b2be0> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7ce4cd18582a88f143d462d2bbb822be> skos:altLabel """Sint-Niklaas""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7ce4cd18582a88f143d462d2bbb822be> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7d4f8b6966bc6827ef64f742dcc9ff03> skos:altLabel """Sint-Jan in de Olie""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7d4f8b6966bc6827ef64f742dcc9ff03> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7d5d0c3cb64d8af3569559c66debaca2> skos:altLabel """Sint-Gertrudis""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7d5d0c3cb64d8af3569559c66debaca2> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7dae9e632630047487a61d860ce1dcbd> skos:altLabel """Sint-Gertrudis""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7dae9e632630047487a61d860ce1dcbd> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7dfb1dd2286802d2f67897ca5b8e6363> skos:altLabel """Sint-Amandus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7dfb1dd2286802d2f67897ca5b8e6363> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7e48e55993e92df4e75f149deacf7d61> skos:altLabel """Sint-Aldegonde""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7e48e55993e92df4e75f149deacf7d61> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7f0c6b985bed85f53a85ef657a06a2ec> skos:altLabel """Sint-Jacobus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7f0c6b985bed85f53a85ef657a06a2ec> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/80032995e2457306fb228eb214d6ce14> skos:altLabel """Sint-Vincentius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/80032995e2457306fb228eb214d6ce14> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/801010f65235a6fe615c05d93f42f152> skos:altLabel """Sint-Niklaas""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/801010f65235a6fe615c05d93f42f152> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/81fa9c35d08761361aa958408cfd1f34> skos:altLabel """Sint-Andreas en Ghislenus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/81fa9c35d08761361aa958408cfd1f34> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8258b076fc21bdafa3d2c29ee064f482> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8258b076fc21bdafa3d2c29ee064f482> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/826d320f5639b4b0521511ac547668c1> skos:altLabel """Onze-Lieve-Vrouw - Sint-Pieters""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/826d320f5639b4b0521511ac547668c1> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/829910b9f79c1880f6e9a562aea173ca> skos:altLabel """Onze-Lieve-Vrouw Hemelvaart""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/829910b9f79c1880f6e9a562aea173ca> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/82b0e189fba3c1dfb0e6d73d4f322f19> skos:altLabel """Sint-Bartholomeus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/82b0e189fba3c1dfb0e6d73d4f322f19> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/842c6d741870c519e145c19ea2503fbe> skos:altLabel """Sint-Niklaas""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/842c6d741870c519e145c19ea2503fbe> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/85c2b68646aac1bddc6d5f753f286007> skos:altLabel """Sint-Fledericus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/85c2b68646aac1bddc6d5f753f286007> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8612bb15106909264a7859d2b2dadbc9> skos:altLabel """Sint-Pietersbanden""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8612bb15106909264a7859d2b2dadbc9> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/867e23c7683d065d2bfd458ddbb3f752> skos:altLabel """Sint-Niklaas""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/867e23c7683d065d2bfd458ddbb3f752> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8713c3b0af0fce8b64180a93c6cc38b6> skos:altLabel """Sint-Amandus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8713c3b0af0fce8b64180a93c6cc38b6> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/87ace12241c7284c5ac67a69c83223ac> skos:altLabel """Sint-Jozef""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/87ace12241c7284c5ac67a69c83223ac> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/88d83bfc25d9f7e99e6e26cc08198414> skos:altLabel """Sint-Jan-Baptist""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/88d83bfc25d9f7e99e6e26cc08198414> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8a0d347078a44117a5a1ab0bab94cf3c> skos:altLabel """Onze-Lieve-Vrouw Middelares""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8a0d347078a44117a5a1ab0bab94cf3c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8a96077ce7bf0d4b45e952571f1badb6> skos:altLabel """Sint-Petrus en Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8a96077ce7bf0d4b45e952571f1badb6> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8b97c3530f92a92b4e08c8a2240e132c> skos:altLabel """Sint-Anna""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8b97c3530f92a92b4e08c8a2240e132c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8bab7132cad4a7b11d1ec11c86be8a73> skos:altLabel """Sint-Johannes-Bosco""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8bab7132cad4a7b11d1ec11c86be8a73> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8c02bf962b2b9e252925d9a62c77f2d5> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8c02bf962b2b9e252925d9a62c77f2d5> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8fa37395d9bff32d62f56b83f43c234f> skos:altLabel """Sint-Amandus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8fa37395d9bff32d62f56b83f43c234f> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8fa3c295d317ad00f8406fffafbcdbe5> skos:altLabel """Sint-Pharaïldis""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8fa3c295d317ad00f8406fffafbcdbe5> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/90a8fe6a41ef8e661bcf713aa6f7d755> skos:altLabel """Sint-Paulus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/90a8fe6a41ef8e661bcf713aa6f7d755> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/91bfccf07e2087a2675f41bcc838214f> skos:altLabel """Sint-Lutgardis""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/91bfccf07e2087a2675f41bcc838214f> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/92508c3ed3bff42ce94ab1574a68ed30> skos:altLabel """Sint-Petrus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/92508c3ed3bff42ce94ab1574a68ed30> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/93d1f20490dd184026683e219658f951> skos:altLabel """Sint-Michiel""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/93d1f20490dd184026683e219658f951> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/94b613636e3e9d617e8d2400be0ebca3> skos:altLabel """Sint-Joris""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/94b613636e3e9d617e8d2400be0ebca3> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/960641f9450cdb95242f2296765a824c> skos:altLabel """Sint-Bavo""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/960641f9450cdb95242f2296765a824c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/96162cb27a738ebb941a4360b4aa644a> skos:altLabel """Sint-Niklaas""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/96162cb27a738ebb941a4360b4aa644a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/978d5587d3ab9a391cc073e5391ce0f5> skos:altLabel """Onze-Lieve-Vrouw van de Rozenkrans""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/978d5587d3ab9a391cc073e5391ce0f5> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/97b9434fdbdce18cab0547ce5a9b2270> skos:altLabel """Onze-Lieve-Vrouw""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/97b9434fdbdce18cab0547ce5a9b2270> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/988d0dea59195958c807683238a79775> skos:altLabel """Sint-Amandus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/988d0dea59195958c807683238a79775> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9961fed5728f393a8cfc594fe27ec78f> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9961fed5728f393a8cfc594fe27ec78f> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9aa1b56cea57bf28798bb511dc5e5e9b> skos:altLabel """Onze-Lieve-Vrouw""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9aa1b56cea57bf28798bb511dc5e5e9b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9b3c044561ad7e9b95b806d0b7ae8d2e> skos:altLabel """Onze-Lieve-Vrouw van Bijstand""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9b3c044561ad7e9b95b806d0b7ae8d2e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9c455ada08ad97a2974ce799bc765413> skos:altLabel """Sint-Anna""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9c455ada08ad97a2974ce799bc765413> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9cad52f80b69cacfdac88c9c30e3eaa5> skos:altLabel """Sint-Amandus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9cad52f80b69cacfdac88c9c30e3eaa5> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9e3c3a3f33c8980f214747eba3a65260> skos:altLabel """Sint-Cornelius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9e3c3a3f33c8980f214747eba3a65260> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9eb47e87de3150fe9e606de6354579c7> skos:altLabel """Sint-Eligius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9eb47e87de3150fe9e606de6354579c7> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9ebe94648da8f44f72309e59afd602e7> skos:altLabel """Sint-Bavo""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9ebe94648da8f44f72309e59afd602e7> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9ef8bdfa091963e2d6ca79c9c6dc49d8> skos:altLabel """Sint-Catharina""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9ef8bdfa091963e2d6ca79c9c6dc49d8> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9f23ef9689f2a3d719f9caa01d0401ea> skos:altLabel """Sint-Pietersbanden""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9f23ef9689f2a3d719f9caa01d0401ea> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9f35bc3324cba69150a8d09d2a132355> skos:altLabel """Sint-Pietersbanden""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9f35bc3324cba69150a8d09d2a132355> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9f99cbcec04f91479f013fd83a9131f2> skos:altLabel """Sint-Margriet""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9f99cbcec04f91479f013fd83a9131f2> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a07c38a4a3929b03ad09ae5abc7284fb> skos:altLabel """Christus-Koning""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a07c38a4a3929b03ad09ae5abc7284fb> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a090883d78d45d09746f465b5bc69638> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a090883d78d45d09746f465b5bc69638> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a203e3854cf6ce99ec6086ad0102cae7> skos:altLabel """Sint-Denijs""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a203e3854cf6ce99ec6086ad0102cae7> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a21614d799b006f9e0b3715f16a07346> skos:altLabel """Sint-Amandus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a21614d799b006f9e0b3715f16a07346> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a2377d8ab1fa3c0be76a65bcd7a57f8b> skos:altLabel """Sint-Amandus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a2377d8ab1fa3c0be76a65bcd7a57f8b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a237ac670f9a7c9bfdd0ecf5e09f0e9c> skos:altLabel """Onze-Lieve-Vrouw""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a237ac670f9a7c9bfdd0ecf5e09f0e9c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a3076ee9885d7d702370e5ca39ba2c06> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a3076ee9885d7d702370e5ca39ba2c06> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a3cdeec177cea1938f390848d8d1b0f9> skos:altLabel """Sint-Laurentius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a3cdeec177cea1938f390848d8d1b0f9> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a422ca8edca3b79b9ff816ff3bb02707> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a422ca8edca3b79b9ff816ff3bb02707> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a51f65ab7b245dfa76e9698bd5e0f20c> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a51f65ab7b245dfa76e9698bd5e0f20c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a522263b9a7a647e11b079a318ad01be> skos:altLabel """Sint-Amandus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a522263b9a7a647e11b079a318ad01be> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a557cc4444a020e393847ebc2ddb0a8d> skos:altLabel """Onze-Lieve-Vrouw""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a557cc4444a020e393847ebc2ddb0a8d> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a6bffa82488fbc44c57ecc3fc9805788> skos:altLabel """Sint-Jozef en Sint-Antonius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a6bffa82488fbc44c57ecc3fc9805788> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a7292e4529aacd897ef82db1445282ac> skos:altLabel """Sint-Pietersbanden""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a7292e4529aacd897ef82db1445282ac> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a893d74def881da8988336e387dea0c9> skos:altLabel """Onze-Lieve-Vrouw Hemelvaart""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a893d74def881da8988336e387dea0c9> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a8e1ffeafe37c3fa343bfed3c6bfb01c> skos:altLabel """Sint-Walburga""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a8e1ffeafe37c3fa343bfed3c6bfb01c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/aa5150c6c39cfa2bfdd5e26f79050202> skos:altLabel """Sint-Godelieve""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/aa5150c6c39cfa2bfdd5e26f79050202> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/aa984f5fa1d94cc9aee8cc4bc9c44fc9> skos:altLabel """Sint-Bavo""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/aa984f5fa1d94cc9aee8cc4bc9c44fc9> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/aa9995c079c5b6840faa1cab946d16b4> skos:altLabel """Sint-Amandus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/aa9995c079c5b6840faa1cab946d16b4> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/aba45e459ecdad0c18264bbb22562a49> skos:altLabel """Sint-Aldegonde""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/aba45e459ecdad0c18264bbb22562a49> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ac383d448d2eae60f48e613c883e60a5> skos:altLabel """Sint-Radegondis""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ac383d448d2eae60f48e613c883e60a5> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ad3e72a2960c9da8fa15e75075ca7879> skos:altLabel """Sint-Bavo""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ad3e72a2960c9da8fa15e75075ca7879> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ae3fa54b46a2fe6172178b96ec844841> skos:altLabel """Sint-Christoffel""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ae3fa54b46a2fe6172178b96ec844841> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/aeef3f494f3854970ed87dce7735b68e> skos:altLabel """Sint-Laurentius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/aeef3f494f3854970ed87dce7735b68e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/afa4d20623ce9588aa04b3bf53045464> skos:altLabel """Onze-Lieve-Vrouw""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/afa4d20623ce9588aa04b3bf53045464> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b038ea91f8c681d4b113bbb0eb49bd08> skos:altLabel """Onze-Lieve-Vrouw Hemelvaart""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b038ea91f8c681d4b113bbb0eb49bd08> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b0bd2b91bf98ddfa9d615b65c400483c> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b0bd2b91bf98ddfa9d615b65c400483c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b0d8d6503289d28cbd94ba95dad20e7b> skos:altLabel """Onze-Lieve-Vrouw Hulp der Christenen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b0d8d6503289d28cbd94ba95dad20e7b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b11d7a416328f2f240c6eeaf6a1f04c5> skos:altLabel """Sint-Livinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b11d7a416328f2f240c6eeaf6a1f04c5> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b18a5d3943087d509d76dcceeba102c3> skos:altLabel """Sint-Amandus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b18a5d3943087d509d76dcceeba102c3> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b2253ab18a72cd51775fb5076c5ef29b> skos:altLabel """Onze-Lieve-Vrouw Hemelvaart""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b2253ab18a72cd51775fb5076c5ef29b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b27e7a40b0a6d2f80c5b935e9e2f536a> skos:altLabel """Sint-Eligius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b27e7a40b0a6d2f80c5b935e9e2f536a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b3d3b3f75b79a5179a7dd1410e785b13> skos:altLabel """Onze-Lieve-Vrouw van 7 Weeën""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b3d3b3f75b79a5179a7dd1410e785b13> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b40b8f94b6750df0ab91d8e210e448a6> skos:altLabel """Onze-Lieve-Vrouw Geboorte""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b40b8f94b6750df0ab91d8e210e448a6> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b4c348a07a94fad7795a1a5b294eff61> skos:altLabel """Sint-Jan-Baptist""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b4c348a07a94fad7795a1a5b294eff61> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b58e8273102ce2fefb153915ef692538> skos:altLabel """Heilig Kruis""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b58e8273102ce2fefb153915ef692538> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b81e29828346f01582bb400eb0b3255c> skos:altLabel """Sint-Antonius van Padua""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b81e29828346f01582bb400eb0b3255c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b86498eada9d8a14b6e8efb41098544b> skos:altLabel """Sint-Gertrudis""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b86498eada9d8a14b6e8efb41098544b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b91a829cc7447e3f52885bd0cfd92a6f> skos:altLabel """Sint-Jan-Baptist""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b91a829cc7447e3f52885bd0cfd92a6f> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b92de1c8c1f384e9e2028a413585b8e9> skos:altLabel """Heilig Hart""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b92de1c8c1f384e9e2028a413585b8e9> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b93b061a7465795d617e3320d963d6ca> skos:altLabel """Sint-Paulus' Bekering""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b93b061a7465795d617e3320d963d6ca> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b977848bce2f335d4cdbf8b4683dcf28> skos:altLabel """Sint-Catharina""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b977848bce2f335d4cdbf8b4683dcf28> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b9c2cc5db5a08d33b049663f9591fba6> skos:altLabel """Sint-Pietersbanden""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b9c2cc5db5a08d33b049663f9591fba6> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bbea95a65ce71e68cec9f698b18d00c6> skos:altLabel """Onze-Lieve-Vrouw Hemelvaart""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bbea95a65ce71e68cec9f698b18d00c6> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bc8fe3d190455af64331741fb2b9c1eb> skos:altLabel """Sint-Petrus en Paulus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bc8fe3d190455af64331741fb2b9c1eb> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bcc0bdbfd49ad9413db76b2bc0dc5497> skos:altLabel """Sint-Pietersbanden""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bcc0bdbfd49ad9413db76b2bc0dc5497> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bcca10210917bc2c04ba3928045fdea4> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bcca10210917bc2c04ba3928045fdea4> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bd2864c267a9bf0dee25fb396bcc4fd8> skos:altLabel """Sint-Agnes""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bd2864c267a9bf0dee25fb396bcc4fd8> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bd5d0d46616381b99827270e6087fa82> skos:altLabel """Sint-Niklaas""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bd5d0d46616381b99827270e6087fa82> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bd9e5e433355946fc48b4d4001347255> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bd9e5e433355946fc48b4d4001347255> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/be8a431f34309fd55c73e837a3083823> skos:altLabel """Sint-Jan-Baptist""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/be8a431f34309fd55c73e837a3083823> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bea1eb1ee24930f2c157a26f96323b60> skos:altLabel """Sint-Macharius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bea1eb1ee24930f2c157a26f96323b60> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/beae209163053d10d5a56b5a8cdf9687> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/beae209163053d10d5a56b5a8cdf9687> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c1bac862ddbc53626479e059e2443019> skos:altLabel """Sint-Bernadette""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c1bac862ddbc53626479e059e2443019> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c48babc2d24281a63540766253680d27> skos:altLabel """Sint-Stefanus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c48babc2d24281a63540766253680d27> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c490cfc8851d2346e36928ea9f9403d3> skos:altLabel """Sint-Pietersbanden""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c490cfc8851d2346e36928ea9f9403d3> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c4dcfb7eca4b438ba4ad885b04b34b25> skos:altLabel """Sint-Jozef""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c4dcfb7eca4b438ba4ad885b04b34b25> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c4ea3749712e99cf0e1e72534be04a81> skos:altLabel """Sint-Apollonia""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c4ea3749712e99cf0e1e72534be04a81> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c65e88313eb19554952b2e6185893a8b> skos:altLabel """Sint-Godelieve""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c65e88313eb19554952b2e6185893a8b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c6818299bedb5273c53e05590c12accc> skos:altLabel """Onze-Lieve-Vrouw Hemelvaart""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c6818299bedb5273c53e05590c12accc> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c70f456b13b57d8629fddd161b78d4ca> skos:altLabel """Onze-Lieve-Vrouw Geboorte""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c70f456b13b57d8629fddd161b78d4ca> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c9e8618cb73e6d4f16ba8c571efef477> skos:altLabel """Sint-Pietersbanden""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c9e8618cb73e6d4f16ba8c571efef477> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ca4df5081017caddbc654514a8f94b9e> skos:altLabel """Sint-Dionysius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ca4df5081017caddbc654514a8f94b9e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ca596072ef2b3e1506be8f8170d656e1> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ca596072ef2b3e1506be8f8170d656e1> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cab6a26000e3dffae940d5a661e0db6a> skos:altLabel """Heilig Kruis""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cab6a26000e3dffae940d5a661e0db6a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cca32587d498b7dc75ccb4dd0e0436a6> skos:altLabel """Sint-Amandus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cca32587d498b7dc75ccb4dd0e0436a6> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ccbf2b9e3adaea322a55bb1b0b8403d6> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ccbf2b9e3adaea322a55bb1b0b8403d6> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cd55b711e6ff0f7bf4b4de7125f0823a> skos:altLabel """Heilig Hart""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cd55b711e6ff0f7bf4b4de7125f0823a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cd82b5cf7d617f5a0eb3d87b3862b048> skos:altLabel """Onze-Lieve-Vrouw Hemelvaart""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cd82b5cf7d617f5a0eb3d87b3862b048> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ce686fe137df8d9e23d2de242bcc7046> skos:altLabel """Sint-Antonius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ce686fe137df8d9e23d2de242bcc7046> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cf549ca2b8e562f67f3ba1c73fc5ff3b> skos:altLabel """Sint-Bonifacius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cf549ca2b8e562f67f3ba1c73fc5ff3b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cfb21a5627a0e67ed2df17869550971d> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cfb21a5627a0e67ed2df17869550971d> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cfb2ad87425946fbdb9bb29ac6d61a4f> skos:altLabel """Sint-Margriet""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cfb2ad87425946fbdb9bb29ac6d61a4f> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d0cf7f75868008b5b04422c054ecb38b> skos:altLabel """Sint-Stefanus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d0cf7f75868008b5b04422c054ecb38b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d1cb6024e55aa7118f5f5d45f42fe2bf> skos:altLabel """Sint-Lambertus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d1cb6024e55aa7118f5f5d45f42fe2bf> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d2613a9b8c5ce9afdb517082e5063cb9> skos:altLabel """Sint-Egidius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d2613a9b8c5ce9afdb517082e5063cb9> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d2c14055e4e32a6d18b1480270cc7b83> skos:altLabel """Onze-Lieve-Vrouw Geboorte""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d2c14055e4e32a6d18b1480270cc7b83> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d2e470c29bb4a19e842281ab51a741ac> skos:altLabel """Sint-Petrus en Paulus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d2e470c29bb4a19e842281ab51a741ac> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d36c339e23c9d4382b882d00e2ad9235> skos:altLabel """Sint-Eligius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d36c339e23c9d4382b882d00e2ad9235> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d39c374963160ec2b1bf13890596d9b3> skos:altLabel """Sint-Bavo""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d39c374963160ec2b1bf13890596d9b3> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d52de436e194111289248db2d06e99ac> skos:altLabel """Onze-Lieve-Vrouw""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d52de436e194111289248db2d06e99ac> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d5add5f108cf69b119d07b65e0f6671c> skos:altLabel """Sint-Paulus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d5add5f108cf69b119d07b65e0f6671c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d640003a744edbe1a0597ab57243ab5e> skos:altLabel """Sint-Egidius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d640003a744edbe1a0597ab57243ab5e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d9300aa73b9b5792eaa34bc38fa7fedc> skos:altLabel """Sint-Rochus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d9300aa73b9b5792eaa34bc38fa7fedc> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d9a9d3cc81523357ef879d635acfd75d> skos:altLabel """Sint-Gertrudis""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d9a9d3cc81523357ef879d635acfd75d> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/da1686c247880dcd8d904645b5ce57af> skos:altLabel """Sint-Michiel""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/da1686c247880dcd8d904645b5ce57af> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/da40059e14ed297dc4188b4e908c1989> skos:altLabel """Onze-Lieve-Vrouw van Altijddurende Bijstand""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/da40059e14ed297dc4188b4e908c1989> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/da76ab54faed488c7759b616337933da> skos:altLabel """Sint-Martinus en Eutropius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/da76ab54faed488c7759b616337933da> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/da95046fec68766dda604962409dea98> skos:altLabel """Sint-Jan-Evangelist""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/da95046fec68766dda604962409dea98> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/dbdb0de14f6e1ca985463476d304bf41> skos:altLabel """Onze-Lieve-Vrouw en Sint-Petrus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/dbdb0de14f6e1ca985463476d304bf41> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/dc0ea14306d39e3b92a25ccc01eded68> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/dc0ea14306d39e3b92a25ccc01eded68> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/dc32dbe8d1f85999cd39a5c9893a9c7d> skos:altLabel """Alle Heilligen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/dc32dbe8d1f85999cd39a5c9893a9c7d> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/dd8d8ed265456f92f5da2196ea0d824c> skos:altLabel """Heilig Hart""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/dd8d8ed265456f92f5da2196ea0d824c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ddd0b8b7481569d905a03ebbd0c57b41> skos:altLabel """Sint-Petrus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ddd0b8b7481569d905a03ebbd0c57b41> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/dfd715e74ee4fd4d56acce888c0a000b> skos:altLabel """Sint-Paulus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/dfd715e74ee4fd4d56acce888c0a000b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e0089caed386534d77771c66c6e5a61b> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e0089caed386534d77771c66c6e5a61b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e064ced4aa3e09f3c6660a5839b317f4> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e064ced4aa3e09f3c6660a5839b317f4> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e0a92a88b07c91980d09d035341b9712> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e0a92a88b07c91980d09d035341b9712> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e11170b8cbd2d74102651cb967fa28e5> skos:altLabel """Sint-Baafs""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e11170b8cbd2d74102651cb967fa28e5> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e245129369a4cc41f290e65e800c86d7> skos:altLabel """Sint-Magdalena""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e245129369a4cc41f290e65e800c86d7> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e38641c3177b6b4014df296e67cb9d66> skos:altLabel """Onze-Lieve-Vrouw Hemelvaart""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e38641c3177b6b4014df296e67cb9d66> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e68f4e2cea20a40e97bbc276d48fcd4c> skos:altLabel """Onze-Lieve-Vrouw van Bijstand""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e68f4e2cea20a40e97bbc276d48fcd4c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e6e6bb2285cc5027b8b0aeb89de9d72a> skos:altLabel """Sint-Pietersstoel""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e6e6bb2285cc5027b8b0aeb89de9d72a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e71dc9e1929b1bff434473aa38cb3db2> skos:altLabel """Sint-Michiel""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e71dc9e1929b1bff434473aa38cb3db2> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e76220be705b6f0d3771c88b226f1909> skos:altLabel """Sint-Niklaas""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e76220be705b6f0d3771c88b226f1909> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e7e9906eb81751177b9917cb25931ccb> skos:altLabel """Sint-Mattheus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e7e9906eb81751177b9917cb25931ccb> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e998af4039651eec4f62a7102fd58b8a> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e998af4039651eec4f62a7102fd58b8a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e9add3c1b713d3e799ac1f43065a5027> skos:altLabel """Onze-Lieve-Vrouw Hulp der Christenen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e9add3c1b713d3e799ac1f43065a5027> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e9ba870009446b374ff48bb2ef6e2dcf> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e9ba870009446b374ff48bb2ef6e2dcf> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e9f1328fb49464cfb3bfd16b8cde9ae8> skos:altLabel """Sint-Amandus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e9f1328fb49464cfb3bfd16b8cde9ae8> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ec266ee786b0c2dab1f92dd860f7625e> skos:altLabel """Onze-Lieve-Vrouw""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ec266ee786b0c2dab1f92dd860f7625e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ee380ce0ad7b5d56f9b75c8b47fa7d51> skos:altLabel """Heilig Hart""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ee380ce0ad7b5d56f9b75c8b47fa7d51> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ee39915cfd95476af56294bd84ec344b> skos:altLabel """Heilige Familie""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ee39915cfd95476af56294bd84ec344b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ef228aaca1b4f48731deac8dee799422> skos:altLabel """Onze Lieve-Vrouw""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ef228aaca1b4f48731deac8dee799422> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f0789f8d5500de5c7452d20bf166d54a> skos:altLabel """Heilig Hart""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f0789f8d5500de5c7452d20bf166d54a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f097ccc4694a33ee432785486eddd617> skos:altLabel """Sint-Onkomena""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f097ccc4694a33ee432785486eddd617> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f11b30cf12fd44b1ce1d5e8724cc9cdc> skos:altLabel """Sint-Simon en Judas""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f11b30cf12fd44b1ce1d5e8724cc9cdc> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f13e8950061e674b0475e6f0c62c4c32> skos:altLabel """Sint-Jozef""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f13e8950061e674b0475e6f0c62c4c32> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f1ee590f03f8fd5948ed7deb7274299a> skos:altLabel """Sint-Egidius""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f1ee590f03f8fd5948ed7deb7274299a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f260a93f43c568d9c99eaf811cacd3e1> skos:altLabel """Onze-Lieve-Vrouw Hemelvaart""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f260a93f43c568d9c99eaf811cacd3e1> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f27e13c072e30e1838220ce0c55bb890> skos:altLabel """Onze-Lieve-Vrouw Presentatie""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f27e13c072e30e1838220ce0c55bb890> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f2ea3e0d18f9f9dc405712f5f5a9475b> skos:altLabel """Sint-Michiels""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f2ea3e0d18f9f9dc405712f5f5a9475b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f3b99fa233332c3d972c298b06f98654> skos:altLabel """Heilig Hart""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f3b99fa233332c3d972c298b06f98654> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f4539efbcfdd731154a0426b2ababdac> skos:altLabel """Onze-Lieve-Vrouw ten Hemel Opgenomen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f4539efbcfdd731154a0426b2ababdac> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f4d71e472b2154abccd9246186853a83> skos:altLabel """Sint-Pietersbanden""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f4d71e472b2154abccd9246186853a83> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f58fc6cc0fcaac08e6d759b75a3ae8ed> skos:altLabel """Sint-Petrus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f58fc6cc0fcaac08e6d759b75a3ae8ed> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f64ab9a9e43a11f275fed62534a9e382> skos:altLabel """Onze-Lieve-Vrouw Hulp der Christenen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f64ab9a9e43a11f275fed62534a9e382> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f6e44c631af8d9296dfa1d0d57c40a94> skos:altLabel """Sint-Apollonia""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f6e44c631af8d9296dfa1d0d57c40a94> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f70abd021b2fd6bcd52126c7c2588962> skos:altLabel """Onze-Lieve-Vrouw Hemelvaart""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f70abd021b2fd6bcd52126c7c2588962> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f865226227235311d1dbc6736d670f9a> skos:altLabel """Sint-Gerardus Majella""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f865226227235311d1dbc6736d670f9a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f8807691a8e6c96281d69e65ec9a5098> skos:altLabel """Heilig Hart""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f8807691a8e6c96281d69e65ec9a5098> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f909fb6c13b9fa27147d781cfdab7c49> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f909fb6c13b9fa27147d781cfdab7c49> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f9d8dc737ed81134e501c5aa38fc1c5d> skos:altLabel """Sint-Amandus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f9d8dc737ed81134e501c5aa38fc1c5d> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fa1a329419aefb4d2360740e171fff64> skos:altLabel """Sint-Antonius Abt""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fa1a329419aefb4d2360740e171fff64> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/faf1cfcc7e6fa9bb4c9b928e58250815> skos:altLabel """Sint-Martinus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/faf1cfcc7e6fa9bb4c9b928e58250815> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fb40e8042c44a28022abbed7960fbbdb> skos:altLabel """Sint-Amandus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fb40e8042c44a28022abbed7960fbbdb> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fb63a9ab65962f807470529de446d8d6> skos:altLabel """Sint-Christoffel""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fb63a9ab65962f807470529de446d8d6> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fc0c25f72ba093d097ad58082639c88f> skos:altLabel """Sint-Salvator""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fc0c25f72ba093d097ad58082639c88f> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fc5042fb825112bc3671dce6cd5a836b> skos:altLabel """Sint-Amandus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fc5042fb825112bc3671dce6cd5a836b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fd9fc255217cdc435ec4400e0d1e8ed6> skos:altLabel """Sint-Anna""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fd9fc255217cdc435ec4400e0d1e8ed6> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fdd05d4db761eec3138d931d11fc33e8> skos:altLabel """Sint-Maurus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fdd05d4db761eec3138d931d11fc33e8> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fe0d4b4d0cd46e58e016532bb1c59679> skos:altLabel """Sint-Niklaas""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fe0d4b4d0cd46e58e016532bb1c59679> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ffc0ebfb7e8f31c8d55f32b86d806e94> skos:altLabel """Sint-Gerulphus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ffc0ebfb7e8f31c8d55f32b86d806e94> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fff72bd79ad1e878e33b0025f71b1669> skos:altLabel """Sint-Ludgerus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fff72bd79ad1e878e33b0025f71b1669> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0018ad6326ac8723d97163a83f9e17ac> skos:altLabel """Sint-Lambertus Geistingen-Ophoven""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0018ad6326ac8723d97163a83f9e17ac> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/029dd1546d4e4bb0e046e08f86c6d4b7> skos:altLabel """Sint-Jozef Rijkel""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/029dd1546d4e4bb0e046e08f86c6d4b7> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/02cc4e67420edb8d3a761ab5b552950c> skos:altLabel """Sint-Gertrudis Riksingen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/02cc4e67420edb8d3a761ab5b552950c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/034313c88b29a553faffe8a143accff1> skos:altLabel """Sint-Martinus Vechmaal""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/034313c88b29a553faffe8a143accff1> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/03d6f6d5a75a5a6c85b38b411e07ffba> skos:altLabel """Sint-Barbara Werkplaatsen-Lommel""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/03d6f6d5a75a5a6c85b38b411e07ffba> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/04430e7310b226c591eb3c0593752f96> skos:altLabel """Salvator Mundi Melveren""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/04430e7310b226c591eb3c0593752f96> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/04fd96ab0626885c16945393c306d70d> skos:altLabel """Sint-Jan Baptist Tongeren""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/04fd96ab0626885c16945393c306d70d> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0596b13ef625ce16005f0717b2ec641e> skos:altLabel """O.-L.-V.-Tenhemelopneming Oud-Waterschei""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0596b13ef625ce16005f0717b2ec641e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/059a5ecf551cce84717c2f718bba13cb> skos:altLabel """Sint-Jozef Heesveld""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/059a5ecf551cce84717c2f718bba13cb> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/05c8e1bc74ef76ffe1322a5832b13c1d> skos:altLabel """Sint-Petrus en Sint-Laurentius Zichen-Bolder""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/05c8e1bc74ef76ffe1322a5832b13c1d> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/08c1f39c7bd49836790949c9f0d38bcc> skos:altLabel """Sint-Jan-Baptist Romershoven""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/08c1f39c7bd49836790949c9f0d38bcc> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/08e433018f28b469216e2dba803b1aba> skos:altLabel """Sint-Agatha Berlingen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/08e433018f28b469216e2dba803b1aba> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/091806b4719d9517c51f321eeb3ce6c2> skos:altLabel """Sint-Martinus Meeuwen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/091806b4719d9517c51f321eeb3ce6c2> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/09dedc5f3d20af033870c4c86896888b> skos:altLabel """Sint-Eventius Winterslag II""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/09dedc5f3d20af033870c4c86896888b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0c0865fa2dba074d464ebd36baba68a5> skos:altLabel """Sint-Paulus Heeserbergen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0c0865fa2dba074d464ebd36baba68a5> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0cdf3115f2d2ea3f3a6324a5c7251e8f> skos:altLabel """Sint-Servatius Koninksem""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0cdf3115f2d2ea3f3a6324a5c7251e8f> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0d92242d744104f5dc03714f6deeee79> skos:altLabel """Sint-Jan Kuringen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0d92242d744104f5dc03714f6deeee79> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0daaf1b65d8b8987b3016dcd9ff45029> skos:altLabel """Sint-Niklaas Wimmertingen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0daaf1b65d8b8987b3016dcd9ff45029> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0efc42cd1d06d62ae2c8ac6a5ffb13b9> skos:altLabel """Maagd der Armen Schoonbeek-Beverst""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0efc42cd1d06d62ae2c8ac6a5ffb13b9> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/10e60ccfd414b5bf7ca85727d2f55ec6> skos:altLabel """Sint-Albanus Vlijtingen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/10e60ccfd414b5bf7ca85727d2f55ec6> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/10ed2c1d135e20c8fc0c3700e15dbd91> skos:altLabel """Sint-Remigius Waltwilder""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/10ed2c1d135e20c8fc0c3700e15dbd91> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/113e0c3967b68911d2bf26080ce8d555> skos:altLabel """Maagd der Armen Mariaheide-Mariahof Vucht""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/113e0c3967b68911d2bf26080ce8d555> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/120bb225aff496815d7041e21562e7dd> skos:altLabel """Sint-Heribertus Remersdaal""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/120bb225aff496815d7041e21562e7dd> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/14d7ccb066bebde287f4cad861bb066d> skos:altLabel """Sint-Dionysius Gotem""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/14d7ccb066bebde287f4cad861bb066d> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1745abe93338d787a21ebdcbaf13bfe7> skos:altLabel """O.L.V. van Banneux Houthalen-Oost""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1745abe93338d787a21ebdcbaf13bfe7> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/179e23909a534fad859e16e5089b4b26> skos:altLabel """Sint-Servatius Ophoven""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/179e23909a534fad859e16e5089b4b26> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/18a8e0325d101503f13da2b915d0125f> skos:altLabel """Sint-Jozef Werkman Laak-Houthalen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/18a8e0325d101503f13da2b915d0125f> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/18d8a01873cb08e30a0a537d910d726d> skos:altLabel """Sint-Martinus Gors-Opleeuw""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/18d8a01873cb08e30a0a537d910d726d> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/18f2bbd8182cbf3eb145ae33d134d7a5> skos:altLabel """Sint-Jozef Zonhoven-Halveweg""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/18f2bbd8182cbf3eb145ae33d134d7a5> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1a0f198b1566d5d3c27ade118e4116ec> skos:altLabel """Sint-Pancratius Widooie""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1a0f198b1566d5d3c27ade118e4116ec> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1a4fabaa18a13260a30a1d2ccc619035> skos:altLabel """Sint-Jozef Smeermaas""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1a4fabaa18a13260a30a1d2ccc619035> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1a77d19b5d3a74774030dca0a498eac2> skos:altLabel """Sint-Lambertus Veldwezelt""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1a77d19b5d3a74774030dca0a498eac2> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1b70194968d13926697e8f88cd1c6e3d> skos:altLabel """Sint-Gertrudis Heppeneert""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1b70194968d13926697e8f88cd1c6e3d> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1c9f3fb79f4c20ceacdaf7a873b41cde> skos:altLabel """Sint-Lutgardis Tongeren""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1c9f3fb79f4c20ceacdaf7a873b41cde> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1cdf1993fb28a017a3f2aef66d7d6521> skos:altLabel """Sint-Petrus Halen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1cdf1993fb28a017a3f2aef66d7d6521> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1dbe0186b93eee4015ce071a53e2d9c8> skos:altLabel """O.L.V. van Lourdes Heide-Heuvel""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1dbe0186b93eee4015ce071a53e2d9c8> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/21506b86b89396d77bffa857168798e2> skos:altLabel """Sint-Quirinus Viversel-Zolder""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/21506b86b89396d77bffa857168798e2> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/21a706e2243c38fc158171c7bf7d19ba> skos:altLabel """Sint-Lambertus Bevingen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/21a706e2243c38fc158171c7bf7d19ba> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2529086645359c5f784d268222d89c95> skos:altLabel """Sint-Lambertus Opglabbeek""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2529086645359c5f784d268222d89c95> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2535ea1cb446ad99a752c4cf2d6a80c0> skos:altLabel """Sint-Aldegondis Alken""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2535ea1cb446ad99a752c4cf2d6a80c0> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/256d1c655cd9df3785b3a89ae72726ab> skos:altLabel """Sint-Martinus Martenslinde""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/256d1c655cd9df3785b3a89ae72726ab> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/25e8a9f2e4adac7225ea38347de41259> skos:altLabel """Sint-Job Bolderberg-Zolder""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/25e8a9f2e4adac7225ea38347de41259> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/26408b60475ecd4f140bfd1b8e7d411e> skos:altLabel """Sint-Brixius Schalkhoven""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/26408b60475ecd4f140bfd1b8e7d411e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/26ac5b91848bd8f8100a07d5325f68a7> skos:altLabel """Sint-Jan de Doper Paal""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/26ac5b91848bd8f8100a07d5325f68a7> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/27c0d1f5c461be91bca2c3d00ce7b9e4> skos:altLabel """O.L.V.-Geboorte Tongeren""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/27c0d1f5c461be91bca2c3d00ce7b9e4> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/27cd432cbfbba42816f0f3f9be6b7dd2> skos:altLabel """Sint-Martinus Tessenderlo""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/27cd432cbfbba42816f0f3f9be6b7dd2> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2abf996dca6933078d39dc0a0d84a6b5> skos:altLabel """Sint-Hubertus Sint-Huibrechts-Hern""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2abf996dca6933078d39dc0a0d84a6b5> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2bd2b3262d847de556eba671c2731c22> skos:altLabel """Heilig Sacrament Kattenbos""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2bd2b3262d847de556eba671c2731c22> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2f6acffa2ce7ee87b351c504d647941b> skos:altLabel """Sint-Stephanus 's Herenelderen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/2f6acffa2ce7ee87b351c504d647941b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/32a6724bc96197dbc9c58ee1912580fe> skos:altLabel """O.L.V.-Tenhemelopneming Veulen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/32a6724bc96197dbc9c58ee1912580fe> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/32ac83432b6be0f13408ce33b2d1af8c> skos:altLabel """Sint-Lambertus Hendrieken-Voort""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/32ac83432b6be0f13408ce33b2d1af8c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/32bd5e066ad3ba95db753b1ad9d3b39e> skos:altLabel """Sint-Paulus Lanklaar""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/32bd5e066ad3ba95db753b1ad9d3b39e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3519d4653df066d7cbda1ad0b132c8ab> skos:altLabel """O.L.V.-Onbevlekt Ontvangen Linde-Peer""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3519d4653df066d7cbda1ad0b132c8ab> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/35fdf97c5e04495d9ff13c22940156b1> skos:altLabel """Sint-Lambertus Horpmaal""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/35fdf97c5e04495d9ff13c22940156b1> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/360fbaeb3648a7dcc03a81c51181f345> skos:altLabel """Sint-Benedictus Lozen-Bocholt""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/360fbaeb3648a7dcc03a81c51181f345> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/36880084f4ce4089164fb69e0e3d7190> skos:altLabel """Sint-Mauritius Bilzen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/36880084f4ce4089164fb69e0e3d7190> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/37910b38973de7f64e0957199189e3fe> skos:altLabel """Sint-Saturninus Mielen-boven-Aalst""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/37910b38973de7f64e0957199189e3fe> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/37e04fc4f761aa19976a300364fe6a82> skos:altLabel """Sint-Jozef-Werkman Hoevenzavel""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/37e04fc4f761aa19976a300364fe6a82> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/39c85c0cf1fb4e1aad6187179ddf41ce> skos:altLabel """Sint-Jozef Rapertingen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/39c85c0cf1fb4e1aad6187179ddf41ce> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3a243eea9347ce1fc56e2d5d2cfb33a8> skos:altLabel """O.L.V.-Geboorte Berbroek""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3a243eea9347ce1fc56e2d5d2cfb33a8> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3b64e991e78dd23a7ce6578f3c691786> skos:altLabel """Sint-Jan-Baptist Wellen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3b64e991e78dd23a7ce6578f3c691786> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3b932d274c79ef5583fb0995686a4357> skos:altLabel """Sint-Petrus Elen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3b932d274c79ef5583fb0995686a4357> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3b9b9300ee406116248f82c19cfe0f61> skos:altLabel """Sint-Ursula Kleine-Brogel""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3b9b9300ee406116248f82c19cfe0f61> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3c884d204ac79fec3ab441290264abdc> skos:altLabel """Sint-Martinus Genk""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3c884d204ac79fec3ab441290264abdc> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3d328f469e5debdf4e8c353587bf7588> skos:altLabel """Sint-Martinus Overpelt""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3d328f469e5debdf4e8c353587bf7588> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3d8d3c30fac104f93e617e373248e80e> skos:altLabel """Sint-Petrus Sint-Pieters-Voeren""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3d8d3c30fac104f93e617e373248e80e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3df7a2533172916180439f4f7631fb47> skos:altLabel """Sint-Ursula Lanaken""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3df7a2533172916180439f4f7631fb47> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3e48db9c75a3ed7da744485b1fabbc48> skos:altLabel """Sint-Aldegondis Kleine-Spouwen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3e48db9c75a3ed7da744485b1fabbc48> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3eb5a025065635e38c2810aa6cec2064> skos:altLabel """O.L.V.-Bezoeking Wilderen-Duras""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3eb5a025065635e38c2810aa6cec2064> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3f46da053baf828b5562351f53031167> skos:altLabel """O.L.V.-Tenhemelopneming Gorsem""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3f46da053baf828b5562351f53031167> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3fcfe35272a3e69c2e0bf44083cfd576> skos:altLabel """Sint-Harlindis en Relindis Ellikom""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/3fcfe35272a3e69c2e0bf44083cfd576> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4046b25d578cb5f88dbf9fd8bd236d23> skos:altLabel """Sint-Remigius Vucht""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4046b25d578cb5f88dbf9fd8bd236d23> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4058e6b6de005b70451781d8b0e5688c> skos:altLabel """O.L.V.-Tenhemelopneming Sint-Truiden""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4058e6b6de005b70451781d8b0e5688c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/46e62bf4969e9369e6941bc07f3f5e02> skos:altLabel """O.L.V.-Tenhemelopneming Moelingen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/46e62bf4969e9369e6941bc07f3f5e02> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4810e6ea3602a8082f8cbff0e2987233> skos:altLabel """O.L.V.-Onbevlekt Ontvangen Paal-Tervant""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4810e6ea3602a8082f8cbff0e2987233> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4881ff4efeb7292dbe5e6e1ac9c4b575> skos:altLabel """Sint-Martinus Herk-de-Stad""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4881ff4efeb7292dbe5e6e1ac9c4b575> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/48a7f0f0518bfac2eb3439f5af921f27> skos:altLabel """Sint-Jan-Baptist Thiewinkel""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/48a7f0f0518bfac2eb3439f5af921f27> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/48ffe4dee0a6b273200946c2903ef110> skos:altLabel """Sint-Kristoffel Opgrimbie""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/48ffe4dee0a6b273200946c2903ef110> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4c928a61deb1bded47df66ffade3a80a> skos:altLabel """Sint-Vedastus Hoepertingen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4c928a61deb1bded47df66ffade3a80a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4d2243fd9c4efaefb440eba10a48e91c> skos:altLabel """Sint-Gertrudis Piringen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4d2243fd9c4efaefb440eba10a48e91c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4d612abe70a87b09e9a6830cc028ff78> skos:altLabel """Sint-Lambertus Kiewit""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4d612abe70a87b09e9a6830cc028ff78> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4d85345ac8a836b08e5f9153f33981db> skos:altLabel """Sint-Jozef Louwel""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4d85345ac8a836b08e5f9153f33981db> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4e553d4e55f46492b8f1e4c51dde1386> skos:altLabel """Sint-Genoveva  Zussen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4e553d4e55f46492b8f1e4c51dde1386> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4f19a0e93962eb616454f495a9b47466> skos:altLabel """Sint-Quintinus Zonhoven""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4f19a0e93962eb616454f495a9b47466> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4f2420f47051858274aab5cbae097351> skos:altLabel """Sint-Hubertus Kanne""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4f2420f47051858274aab5cbae097351> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5174e35a7373b16c0f7cda664491e2e2> skos:altLabel """Sint-Martinus Heers""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5174e35a7373b16c0f7cda664491e2e2> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/51e42776ff656865a73a32eddeca5ebf> skos:altLabel """Sint-Martinus Montenaken""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/51e42776ff656865a73a32eddeca5ebf> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/522aee29d5c7e1c419dff6e50f048916> skos:altLabel """Sint-Lambertus Meulenberg-Houthalen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/522aee29d5c7e1c419dff6e50f048916> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/525d8d418eeb0cf3e21f744ea86bceb8> skos:altLabel """Sint-Hubertus en Vincentius Zolder""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/525d8d418eeb0cf3e21f744ea86bceb8> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5280e20df07faa4a49cc1e0ebf50722d> skos:altLabel """Heilig Hart Winterslag I""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5280e20df07faa4a49cc1e0ebf50722d> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/52fadb742b9a4d40c276440b8acc46e1> skos:altLabel """Onze Lieve Vrouw Lummen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/52fadb742b9a4d40c276440b8acc46e1> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5328b26476c052a33f7a801daceff203> skos:altLabel """Sint-Catharina Mopertingen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5328b26476c052a33f7a801daceff203> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/54f41590d9866b86b79a860c84411353> skos:altLabel """Sint-Antonius Barrier-Lommel""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/54f41590d9866b86b79a860c84411353> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/54fe8c0fbc1513c912cfe64afcc0320a> skos:altLabel """Sint-Jozef Kolonie-Lommel""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/54fe8c0fbc1513c912cfe64afcc0320a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/55639517d2b221ff66d31aee7e009d90> skos:altLabel """Sint-Servatius Sluizen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/55639517d2b221ff66d31aee7e009d90> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/57e2535737cf6045869b2aeab8879ed1> skos:altLabel """Sint-Willibrordus Reppel""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/57e2535737cf6045869b2aeab8879ed1> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5800ad51bcd76a4bb1efbccc5858f35c> skos:altLabel """Sint-Laurentius Hamont""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5800ad51bcd76a4bb1efbccc5858f35c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5b5730b7c9ed77f3032dcfb258a40fcc> skos:altLabel """O.L.V.-Tenhemelopneming Genendijk-Kwaadmechelen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5b5730b7c9ed77f3032dcfb258a40fcc> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5bcfb6ca8645acd7d828d9ba8e2c1b79> skos:altLabel """Sint-Albertus Zwartberg""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5bcfb6ca8645acd7d828d9ba8e2c1b79> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5db6190b9fb8367c067ba34c526a8c03> skos:altLabel """Sint-Willibrordus Neerpelt-Herent""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/5db6190b9fb8367c067ba34c526a8c03> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/619236e39efa2fa0db6cb0899bee6e01> skos:altLabel """Kruisvinding Mal""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/619236e39efa2fa0db6cb0899bee6e01> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/61b419b66c6ad7cf89cce355a5b42f01> skos:altLabel """Sint-Maternus Tongeren""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/61b419b66c6ad7cf89cce355a5b42f01> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/621c358f0cc6afdeed02f58b85584815> skos:altLabel """Sint-Petrus Teuven""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/621c358f0cc6afdeed02f58b85584815> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/635965afc85c720dc4d1c1fc5608f629> skos:altLabel """Sint-Barbara Holheide""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/635965afc85c720dc4d1c1fc5608f629> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/638c155d9b609487d2c557d1fac231fa> skos:altLabel """Sint-Hubertus Henis""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/638c155d9b609487d2c557d1fac231fa> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/63faaac529fde2681fdc9d833415aee6> skos:altLabel """Sint-Cunibertus Diets-Heur""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/63faaac529fde2681fdc9d833415aee6> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/64d64f93733045670498d83964868a13> skos:altLabel """Sint-Pietersbanden Wintershoven""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/64d64f93733045670498d83964868a13> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/653057c1b86b8c15ea9ed1146eab58b9> skos:altLabel """Sint-Joris Jeuk""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/653057c1b86b8c15ea9ed1146eab58b9> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6ab72756b8bdb73f1c0a3ddc91dbcb91> skos:altLabel """Sint-Martinus Houthalen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6ab72756b8bdb73f1c0a3ddc91dbcb91> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6dcc5bf4fae3a6f509105ac4f2eee0a1> skos:altLabel """Sint-Martinus Dilsen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6dcc5bf4fae3a6f509105ac4f2eee0a1> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6e1acdbc18fca6846e3edb02c79b7230> skos:altLabel """Sint-Petrus Leut""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6e1acdbc18fca6846e3edb02c79b7230> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6e49cb76cbf400e421e2faf002d734cc> skos:altLabel """Sint-Quintinus Hasselt""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6e49cb76cbf400e421e2faf002d734cc> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6ea035e0eee6a9c6924f7776e37166cb> skos:altLabel """Sint-Monulphus en Gondulphus Mechelen-aan-de-Maas""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6ea035e0eee6a9c6924f7776e37166cb> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6f671571d4748315d46fb5fe7b9a257d> skos:altLabel """Sint-Pietersbanden Lommel""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6f671571d4748315d46fb5fe7b9a257d> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7044a86693e1e38760442df4a765505d> skos:altLabel """Sint-Servatius Nerem""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7044a86693e1e38760442df4a765505d> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/70cdc844e48cfdddbc54bfd83bb22527> skos:altLabel """Sint-Lambertus Grote-Spouwen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/70cdc844e48cfdddbc54bfd83bb22527> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/739d2e4e6bc45d0878cabc6a3d06cc1f> skos:altLabel """Sint-Catharina Maaseik""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/739d2e4e6bc45d0878cabc6a3d06cc1f> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/73abc6b839892cc85213f9f47bd183c7> skos:altLabel """Sint-Trudo Peer""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/73abc6b839892cc85213f9f47bd183c7> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/74aac01a0276d543be145838dd5abbf2> skos:altLabel """Sint-Laurentius Bocholt""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/74aac01a0276d543be145838dd5abbf2> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/752a297193a238f4e43cb1cc3388ded4> skos:altLabel """Sint-Andreas Runkelen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/752a297193a238f4e43cb1cc3388ded4> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/766d6c8a764805a7642e9bbaad54f7e8> skos:altLabel """Sint-Hubertus Membruggen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/766d6c8a764805a7642e9bbaad54f7e8> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/771b1cd0388e3c9e934de170e944adc3> skos:altLabel """Christus-Koning Waterschei""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/771b1cd0388e3c9e934de170e944adc3> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7770925bf8338d865dfd068fc9f9c917> skos:altLabel """Sint-Monulphus en Gondulphus Achel""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7770925bf8338d865dfd068fc9f9c917> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/782de670e162582dd436ac6da130cdf1> skos:altLabel """Sint-Quirinus Rukkelingen-Loon""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/782de670e162582dd436ac6da130cdf1> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7a1cf7f1914e82b60845d7e61cac949a> skos:altLabel """Sint-Trudo Helchteren""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7a1cf7f1914e82b60845d7e61cac949a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7a8e61ffc9681ab78655e66904d402f0> skos:altLabel """Sint-Trudo Linkhout""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7a8e61ffc9681ab78655e66904d402f0> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7ae8cf805d9adb5714464c216faa0749> skos:altLabel """Sint-Quintinus Kathedraal""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7ae8cf805d9adb5714464c216faa0749> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7b5d2cbe6c46c7cc79dcb232b0c4fc5e> skos:altLabel """Sint-Gertrudis Gruitrode""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7b5d2cbe6c46c7cc79dcb232b0c4fc5e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7d032292bd84e3e217a0889dd333ee9b> skos:altLabel """Sint-Cornelius Lindelhoeve""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7d032292bd84e3e217a0889dd333ee9b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7e77ec1987fdb8c1b140cc655ef7d551> skos:altLabel """Sint-Gertrudis Beverst""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7e77ec1987fdb8c1b140cc655ef7d551> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7fd7dcef48383d2ef1494161630d4da9> skos:altLabel """Sint-Trudo Wijchmaal""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7fd7dcef48383d2ef1494161630d4da9> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8000fb8910f3f7afb10056217339acbe> skos:altLabel """Regina Pacis Lutselus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8000fb8910f3f7afb10056217339acbe> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/80a49d5e6c22ac6c69054f66fd8c996c> skos:altLabel """Sint-Niklaas Niel-bij-As""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/80a49d5e6c22ac6c69054f66fd8c996c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/80cd5e4793cf022453a9642e70c440f3> skos:altLabel """Sint-Laurentius Meeswijk""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/80cd5e4793cf022453a9642e70c440f3> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/81583d503aa94e8e02a95c2ba639d433> skos:altLabel """Sint-Martinus Genoelselderen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/81583d503aa94e8e02a95c2ba639d433> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/83cedbdfaad72434b79fc1a92798db1e> skos:altLabel """Heilig Hart Hasselt""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/83cedbdfaad72434b79fc1a92798db1e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8423ac2c38dbb88041cb74bd9ffde308> skos:altLabel """Sint-Stephanus Batsheers""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8423ac2c38dbb88041cb74bd9ffde308> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/84b9a1176a8ee2670ec318edd7b32600> skos:altLabel """Maria Goretti Bokrijk II""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/84b9a1176a8ee2670ec318edd7b32600> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/84e45c9ea65afbb366e02b6bd9472fba> skos:altLabel """Sint-Stephanus Hoeselt""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/84e45c9ea65afbb366e02b6bd9472fba> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8565482e0ce7860a7799fe27957b2755> skos:altLabel """Sint-Jacobus Eversel-Heusden""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8565482e0ce7860a7799fe27957b2755> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/85891631d93627baa2971e6cb09944cb> skos:altLabel """Sint-Pancratius Zelk""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/85891631d93627baa2971e6cb09944cb> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/85b57e1bef3c753681c5989b5c1100ba> skos:altLabel """Sint-Trudo Buvingen-Muizen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/85b57e1bef3c753681c5989b5c1100ba> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/86c66c5e5027c0acbc33a9d8e3d29738> skos:altLabel """O.L.V.-Tenhemelopneming Heks""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/86c66c5e5027c0acbc33a9d8e3d29738> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/89c10efb008103e85fa5a3e75cd17946> skos:altLabel """Sint-Lambertus Neerharen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/89c10efb008103e85fa5a3e75cd17946> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8a90a8de8b1f6bb0a6ab29cf81428754> skos:altLabel """Sint-Odulphus Borgloon""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8a90a8de8b1f6bb0a6ab29cf81428754> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8eb34b0dbb84730dd3b0b54c7b548c40> skos:altLabel """Sint-Theodardus Beringen-Mijn""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8eb34b0dbb84730dd3b0b54c7b548c40> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8ef2aa7c7668a78276a8a97595cfef83> skos:altLabel """Sint-Lambertus Hechtel""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8ef2aa7c7668a78276a8a97595cfef83> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8fe49a2fff6bbcd9669d69cc987d531b> skos:altLabel """Sint-Amandus Stokrooie""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8fe49a2fff6bbcd9669d69cc987d531b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9138562c0aa5fde328e28dcc357f1d2d> skos:altLabel """Sint-Martinus Rutten""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9138562c0aa5fde328e28dcc357f1d2d> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/919679a5537e5f1926a98d3b73b50de1> skos:altLabel """Onze Lieve Vrouw Gerdingen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/919679a5537e5f1926a98d3b73b50de1> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/936e984c90bc03653abdae811cf84abe> skos:altLabel """Sint-Monulphus en Gondulphus Sint-Huibrechts-Lille""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/936e984c90bc03653abdae811cf84abe> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/94a4fcff105eacf0698b4fcdc90a630f> skos:altLabel """Sint-Medardus Vreren""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/94a4fcff105eacf0698b4fcdc90a630f> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/963815a67a10cdbe5e4b60ded99b729b> skos:altLabel """Sint-Martinus Beek-Bree""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/963815a67a10cdbe5e4b60ded99b729b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9810e0989817262fd70c72b909163c09> skos:altLabel """Sint-Jan-Baptist Lommel-Kerkhoven""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9810e0989817262fd70c72b909163c09> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9921f1e1e875f7569fbf75a5980ea9d4> skos:altLabel """Sint-Servatius Lanaken-Heide""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9921f1e1e875f7569fbf75a5980ea9d4> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/99ecaacc4a9af278164637c40ac145cd> skos:altLabel """O.L.V. van Banneux Hasselt""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/99ecaacc4a9af278164637c40ac145cd> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9ab4db70eb324392a9d47f955a544a4d> skos:altLabel """Sint-Jozef Wauberg-Peer""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9ab4db70eb324392a9d47f955a544a4d> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9abec4079342bd9f3e5961949847f817> skos:altLabel """Sint-Ludgerus Neerrepen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9abec4079342bd9f3e5961949847f817> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9b4ae93e5324814efa1d7b0b7ebc79b8> skos:altLabel """Sint-Niklaas Neerpelt""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9b4ae93e5324814efa1d7b0b7ebc79b8> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9c194cc30765a9c7f389735e84f24524> skos:altLabel """Kruisverheffing Jesseren""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9c194cc30765a9c7f389735e84f24524> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9d5a07c1312954d171b17daae019692c> skos:altLabel """Maagd der Armen Grote-Heide""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9d5a07c1312954d171b17daae019692c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9da34ed22fad3be2b80044040f571586> skos:altLabel """Sint-Joris Alken""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9da34ed22fad3be2b80044040f571586> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a000fb2e232eb7a18f041b9e6c64c39b> skos:altLabel """Sint-Barbara Eisden""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a000fb2e232eb7a18f041b9e6c64c39b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a0d960d87251f4f398d927f8ef033608> skos:altLabel """Heilig Hart Rooierheide""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a0d960d87251f4f398d927f8ef033608> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a0f38a034a4fe4b93accfc57626b252e> skos:altLabel """Maagd der Armen Lutlommel""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a0f38a034a4fe4b93accfc57626b252e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a185c5b9057c37701f8044348a14a21a> skos:altLabel """Sint-Sebastianus Niel-bij-Sint-Truiden""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a185c5b9057c37701f8044348a14a21a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a3c7856908205628acbaefd73ae4d2e2> skos:altLabel """Sint-Martinus Mettekoven""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a3c7856908205628acbaefd73ae4d2e2> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a3de697c65e7d7c792ec10c28b9a5932> skos:altLabel """Sint-Quintinus Hees""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a3de697c65e7d7c792ec10c28b9a5932> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a42e7b9dda57670370d326597923b6c5> skos:altLabel """Sint-Trudo Grote-Brogel""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a42e7b9dda57670370d326597923b6c5> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a51514dae3665218ef1b6dda7dadb12d> skos:altLabel """Runkst, kerk Heilig Kruis""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a51514dae3665218ef1b6dda7dadb12d> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a639ec8aebde00c5b9d74dd047a5bf80> skos:altLabel """Sint-Trudo Eksel""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a639ec8aebde00c5b9d74dd047a5bf80> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a650fbb527e064c6e811a00aeaf7fcbf> skos:altLabel """Sint-Donatus Dorne-Opoeteren""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a650fbb527e064c6e811a00aeaf7fcbf> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a6604aa8f5b5aa49d1b4b32528fc10ef> skos:altLabel """O.L.V.-Bezoeking Godsheide""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a6604aa8f5b5aa49d1b4b32528fc10ef> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a66ac00d28216700a7a617ed8ff6a7cc> skos:altLabel """Sint-Hubertus Neerglabbeek""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a66ac00d28216700a7a617ed8ff6a7cc> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a725152c78acf7c0b5bda7e581ae6c59> skos:altLabel """O.L.V.-Tenhemelopneming Leopoldsburg""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a725152c78acf7c0b5bda7e581ae6c59> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a7fcafcfbb8fbd19df58622f41b87b14> skos:altLabel """Sint-Lambertus Neeroeteren""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a7fcafcfbb8fbd19df58622f41b87b14> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a8239675e25d4c54aaeca5fa08f71566> skos:altLabel """Sint-Martinus Groot-Gelmen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a8239675e25d4c54aaeca5fa08f71566> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a886d09c09a074dc7789d521570791d7> skos:altLabel """O.L.V.-Tenhemelopneming Wijshagen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a886d09c09a074dc7789d521570791d7> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a93acce451879b85d017b94c629a3557> skos:altLabel """Heilig Hart Korspel-Beverlo""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a93acce451879b85d017b94c629a3557> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ab1027dad0aeb5fa91cf2548a81312ab> skos:altLabel """Sint-Ursula Eigenbilzen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ab1027dad0aeb5fa91cf2548a81312ab> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/aba52a412581ff07433a6c3fa0296665> skos:altLabel """Sint-Domatianus Werm""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/aba52a412581ff07433a6c3fa0296665> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ac5436af0ce5d785d87eadfd75a202fe> skos:altLabel """Sint-Lambertus Beverlo""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ac5436af0ce5d785d87eadfd75a202fe> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/adc4b855b64e0c2fafc910074105a4f4> skos:altLabel """Sint-Jozef Tongeren""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/adc4b855b64e0c2fafc910074105a4f4> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ae3a78ce2be03bd5cee99b2809ad1204> skos:altLabel """Sint-Gerardus Koersel-Stal""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ae3a78ce2be03bd5cee99b2809ad1204> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ae4a102ae5279db7a22ef5a740e110b7> skos:altLabel """O.L.V.-Tenhemelopneming Munsterbilzen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ae4a102ae5279db7a22ef5a740e110b7> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b11d86dca1b242cbcf876d0ddea190e7> skos:altLabel """Sint-Lambertus Zelem""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b11d86dca1b242cbcf876d0ddea190e7> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b2e0cb8ac3409ebb0c6ac837636293e4> skos:altLabel """Sint-Amandus Zammelen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b2e0cb8ac3409ebb0c6ac837636293e4> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b5febe7c0b41b040ef4d283f7922fd1e> skos:altLabel """Sint-Petrus Tongerlo""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b5febe7c0b41b040ef4d283f7922fd1e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b7400a71b70dc36a844d17fe8497c28b> skos:altLabel """O.L.V.-Boodschap Klein-Gelmen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b7400a71b70dc36a844d17fe8497c28b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b77a819a7f2c30b96466d89d27388097> skos:altLabel """Sint-Joris Boorsem""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b77a819a7f2c30b96466d89d27388097> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b80630b82b040cc24a0dfc36653ab4ba> skos:altLabel """Sint-Jan Baptist Schulen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b80630b82b040cc24a0dfc36653ab4ba> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b9cbb485df27a534d9046ef43d7f2bfd> skos:altLabel """Sint-Andreas Loksbergen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b9cbb485df27a534d9046ef43d7f2bfd> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bb356e23638d57d1c4169dd3a321b203> skos:altLabel """Sint-Jan Baptist Herderen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bb356e23638d57d1c4169dd3a321b203> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bb5149567b375d43216c7634fada6187> skos:altLabel """Sint-Quintinus Guigoven""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bb5149567b375d43216c7634fada6187> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bc127415d926c8743d41b574edaefc27> skos:altLabel """Sint-Gertrudis Kuringen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bc127415d926c8743d41b574edaefc27> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bce65193b8538c33c159cc64bd8a53cb> skos:altLabel """Sint-Willibrordus Eisden""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bce65193b8538c33c159cc64bd8a53cb> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bdcb11bc30ceb65eaee69b23e891b71a> skos:altLabel """Sint-Augustinus Sint-Truiden""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bdcb11bc30ceb65eaee69b23e891b71a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/beb4a48c99d8f5feed67b8e7443c31ce> skos:altLabel """Sint-Servatius Diepenbeek""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/beb4a48c99d8f5feed67b8e7443c31ce> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bf5b6dc13245b33bd38b7a206fb42e59> skos:altLabel """Sint-Petrus Gingelom""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bf5b6dc13245b33bd38b7a206fb42e59> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bfece91520b0cd599fade4b1cbed63bc> skos:altLabel """Sint-Petrus Lauw""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bfece91520b0cd599fade4b1cbed63bc> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c1336d0f1f6030cbc22ee030024f4eb0> skos:altLabel """Sint-Petrus Boekhout""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c1336d0f1f6030cbc22ee030024f4eb0> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c14db70613b6671b21b6fd37dc2b24bb> skos:altLabel """Salvator-Mundi Hamont-Lo""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c14db70613b6671b21b6fd37dc2b24bb> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c26fd4ffff3ec32d2b8f161a06546d0a> skos:altLabel """O.L.V.-Rozenkrans Termien""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c26fd4ffff3ec32d2b8f161a06546d0a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c29799f7758e4dce6370a53766b244ea> skos:altLabel """Sint-Trudo Opitter""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c29799f7758e4dce6370a53766b244ea> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c2b668da1d70ea4628e959ad993d1948> skos:altLabel """Sint-Valentinus Berkenbos""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c2b668da1d70ea4628e959ad993d1948> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c31f20c9997e1eac11bda1e9ecf45ab5> skos:altLabel """Sint-Elisabeth Stokkem""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c31f20c9997e1eac11bda1e9ecf45ab5> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c46e43248a39d0dc72dac1e82b35fe44> skos:altLabel """Sint-Willibrordus Meldert""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c46e43248a39d0dc72dac1e82b35fe44> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c484c2a241ee2db50477e8e4ebc00233> skos:altLabel """Onze Lieve Vrouw Lindeman-Zolder""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c484c2a241ee2db50477e8e4ebc00233> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c4be8806fada5e169816d87d08debb01> skos:altLabel """Sint-Laurentius Gellik""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c4be8806fada5e169816d87d08debb01> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c503daa4deda88f2159955e8d2df9aa0> skos:altLabel """Sint-Stephanus Val-Meer""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c503daa4deda88f2159955e8d2df9aa0> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c55f3b42c2aee8adda0982862774de78> skos:altLabel """Sint-Anna Aldeneik""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c55f3b42c2aee8adda0982862774de78> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c5f158cdb4f5cf3f9f3fe2f1605e9781> skos:altLabel """Sint-Anna Mechelen-Bovelingen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c5f158cdb4f5cf3f9f3fe2f1605e9781> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c7168e61186468e292101660caa431f9> skos:altLabel """Sint-Niklaas Uikhoven""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c7168e61186468e292101660caa431f9> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c867effa6d65cd28ca6111362849acf2> skos:altLabel """O.L.V. Maagd der Armen Strooiendorp""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c867effa6d65cd28ca6111362849acf2> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c875e9d1362d70197a7de9e335266447> skos:altLabel """Sint-Martinus Sint-Truiden""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c875e9d1362d70197a7de9e335266447> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c928e74a73159a740b3e101213eafa2d> skos:altLabel """O.L.V.-Tenhemelopneming Zutendaal""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c928e74a73159a740b3e101213eafa2d> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c9be2abd3a9e22ee655a1c208778a508> skos:altLabel """Sint-Jozef Kuringen-Tuilt""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c9be2abd3a9e22ee655a1c208778a508> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ca1b74e1e120025d467473a44e19bdb7> skos:altLabel """Sint-Jan Baptist de la Salle Bokrijk I""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ca1b74e1e120025d467473a44e19bdb7> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cb5d7c910962f7faa29e95870d64a98a> skos:altLabel """Sint-Pieter Haren""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cb5d7c910962f7faa29e95870d64a98a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cb9a49a92a48c68813eae1f7d1f542a0> skos:altLabel """Sint-Pieter Rosmeer""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cb9a49a92a48c68813eae1f7d1f542a0> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cc233970582ca9055c14e3fc395959b4> skos:altLabel """O.L.V.-Tenhemelopneming Kortenbos""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cc233970582ca9055c14e3fc395959b4> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cc25a13e3e91da9c4cbbac723f653fb3> skos:altLabel """Sint-Catharina Hasselt""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cc25a13e3e91da9c4cbbac723f653fb3> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ce5016afc774d4024e2a0b791aa00e31> skos:altLabel """Sint-Lambertus Alt-Hoeselt""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ce5016afc774d4024e2a0b791aa00e31> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cec95634ac07b6465e1ff532106c4070> skos:altLabel """Sint-Stephanus Millen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cec95634ac07b6465e1ff532106c4070> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cf6c5861665793f2eb3ed6471b55d1c6> skos:altLabel """Sint-Petrus Kortessem""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cf6c5861665793f2eb3ed6471b55d1c6> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cfd01ed85eab6517b76003bf2e4576da> skos:altLabel """Sint-Rochus Genenbos""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/cfd01ed85eab6517b76003bf2e4576da> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d0367e70bfa933967a321b5a5fe084ef> skos:altLabel """Sint-Martinus Kessenich""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d0367e70bfa933967a321b5a5fe084ef> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d2fbbc66ec4ccad880add34a3f96ebfa> skos:altLabel """Sint-Martinus Kerkom""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d2fbbc66ec4ccad880add34a3f96ebfa> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d313ba819b155fa047babab3ca300362> skos:altLabel """Heilig Hart Boekt-Zolder""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d313ba819b155fa047babab3ca300362> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d3a74e0b0cfa2e932c9c3ebd5e261021> skos:altLabel """Sint-Martinus Riemst""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d3a74e0b0cfa2e932c9c3ebd5e261021> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d50b43868d7079c0a035de10044157d1> skos:altLabel """Sint-Theresia As""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d50b43868d7079c0a035de10044157d1> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d572f30b69fe2a8ca97f6d4c1ccbb352> skos:altLabel """Sint-Martinus Stevoort""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d572f30b69fe2a8ca97f6d4c1ccbb352> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d5882958785bd42c7b4b68970cdd94b7> skos:altLabel """Sint-Petrus en Andreas Proosterbos""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d5882958785bd42c7b4b68970cdd94b7> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d620fb3a916f40fd754832a887f847bc> skos:altLabel """O.L.V.-Geboorte Rijkhoven""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d620fb3a916f40fd754832a887f847bc> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d69d8a3ca0ef4c34acd1a0664301f411> skos:altLabel """Sint-Monulphus en Gondulphus Rotem""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d69d8a3ca0ef4c34acd1a0664301f411> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d6ae155e5126120ee4bc67bb256b0be7> skos:altLabel """O.L.V.-Maria Middelares Hoeselt""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d6ae155e5126120ee4bc67bb256b0be7> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d72b82b3ff1e79eaf201fbc81f93a4c1> skos:altLabel """Sint-Lambertus Opheers""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d72b82b3ff1e79eaf201fbc81f93a4c1> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d774e5a21f080dc4e733af3931869a85> skos:altLabel """O.L.V-Geboorte Donk""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d774e5a21f080dc4e733af3931869a85> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d79a1f7cf772267851cbf90ed05ae485> skos:altLabel """Sint-Monulphus en Gondulphus Kaulille""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d79a1f7cf772267851cbf90ed05ae485> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d89733d845ce2156fec4537214fa27fe> skos:altLabel """Sint-Niklaas, Sint-Pieter Sint-Truiden""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d89733d845ce2156fec4537214fa27fe> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d8d9c8b6fd5dae1a80e0570ad97d246b> skos:altLabel """Maria Moeder van de Kerk Kolderbos-Langerlo""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d8d9c8b6fd5dae1a80e0570ad97d246b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d98aeac68f0131daa0c88f621f7a47f3> skos:altLabel """Sint-Petrus Rekem""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/d98aeac68f0131daa0c88f621f7a47f3> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/da41be38e910b65ffa92c1df6e246208> skos:altLabel """Sint-Rochus Ulbeek""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/da41be38e910b65ffa92c1df6e246208> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/daa992c59466e468c554e0e58be0325d> skos:altLabel """Sint-Willibrordus Heusden""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/daa992c59466e468c554e0e58be0325d> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/dbab060684d76622901a91c6d39effae> skos:altLabel """Sint-Michiel Bree""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/dbab060684d76622901a91c6d39effae> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/dc0a001ceca625d892d44e755e704bbd> skos:altLabel """O.L.V.-Tenhemelopneming Kermt""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/dc0a001ceca625d892d44e755e704bbd> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/dc301a78b6717cb47e84638310e848e0> skos:altLabel """Sint-Pieter Nieuwerkerken""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/dc301a78b6717cb47e84638310e848e0> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/de6be329e55260eea2716552b952379c> skos:altLabel """Sint-Brigida Koersel""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/de6be329e55260eea2716552b952379c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e039649a1be3554a81ef0bdaad21ef44> skos:altLabel """Sint-Martinus Velm""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e039649a1be3554a81ef0bdaad21ef44> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e0c888cc32a3f8a4357264d9c521999c> skos:altLabel """Sint-Michael Kesselt-Veldwezelt""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e0c888cc32a3f8a4357264d9c521999c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e1f8076e79fa4486d2cd621ca4bf7fc4> skos:altLabel """Sint-Genoveva Zepperen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e1f8076e79fa4486d2cd621ca4bf7fc4> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e2a18a43b0ba08b5250a13ac57a279dc> skos:altLabel """Sint-Martinus Sint-Martensvoeren""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e2a18a43b0ba08b5250a13ac57a279dc> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e2b7bca6ebdd41be1befed6d8cc46fc9> skos:altLabel """Heilige Kruisvinding Achel-Statie""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e2b7bca6ebdd41be1befed6d8cc46fc9> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e43f3797322885b3c0def1858ef8eea2> skos:altLabel """Sint-Lambertus 's Gravenvoeren""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e43f3797322885b3c0def1858ef8eea2> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e4a27d5953b9ab5f28a22d26597363b6> skos:altLabel """Sint-Martinus Kinrooi""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e4a27d5953b9ab5f28a22d26597363b6> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e535c62e39ed5fe9b8f25ff38cbc189a> skos:altLabel """Sint-Dionysius Opoeteren""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e535c62e39ed5fe9b8f25ff38cbc189a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e5f5131487b8915cae1c6255e5088f52> skos:altLabel """Sint-Pietersbanden Beringen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e5f5131487b8915cae1c6255e5088f52> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e79c0eebb4cf1e1dcfabed213ac4c4c8> skos:altLabel """Sint-Leonardus Molenbeersel""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e79c0eebb4cf1e1dcfabed213ac4c4c8> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e876756296bf17aac26adf0a75817e9b> skos:altLabel """O.L.V.-Boodschap Spalbeek""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e876756296bf17aac26adf0a75817e9b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e97a294b9defdc67614f67bc7a16d98c> skos:altLabel """Sint-Gillis Tongeren""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e97a294b9defdc67614f67bc7a16d98c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ead93cb87e37661a3fb3dad5bdec1068> skos:altLabel """Sint-Martinus Hasselt""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ead93cb87e37661a3fb3dad5bdec1068> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/eb1b93e59748346890acda1a812629f4> skos:altLabel """Sint-Jacobus Schurhoven""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/eb1b93e59748346890acda1a812629f4> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ecca1e27aad771126e5f681243540a2a> skos:altLabel """Sint-Jozef Boseind""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ecca1e27aad771126e5f681243540a2a> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ed09cdbd5b488e6d245694a0ccc9227d> skos:altLabel """O.L.V.-Onbevlekt Ontvangen Schakkebroek""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ed09cdbd5b488e6d245694a0ccc9227d> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ed3191d37c986d94b509226359524481> skos:altLabel """Sint-Jan Baptist Herstappe""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ed3191d37c986d94b509226359524481> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ed37db8f2989dfcdec54732b6b62926e> skos:altLabel """Sint-Laurentius Brustem""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ed37db8f2989dfcdec54732b6b62926e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ef4b91da78567af589df0f33ecc154e6> skos:altLabel """Sint-Antonius Lillo-Houthalen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ef4b91da78567af589df0f33ecc154e6> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f01c9ee766a264c4d621e91eb353aba5> skos:altLabel """Sint-Jozef Wiemesmeer""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f01c9ee766a264c4d621e91eb353aba5> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f17652d2163aa5187d4730e0459f6497> skos:altLabel """Sint-Laurentius Overrepen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f17652d2163aa5187d4730e0459f6497> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f23c405a84e8147e3516deb8372559fe> skos:altLabel """Sint-Lucia Engsbergen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f23c405a84e8147e3516deb8372559fe> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f257217efa1b9c366ce4f478fb02a205> skos:altLabel """O.L.V.-Geboorte Oostham""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f257217efa1b9c366ce4f478fb02a205> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f2fef60a96e03fee79a7f2e7d634e55e> skos:altLabel """O.L.V. van Fatima Bret-Gelieren""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f2fef60a96e03fee79a7f2e7d634e55e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f3817477f72d75ea3a24f72183815bda> skos:altLabel """Sint-Jozef Sledderlo""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f3817477f72d75ea3a24f72183815bda> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f4081a605851638f5669b76f73b908ff> skos:altLabel """Sint-Barbara Berg""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f4081a605851638f5669b76f73b908ff> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f56420b0c7fd638d8a7a041807aeada3> skos:altLabel """Sint-Lambertus Sint-Lambrechts-Herk""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f56420b0c7fd638d8a7a041807aeada3> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f5e52765858eb7689d796eff00da3315> skos:altLabel """Sint-Martinus Berg""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f5e52765858eb7689d796eff00da3315> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f6d830270664018e673008f3bbf3456b> skos:altLabel """Sint-Blasius Heppen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f6d830270664018e673008f3bbf3456b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f7eafb8a4ecc1faa5dc87351ed50cba7> skos:altLabel """Sint-Pieter en Paulus Vroenhoven""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f7eafb8a4ecc1faa5dc87351ed50cba7> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f8353cd38271ac524e1367584fbb00f8> skos:altLabel """Sint-Barbara Ter Heide""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f8353cd38271ac524e1367584fbb00f8> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fa0768293b86ae604e0501a4b93506ef> skos:altLabel """Sint-Jozef-Werkman Schoot""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fa0768293b86ae604e0501a4b93506ef> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fbe42b2f659658f1ccfb170dfe06f242> skos:altLabel """Sint-Philomena Kotem""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fbe42b2f659658f1ccfb170dfe06f242> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fdd219a0bdf92157d94589de11bf2528> skos:altLabel """O.L.V.-Onbevlekt Ontvangen Terkoest""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fdd219a0bdf92157d94589de11bf2528> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fdf1b3f06e45cf28300d9c4a0e5bf7ef> skos:altLabel """Drie Moren Gutschoven""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fdf1b3f06e45cf28300d9c4a0e5bf7ef> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fdfe00f6e32bec9f3175dff0dbae1b83> skos:altLabel """Sint-Petrus Borlo""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fdfe00f6e32bec9f3175dff0dbae1b83> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fea8f48cf6688e309e7dfdeb8c26a367> skos:altLabel """O.L.V. der Kempen Opglabbeek""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fea8f48cf6688e309e7dfdeb8c26a367> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/24ff08070bc1e47b498ab8139b9d3792> skos:altLabel """Islamitische geloofsgemeenschap Selimiye Camii van Heusden-Zolder""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/24ff08070bc1e47b498ab8139b9d3792> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7b0d877894765abf5052e12c7bed553e> skos:altLabel """Islamitische geloofsgemeenschap Beraat van Diest""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7b0d877894765abf5052e12c7bed553e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a8faa182c59167da7551f40979dc5022> skos:altLabel """Islamitische geloofsgemeenschap Yavuz Sultan Selim van Gent""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a8faa182c59167da7551f40979dc5022> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/db46915e77fbf8f083e9861c802b2b13> skos:altLabel """Islamitische geloofsgemeenschap Mehmet Akif van Antwerpen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/db46915e77fbf8f083e9861c802b2b13> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4fd6da5f1e1ea6e60f611abc4df28456> skos:altLabel """Islamitische geloofsgemeenschap Culturele Islamitische vereniging Badr van Hasselt""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/4fd6da5f1e1ea6e60f611abc4df28456> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/619a5721094b28807dca8d04de69e3e0> skos:altLabel """Islamitische geloofsgemeenschap Yunus Emre van Genk""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/619a5721094b28807dca8d04de69e3e0> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7e3fb673922f9495c48251f316c5c4ff> skos:altLabel """Islamitische geloofsgemeenschap Yesil Camii van Houthalen-Helchteren""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7e3fb673922f9495c48251f316c5c4ff> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/adeaab8a02815bf2c5816165a45ad4c5> skos:altLabel """Islamitische geloofsgemeenschap Sultan Ahmet van Heusden-Zolder""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/adeaab8a02815bf2c5816165a45ad4c5> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c1c334a2cc56ac501badce5e879aec65> skos:altLabel """Islamitische geloofsgemeenschap Hicret Camii van Sint-Niklaas""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c1c334a2cc56ac501badce5e879aec65> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c7d6827eb88cd977146e72583461071b> skos:altLabel """Islamitische geloofsgemeenschap Ensar van Mol""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c7d6827eb88cd977146e72583461071b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ca0daee18a29e187017bf236e26f1ec2> skos:altLabel """Islamitische geloofsgemeenschap Hassan Ebno Tabit van Genk""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ca0daee18a29e187017bf236e26f1ec2> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f95b761af55091b491fd62bd6bed11dc> skos:altLabel """Islamitische geloofsgemeenschap Al Ihsaan van Leuven""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f95b761af55091b491fd62bd6bed11dc> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b540096ac8be2c9c72dafd59e61080c5> skos:altLabel """Islamitische geloofsgemeenschap Tevhid Camii van Gent""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b540096ac8be2c9c72dafd59e61080c5> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0f2a4604a962926d67518bb3846af1c9> skos:altLabel """Islamitische geloofsgemeenschap Yildirim Beyazit Camii van Genk""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/0f2a4604a962926d67518bb3846af1c9> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/58d6bea16bd86c7df65caa9625af97aa> skos:altLabel """Islamitische geloofsgemeenschap Mevlana Camii van Genk""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/58d6bea16bd86c7df65caa9625af97aa> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a6e0531c6c4b5885552604163cfabfbc> skos:altLabel """Islamitische geloofsgemeenschap Selimiye Camii van Lommel""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a6e0531c6c4b5885552604163cfabfbc> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a8880f3d8b482788c5f3adbf58f01b4f> skos:altLabel """Islamitische geloofsgemeenschap Al Mouhsinine van Bilzen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a8880f3d8b482788c5f3adbf58f01b4f> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ef77bb3094fdc4a7ed7e09551500acfe> skos:altLabel """Islamitische geloofsgemeenschap Attaqwa van Antwerpen (Deurne)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ef77bb3094fdc4a7ed7e09551500acfe> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8c46fc84fb7a11cca44bde007a0c081c> skos:altLabel """Islamitische geloofsgemeenschap Innerlijke Vrede van Antwerpen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/8c46fc84fb7a11cca44bde007a0c081c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/928335b5a7b1cb7850c7cc98574e9ec9> skos:altLabel """Islamitische geloofsgemeenschap Fatih van Genk""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/928335b5a7b1cb7850c7cc98574e9ec9> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/934cb872a84a86ceb9a9e10abb1d08fa> skos:altLabel """Islamitische geloofsgemeenschap Barmhartig van Sint-Truiden""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/934cb872a84a86ceb9a9e10abb1d08fa> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fd4ae252fffca29852354b12ef37b086> skos:altLabel """Islamitische geloofsgemeenschap Assounah van Waregem (Desselgem)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/fd4ae252fffca29852354b12ef37b086> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a8d9f1a45c11c6761306bdf680349593> skos:altLabel """Islamitische geloofsgemeenschap Ensarija van Gent""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a8d9f1a45c11c6761306bdf680349593> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/62B968EDD7779543F777954A> skos:altLabel """Tauhid""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/62B968EDD7779543F777954A> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/62C427EBD7779543F777959E> skos:altLabel """El Mouslimine""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/62C427EBD7779543F777959E> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/104a6b6eabd0192afdeb70d3b517aef1> skos:altLabel """Islamitische geloofsgemeenschap Kevser van Aalst""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/104a6b6eabd0192afdeb70d3b517aef1> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b798c1a0e56ace342d225a503dcc384c> skos:altLabel """Orthodoxe Kerk Moeder Gods, Troosteres der Bedroefden van Diksmuide (Pervijze)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b798c1a0e56ace342d225a503dcc384c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6c16ba36223ff4e2dd0e76036a0b0d50> skos:altLabel """Orthodoxe Kerk H. Barbara van Genk""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6c16ba36223ff4e2dd0e76036a0b0d50> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9daaa2917a374a55e3d8ba100bf329e5> skos:altLabel """Orthodoxe Kerk H. Dimitrios van Maasmechelen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/9daaa2917a374a55e3d8ba100bf329e5> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e0e7121368dfc45d9a809a1a36b65e32> skos:altLabel """Orthodoxe Kerk H. Konstantijn en Helena van Brugge""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e0e7121368dfc45d9a809a1a36b65e32> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/eecb5159c45e6e9fa263d6d697f3b446> skos:altLabel """Orthodoxe Kerk H. Amandus van Kortrijk""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/eecb5159c45e6e9fa263d6d697f3b446> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/064d0956f36a54c27e9d93828a34f538> skos:altLabel """Orthodoxe Kerk Maria-Boodschap van Antwerpen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/064d0956f36a54c27e9d93828a34f538> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1808db0b0ef2934850e3dde50db08f6b> skos:altLabel """Orthodoxe Kerk H. Nectarios - Oecumenisch Patriarchaat van Constantinopel van Beringen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1808db0b0ef2934850e3dde50db08f6b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/39090eb31b28e111e47e75dc38eaff42> skos:altLabel """Orthodoxe Kerk Geboorte Moeder Gods van Antwerpen (Wilrijk)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/39090eb31b28e111e47e75dc38eaff42> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bb00c66671c9bf05025876eb749d2a02> skos:altLabel """Orthodoxe Kerk H. Apostel Andreas van Gent""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bb00c66671c9bf05025876eb749d2a02> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c821b81409bd4c56b8eb9e32ce09a841> skos:altLabel """Orthodoxe Kerk H. Aartsengel Michaël Archistrateeg van Genk""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c821b81409bd4c56b8eb9e32ce09a841> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c85d82dfc9fcf2ab5857bb9891a6c447> skos:altLabel """Orthodoxe Kerk H. Apostel en Evangelist Mattheos van Leuven""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c85d82dfc9fcf2ab5857bb9891a6c447> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6b860cbdc90a8952bdd14b707817225e> skos:altLabel """Orthodoxe Kerk HH. Kyrillos en Methodios van Oostende""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/6b860cbdc90a8952bdd14b707817225e> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a76be3cc51350736372b1cb61f5a8245> skos:altLabel """Orthodoxe Kerk HH. Drie Hiërarchen van Hasselt""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/a76be3cc51350736372b1cb61f5a8245> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bba84f42c09cd7c8b2e5a9829a820cf5> skos:altLabel """Orthodoxe Kerk H. Johannes de Theoloog van Oostende""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/bba84f42c09cd7c8b2e5a9829a820cf5> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/43fb31ca870d9c3ea47d02f153c8be6f> skos:altLabel """Orthodoxe Kerk HH. Andreas en Materne van Aalst""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/43fb31ca870d9c3ea47d02f153c8be6f> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/62C40176D7779543F7779593> skos:altLabel """Orthodoxe parochie van de Heiligen Georgios en Alena van Dilbeek""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/62C40176D7779543F7779593> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/62C584C5D7779543F77795CA> skos:altLabel """Orthodoxe Parochie H. Georgios Turnhout""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/62C584C5D7779543F77795CA> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ccc351e0430689ca49e09d77cd074a5d> skos:altLabel """Orthodoxe Kerk Christus' Geboorte van Antwerpen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/ccc351e0430689ca49e09d77cd074a5d> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/20667054581bba972a5968d2d47b5ed4> skos:altLabel """Protestantse Kerk Christelijk Gereformeerde Kerk van Antwerpen (Deurne)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/20667054581bba972a5968d2d47b5ed4> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/580873b83ab874b95711ec2db3ca1717> skos:altLabel """Protestantse Kerk Christengemeente Ichthus van Kortrijk""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/580873b83ab874b95711ec2db3ca1717> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e2f5b8e0224b1af556165508195ccb76> skos:altLabel """Evangelische Kerk Christengemeente van Houthalen-Helchteren (Houthalen)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e2f5b8e0224b1af556165508195ccb76> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1b8737e8a8870c5edaee0f9edf72a881> skos:altLabel """Evangelische Kerk Christengemeente van Antwerpen (Berchem)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1b8737e8a8870c5edaee0f9edf72a881> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1ddd00f077b747579a58189a2151c05c> skos:altLabel """Evangelische Kerk Philadelphia van Antwerpen (Hoboken)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/1ddd00f077b747579a58189a2151c05c> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/25364ce478850ac57891a6ea8b4125d6> skos:altLabel """Evangelische Kerk Duitstalige kerkgemeente van Antwerpen (Wilrijk)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/25364ce478850ac57891a6ea8b4125d6> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/58dfa349109d8725d9b7fb54adfed721> skos:altLabel """Evangelische Kerk van Leuven""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/58dfa349109d8725d9b7fb54adfed721> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/77fd7b2aeb6bcb3f7d80db6e25a98e41> skos:altLabel """Protestantse Kerk De Shelter van Aarschot""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/77fd7b2aeb6bcb3f7d80db6e25a98e41> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7a705f8e2b9cf99d192cd1b1619b3e42> skos:altLabel """Protestantse Kerk Pinkstergemeente De Kruispoort van Brugge""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/7a705f8e2b9cf99d192cd1b1619b3e42> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c2740896a4a3c80c7967ddca52887829> skos:altLabel """Evangelische Kerk De Hoeksteen van Ieper""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c2740896a4a3c80c7967ddca52887829> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e046f7d370958c8822e2bfa241851774> skos:altLabel """Protestantse Kerk Baptistenkerk Bethel van Middelkerke (Lombardsijde)""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e046f7d370958c8822e2bfa241851774> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f0acc5869aa714bf445fb29fc0d26c1b> skos:altLabel """Evangelische Kerk De Graankorrel van Beringen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f0acc5869aa714bf445fb29fc0d26c1b> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/110aa9cc86de3760f583a9c31b5add39> skos:altLabel """Evangelische Kerk Bourgoyen van Gent""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/110aa9cc86de3760f583a9c31b5add39> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/44329be9ac7054b39adbc583b6203ba2> skos:altLabel """Protestantse Kerk Christengemeente Emmanuel van Haacht""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/44329be9ac7054b39adbc583b6203ba2> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/be87d5a9a250eee7232772dc99401b86> skos:altLabel """Evangelische Kerk Vereniging van Vrije evangelische Gemeenten De Burg van Gent""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/be87d5a9a250eee7232772dc99401b86> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c13018155cfdffc26169eae78f1a300d> skos:altLabel """Evangelische gemeente Paulus""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/c13018155cfdffc26169eae78f1a300d> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e004568673ac1db1cb3d9c158c520a48> skos:altLabel """Evangelische Kerk Kerk aan de Leie van Gent""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/e004568673ac1db1cb3d9c158c520a48> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/622EFE7FB72F9F4B33507E89> skos:altLabel """Evangelische Kerk Bilzen""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/622EFE7FB72F9F4B33507E89> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/62C550A8D7779543F77795BF> skos:altLabel """Evangelische Gemeente De Pottenbakker""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/62C550A8D7779543F77795BF> skos:prefLabel ?prefLabel .
+  }
+}
+;
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f99035f2eca9a50996e719c445d2cfd2> skos:altLabel """Evangelische kerk Kortrijk Wijkkerk Mariadorp""" .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/besturenVanDeEredienst/f99035f2eca9a50996e719c445d2cfd2> skos:prefLabel ?prefLabel .
+  }
+}


### PR DESCRIPTION
OP-3115

Adds a migration to import the legal and alternative names for worship services.

## Notes

- Any existing legal name is first removed.
- The alternative name queries check whether there exists a `skos:prefLabel`
  triple for the resource to avoid inserting names for non-exiting organizations
  (in DEV or QA).
- Any already existing alternative names, inputted by the users, are not
  modified or deleted.
- Deployment:
  - Also restart the cache (and resources) service to ensure the changes
    immediately show up for all organizations.
  - Perform full reindex

## TODO

- [x] Wait for information on what to do with unexpected input data, see
      comments ticket.