### PR TITLE
Bump old producers, from 0.15.4 -> 0.15.5

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -383,7 +383,7 @@ services:
     restart: always
     logging: *default-logging
   delta-producer-pub-graph-maintainer-organizations-public-info:
-    image: lblod/delta-producer-publication-graph-maintainer:0.15.4
+    image: lblod/delta-producer-publication-graph-maintainer:0.15.5
     environment:
       MAX_BODY_SIZE: "50mb"
       JOBS_GRAPH: "http://mu.semte.ch/graphs/jobs"
@@ -436,7 +436,7 @@ services:
     restart: always
     logging: *default-logging
   delta-producer-pub-graph-maintainer-public:
-    image: lblod/delta-producer-publication-graph-maintainer:0.15.4
+    image: lblod/delta-producer-publication-graph-maintainer:0.15.5
     environment:
       MAX_BODY_SIZE: "50mb"
       JOBS_GRAPH: "http://mu.semte.ch/graphs/jobs"
@@ -487,7 +487,7 @@ services:
     restart: always
     logging: *default-logging
   delta-producer-pub-graph-maintainer-worship-posts:
-    image: lblod/delta-producer-publication-graph-maintainer:0.15.4
+    image: lblod/delta-producer-publication-graph-maintainer:0.15.5
     environment:
       MAX_BODY_SIZE: "50mb"
       JOBS_GRAPH: "http://mu.semte.ch/graphs/jobs"


### PR DESCRIPTION
There was an issue with the old producers not taking into account all graph filters, thereby exporting sometimes too many triples.

Note: please consider moving these old producers to the latest one. (It should be a matter of shuffling config around)
seeAlso: DL-5911

Can this be first merged in master and then merged in development?