### PR TITLE
feat: add governing bodies, mandates, and functions for 2025 legislature

### DIFF
--- a/config/migrations/2024/20240828104739-governing-bodies-mandates-2025-legislation/20240829160204-timed-governing-bodies-gemeente-2025.sparql
+++ b/config/migrations/2024/20240828104739-governing-bodies-mandates-2025-legislation/20240829160204-timed-governing-bodies-gemeente-2025.sparql
@@ -1,0 +1,60 @@
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX regorg: <http://www.w3.org/ns/regorg#>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?timedGoverningBody a besluit:Bestuursorgaan ;
+      mu:uuid ?timedGoverningBodyUuid ;
+      generiek:isTijdspecialisatieVan ?governingBody ;
+      mandaat:bindingStart "2025-01-01T00:00:00"^^xsd:dateTime .
+  }
+} WHERE {
+  # Note: for municipalities and provinces the graphs differ, splitting this
+  # WHERE clause in two GRAPH clauses simplifies the generation of these
+  # migrations.
+  GRAPH <http://mu.semte.ch/graphs/shared> {
+    ?organization mu:uuid ?organizationUuid ;
+      org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001> . # Gemeente
+  }
+
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?governingBody besluit:bestuurt ?organization ;
+      org:classification ?governingBodyClassification .
+
+    # Only active organizations should get new timed governing bodies
+    ?organization regorg:orgStatus <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> . # Actief (Eng. Active)
+  }
+
+  FILTER (
+          ?organization
+          NOT IN
+          (<http://data.lblod.info/id/bestuurseenheden/4f0eb4436c88cf831c35f84e7c34ce32f9ee4e99c5139aff62990e5e531aa1e7> # Beveren
+           , <http://data.lblod.info/id/bestuurseenheden/05441122597e0b20b61a8968ea1247c07f9014aad1f1f0709d0b1234e3dfbc2f> # Borgloon
+           , <http://data.lblod.info/id/bestuurseenheden/e41ffa04f94bb450a79793020e70d55b5fee5033a5280277998608a9d0913117> # Borsbeek
+           , <http://data.lblod.info/id/bestuurseenheden/e39bc997aa6dd9f240277735efd745b6a0422614d2b36cf01825c86b1b91a9ee> # De Pinte
+           , <http://data.lblod.info/id/bestuurseenheden/00eb231f51bd6b4f5dcc6536b2d09a174ea8583f5bf28b10bc4fc769a07e511d> # Galmaarden
+           , <http://data.lblod.info/id/bestuurseenheden/c69192b973a3ca11531b9657b3ee20aa6688fa33ea1ef1392310fec751980ab2> # Gooik
+           , <http://data.lblod.info/id/bestuurseenheden/3eb8c9fae32d02359dcd7b22e2a74e67a5b48388df31ad819c27c688fedd10b0> # Herne
+           , <http://data.lblod.info/id/bestuurseenheden/a3bd0845853278f478f90b14436d3efa99e73249a84d462f0ddc2e5b6e37a156> # Hoeselt
+           , <http://data.lblod.info/id/bestuurseenheden/f6b131de5e40a0dfd4fc93fedf3b95c9bf156ece718b87fe00469dea2564b3fb> # Kortessem
+           , <http://data.lblod.info/id/bestuurseenheden/6af55cecaea3621f53bb32417a36ed6e3d41b2aa5b9f6d62ab3d80cc8ec11539> # Kruibeke
+           , <http://data.lblod.info/id/bestuurseenheden/c0b6b5cf198cd939251dff8ed052177cfff245074c6b8d43394c8c97f7b6e945> # Melle
+           , <http://data.lblod.info/id/bestuurseenheden/8ef1e4a43efd913e6b09b0ddea344b7b5d723a344ad559389a55ae1ff0bebc8f> # Merelbeke
+           , <http://data.lblod.info/id/bestuurseenheden/5a4b2b4f1de1f3b91b0348a7eb6d6aa0ef9420b8ec31374970c9ffe933a79515> # Meulebeke
+           , <http://data.lblod.info/id/bestuurseenheden/c5dbb08e35e2d090a05d119fef4cc161b5ee1f322698cb8ea3c8c6643a521cf2> # Moerbeke
+           , <http://data.lblod.info/id/bestuurseenheden/0327a51548f73607f8a5ec11b36711a3c96703686ad93a3d632718c135c295db> # Nazareth
+           , <http://data.lblod.info/id/bestuurseenheden/2564e21e3650f91625189ccb7eb055e47754a0633c54c7582a899171fef60c52> # Ruiselede
+           , <http://data.lblod.info/id/bestuurseenheden/af8969752f6b28c66b6bc402d7987fa38774901ac72b95c5cb7976570487c3c9> # Tessenderlo
+           , <http://data.lblod.info/id/bestuurseenheden/1313d4a58f9ecf52cc7e274e3549a759b35e731973cc9f5e07562e5650f594dd> # Wachtebeke
+           , <http://data.lblod.info/id/bestuurseenheden/c362abc58ac4579ff417824ce620962ac57bc344b34fe8f51d21b35ef54da36d> # Zwijndrecht
+          )
+         )
+
+  BIND(SHA256(CONCAT(STR(?governingBodyClassification), " 2025 ", STR(?governingBody),  STR(?organizationUuid))) AS ?timedGoverningBodyUuid)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/bestuursorganen/", STR(?timedGoverningBodyUuid))) AS ?timedGoverningBody)
+}

--- a/config/migrations/2024/20240828104739-governing-bodies-mandates-2025-legislation/20240829160205-timed-governing-bodies-ocmw-2025.sparql
+++ b/config/migrations/2024/20240828104739-governing-bodies-mandates-2025-legislation/20240829160205-timed-governing-bodies-ocmw-2025.sparql
@@ -1,0 +1,60 @@
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX regorg: <http://www.w3.org/ns/regorg#>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?timedGoverningBody a besluit:Bestuursorgaan ;
+      mu:uuid ?timedGoverningBodyUuid ;
+      generiek:isTijdspecialisatieVan ?governingBody ;
+      mandaat:bindingStart "2025-01-01T00:00:00"^^xsd:dateTime .
+  }
+} WHERE {
+  # Note: for municipalities and provinces the graphs differ, splitting this
+  # WHERE clause in two GRAPH clauses simplifies the generation of these
+  # migrations.
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?organization mu:uuid ?organizationUuid ;
+      org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000002> . # OCMW
+  }
+
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?governingBody besluit:bestuurt ?organization ;
+      org:classification ?governingBodyClassification .
+
+    # Only active organizations should get new timed governing bodies
+    ?organization regorg:orgStatus <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> . # Actief (Eng. Active)
+  }
+
+  FILTER (
+          ?organization
+          NOT IN
+          (<http://data.lblod.info/id/bestuurseenheden/72bc672ceb6894d8dd31dc2dff2faad2fd93f4b9f5347d556d092516eaa30aa3> # Beveren
+           , <http://data.lblod.info/id/bestuurseenheden/3834647b5e95ea20f5ffe5a12a09fbd3d7fdf0d187fab385cb7b841422176ad6> # Borgloon
+           , <http://data.lblod.info/id/bestuurseenheden/7125fcbfb7a08f8c01efbed115cea602db249c04afe9b5a2cc298cc7949cd040> # Borsbeek
+           , <http://data.lblod.info/id/bestuurseenheden/144c75e403c5084af57f5c0c86252b8759b56baf9694326abbcb5ea40ab69f1a> # De Pinte
+           , <http://data.lblod.info/id/bestuurseenheden/ba8a253d98ea7d2ab1afc43e5e2cd145a12ccd86b68e71d023e3c13a83d7498f> # Galmaarden
+           , <http://data.lblod.info/id/bestuurseenheden/76c45d60f05bf8afc8c71859342b69cac6a57ee2b320b900a60afd6ba9b8eb9d> # Gooik
+           , <http://data.lblod.info/id/bestuurseenheden/5d21ccef2f5aa3ccbf3a74c6f25ebe9f0b1ef5a97b87f3d79c86ae9d6d857df8> # Herne
+           , <http://data.lblod.info/id/bestuurseenheden/785e8d5516378c7382ad0e7e356d2301496d810c6cd46d72ccebb455d3ac525e> # Hoeselt
+           , <http://data.lblod.info/id/bestuurseenheden/3e077115eeb70b649d44e2ebbb218f2cfcac5d84e130c88584f0ec23f7cebbf9> # Kortessem
+           , <http://data.lblod.info/id/bestuurseenheden/d3c76fd84794dad5e12c9eed6d6332dc5e5c99daf0e4ddd7ceebf13d5d6c0ccd> # Kruibeke
+           , <http://data.lblod.info/id/bestuurseenheden/04895013fe6301f32aa46deae98abfb833a717ece5a33b6c453674c6d0f4cc5e> # Melle
+           , <http://data.lblod.info/id/bestuurseenheden/f56f068943a99059f5bfc3b905fe8848a25a47cfa30fb3ed3d294b47815b2255> # Merelbeke
+           , <http://data.lblod.info/id/bestuurseenheden/3f57a17fbcdfc13def910c54948bec11d71d3f75946b0336fffc0587bf18d783> # Meulebeke
+           , <http://data.lblod.info/id/bestuurseenheden/f2a9a2392d5e4c0f992a84a0871d048a7b91b14681e9980a63aa6ba4b1f7eb8c> # Moerbeke
+           , <http://data.lblod.info/id/bestuurseenheden/0a2d980559eb9f3e0820386541274a72692f495204cd6d951ea1907ecc65829b> # Nazareth
+           , <http://data.lblod.info/id/bestuurseenheden/60daf27c2cf12dd123447aa300dd7320890391dbd8dd6b4dd7ec02258f8281b3> # Ruiselede
+           , <http://data.lblod.info/id/bestuurseenheden/fb1be873c4b31e391613dfae8e68edd694b1fdf126eeecb502b1e5cad6f2f682> # Tessenderlo
+           , <http://data.lblod.info/id/bestuurseenheden/7c6b38fa6fc65879cb674a654617de171adfcfacba086fb918da3749dbaa43b5> # Wachtebeke
+           , <http://data.lblod.info/id/bestuurseenheden/bbc23313f4c8585a0c51f15f920d77123356535cd1cad9af38f5707892c7088d> # Zwijndrecht
+          )
+         )
+
+  BIND(SHA256(CONCAT(STR(?governingBodyClassification), " 2025 ", STR(?governingBody),  STR(?organizationUuid))) AS ?timedGoverningBodyUuid)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/bestuursorganen/", STR(?timedGoverningBodyUuid))) AS ?timedGoverningBody)
+}

--- a/config/migrations/2024/20240828104739-governing-bodies-mandates-2025-legislation/20240829160206-timed-governing-bodies-district-2025.sparql
+++ b/config/migrations/2024/20240828104739-governing-bodies-mandates-2025-legislation/20240829160206-timed-governing-bodies-district-2025.sparql
@@ -1,0 +1,35 @@
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX regorg: <http://www.w3.org/ns/regorg#>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?timedGoverningBody a besluit:Bestuursorgaan ;
+      mu:uuid ?timedGoverningBodyUuid ;
+      generiek:isTijdspecialisatieVan ?governingBody ;
+      mandaat:bindingStart "2025-01-01T00:00:00"^^xsd:dateTime .
+  }
+} WHERE {
+  # Note: for municipalities and provinces the graphs differ, splitting this
+  # WHERE clause in two GRAPH clauses simplifies the generation of these
+  # migrations.
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?organization mu:uuid ?organizationUuid ;
+      org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000003> . # District
+  }
+
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?governingBody besluit:bestuurt ?organization ;
+      org:classification ?governingBodyClassification .
+
+    # Only active organizations should get new timed governing bodies
+    ?organization regorg:orgStatus <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> . # Actief (Eng. Active)
+  }
+
+  BIND(SHA256(CONCAT(STR(?governingBodyClassification), " 2025 ", STR(?governingBody),  STR(?organizationUuid))) AS ?timedGoverningBodyUuid)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/bestuursorganen/", STR(?timedGoverningBodyUuid))) AS ?timedGoverningBody)
+}

--- a/config/migrations/2024/20240828104739-governing-bodies-mandates-2025-legislation/20240829160207-timed-governing-bodies-provincie-2025.sparql
+++ b/config/migrations/2024/20240828104739-governing-bodies-mandates-2025-legislation/20240829160207-timed-governing-bodies-provincie-2025.sparql
@@ -1,0 +1,35 @@
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX regorg: <http://www.w3.org/ns/regorg#>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?timedGoverningBody a besluit:Bestuursorgaan ;
+      mu:uuid ?timedGoverningBodyUuid ;
+      generiek:isTijdspecialisatieVan ?governingBody ;
+      mandaat:bindingStart "2025-01-01T00:00:00"^^xsd:dateTime .
+  }
+} WHERE {
+  # Note: for municipalities and provinces the graphs differ, splitting this
+  # WHERE clause in two GRAPH clauses simplifies the generation of these
+  # migrations.
+  GRAPH <http://mu.semte.ch/graphs/shared> {
+    ?organization mu:uuid ?organizationUuid ;
+      org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000000> . # Provincie
+  }
+
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?governingBody besluit:bestuurt ?organization ;
+      org:classification ?governingBodyClassification .
+
+    # Only active organizations should get new timed governing bodies
+    ?organization regorg:orgStatus <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> . # Actief (Eng. Active)
+  }
+
+  BIND(SHA256(CONCAT(STR(?governingBodyClassification), " 2025 ", STR(?governingBody),  STR(?organizationUuid))) AS ?timedGoverningBodyUuid)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/bestuursorganen/", STR(?timedGoverningBodyUuid))) AS ?timedGoverningBody)
+}

--- a/config/migrations/2024/20240828104739-governing-bodies-mandates-2025-legislation/20240829160208-add-missing-governing-bodies-merged-ocmw-beveren_kruibeke_zwijndrecht.sparql
+++ b/config/migrations/2024/20240828104739-governing-bodies-mandates-2025-legislation/20240829160208-add-missing-governing-bodies-merged-ocmw-beveren_kruibeke_zwijndrecht.sparql
@@ -1,0 +1,113 @@
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+
+# Algemeen directeur
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    # Abstract governing body
+    ?governingBody a besluit:Bestuursorgaan ;
+      mu:uuid ?governingBodyUuid ;
+      skos:prefLabel ?governingBodyLabel ;
+      besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/fd41f573-7d9a-4d9f-b7d0-d5b6114d1622> ;
+      org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/39854196-f214-4688-87a1-d6ad12baa2fa> .
+
+    # Timed specialisation for governing body
+    ?timedGoverningBody a besluit:Bestuursorgaan ;
+      mu:uuid ?timedGoverningBodyUuid ;
+      generiek:isTijdspecialisatieVan ?governingBody ;
+      mandaat:bindingStart "2025-01-01T00:00:00"^^xsd:dateTime .
+  }
+} WHERE {
+    <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/39854196-f214-4688-87a1-d6ad12baa2fa> skos:prefLabel ?classificationLabel .
+    BIND(CONCAT(?classificationLabel, " beveren_kruibeke_zwijndrecht") AS ?governingBodyLabel)
+
+    BIND(SHA256(CONCAT("http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/39854196-f214-4688-87a1-d6ad12baa2fa", " 2025 ", STR(<http://data.lblod.info/id/bestuurseenheden/fd41f573-7d9a-4d9f-b7d0-d5b6114d1622>))) AS ?governingBodyUuid)
+    BIND(IRI(CONCAT("http://data.lblod.info/id/bestuursorganen/", STR(?governingBodyUuid))) AS ?governingBody)
+
+    BIND(SHA256(CONCAT(STR(?governingBodyClassification), " 2025 ", STR(?governingBody),  STR(?organizationUuid))) AS ?timedGoverningBodyUuid)
+    BIND(IRI(CONCAT("http://data.lblod.info/id/bestuursorganen/", STR(?timedGoverningBodyUuid))) AS ?timedGoverningBody)
+}
+;
+# Adjunct-algemeen directeur
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    # Abstract governing body
+    ?governingBody a besluit:Bestuursorgaan ;
+      mu:uuid ?governingBodyUuid ;
+      skos:prefLabel ?governingBodyLabel ;
+      besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/fd41f573-7d9a-4d9f-b7d0-d5b6114d1622> ;
+      org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/11f0af9e-016c-4e0b-983a-d8bc73804abc> .
+
+    # Timed specialisation for governing body
+    ?timedGoverningBody a besluit:Bestuursorgaan ;
+      mu:uuid ?timedGoverningBodyUuid ;
+      generiek:isTijdspecialisatieVan ?governingBody ;
+      mandaat:bindingStart "2025-01-01T00:00:00"^^xsd:dateTime .
+  }
+} WHERE {
+    <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/11f0af9e-016c-4e0b-983a-d8bc73804abc> skos:prefLabel ?classificationLabel .
+    BIND(CONCAT(?classificationLabel, " beveren_kruibeke_zwijndrecht") AS ?governingBodyLabel)
+
+    BIND(SHA256(CONCAT("http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/11f0af9e-016c-4e0b-983a-d8bc73804abc", " 2025 ", STR(<http://data.lblod.info/id/bestuurseenheden/fd41f573-7d9a-4d9f-b7d0-d5b6114d1622>))) AS ?governingBodyUuid)
+    BIND(IRI(CONCAT("http://data.lblod.info/id/bestuursorganen/", STR(?governingBodyUuid))) AS ?governingBody)
+
+    BIND(SHA256(CONCAT(STR(?governingBodyClassification), " 2025 ", STR(?governingBody),  STR(?organizationUuid))) AS ?timedGoverningBodyUuid)
+    BIND(IRI(CONCAT("http://data.lblod.info/id/bestuursorganen/", STR(?timedGoverningBodyUuid))) AS ?timedGoverningBody)
+}
+;
+# Financieel directeur
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    # Abstract governing body
+    ?governingBody a besluit:Bestuursorgaan ;
+      mu:uuid ?governingBodyUuid ;
+      skos:prefLabel ?governingBodyLabel ;
+      besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/fd41f573-7d9a-4d9f-b7d0-d5b6114d1622> ;
+      org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/62644b9c-4514-41dd-a660-4c35257f2b35> .
+
+    # Timed specialisation for governing body
+    ?timedGoverningBody a besluit:Bestuursorgaan ;
+      mu:uuid ?timedGoverningBodyUuid ;
+      generiek:isTijdspecialisatieVan ?governingBody ;
+      mandaat:bindingStart "2025-01-01T00:00:00"^^xsd:dateTime .
+  }
+} WHERE {
+    <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/62644b9c-4514-41dd-a660-4c35257f2b35> skos:prefLabel ?classificationLabel .
+    BIND(CONCAT(?classificationLabel, " beveren_kruibeke_zwijndrecht") AS ?governingBodyLabel)
+
+    BIND(SHA256(CONCAT("http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/62644b9c-4514-41dd-a660-4c35257f2b35", " 2025 ", STR(<http://data.lblod.info/id/bestuurseenheden/fd41f573-7d9a-4d9f-b7d0-d5b6114d1622>))) AS ?governingBodyUuid)
+    BIND(IRI(CONCAT("http://data.lblod.info/id/bestuursorganen/", STR(?governingBodyUuid))) AS ?governingBody)
+
+    BIND(SHA256(CONCAT(STR(?governingBodyClassification), " 2025 ", STR(?governingBody),  STR(?organizationUuid))) AS ?timedGoverningBodyUuid)
+    BIND(IRI(CONCAT("http://data.lblod.info/id/bestuursorganen/", STR(?timedGoverningBodyUuid))) AS ?timedGoverningBody)
+}
+;
+# Adjunct-financieel directeur
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    # Abstract governing body
+    ?governingBody a besluit:Bestuursorgaan ;
+      mu:uuid ?governingBodyUuid ;
+      skos:prefLabel ?governingBodyLabel ;
+      besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/fd41f573-7d9a-4d9f-b7d0-d5b6114d1622> ;
+      org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/ed40469e-3b6f-4f38-99ba-18912ee352b0> .
+
+    # Timed specialisation for governing body
+    ?timedGoverningBody a besluit:Bestuursorgaan ;
+      mu:uuid ?timedGoverningBodyUuid ;
+      generiek:isTijdspecialisatieVan ?governingBody ;
+      mandaat:bindingStart "2025-01-01T00:00:00"^^xsd:dateTime .
+  }
+} WHERE {
+    <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/ed40469e-3b6f-4f38-99ba-18912ee352b0> skos:prefLabel ?classificationLabel .
+    BIND(CONCAT(?classificationLabel, " beveren_kruibeke_zwijndrecht") AS ?governingBodyLabel)
+
+    BIND(SHA256(CONCAT("http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/ed40469e-3b6f-4f38-99ba-18912ee352b0", " 2025 ", STR(<http://data.lblod.info/id/bestuurseenheden/fd41f573-7d9a-4d9f-b7d0-d5b6114d1622>))) AS ?governingBodyUuid)
+    BIND(IRI(CONCAT("http://data.lblod.info/id/bestuursorganen/", STR(?governingBodyUuid))) AS ?governingBody)
+
+    BIND(SHA256(CONCAT(STR(?governingBodyClassification), " 2025 ", STR(?governingBody),  STR(?organizationUuid))) AS ?timedGoverningBodyUuid)
+    BIND(IRI(CONCAT("http://data.lblod.info/id/bestuursorganen/", STR(?timedGoverningBodyUuid))) AS ?timedGoverningBody)
+}

--- a/config/migrations/2024/20240828104739-governing-bodies-mandates-2025-legislation/20240829160209-add-missing-governing-bodies-merged-ocmw-merelbeke_melle.sparql
+++ b/config/migrations/2024/20240828104739-governing-bodies-mandates-2025-legislation/20240829160209-add-missing-governing-bodies-merged-ocmw-merelbeke_melle.sparql
@@ -1,0 +1,113 @@
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+
+# Algemeen directeur
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    # Abstract governing body
+    ?governingBody a besluit:Bestuursorgaan ;
+      mu:uuid ?governingBodyUuid ;
+      skos:prefLabel ?governingBodyLabel ;
+      besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/5d94b2fd-60ee-4e56-a1f0-a586d596adf6> ;
+      org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/39854196-f214-4688-87a1-d6ad12baa2fa> .
+
+    # Timed specialisation for governing body
+    ?timedGoverningBody a besluit:Bestuursorgaan ;
+      mu:uuid ?timedGoverningBodyUuid ;
+      generiek:isTijdspecialisatieVan ?governingBody ;
+      mandaat:bindingStart "2025-01-01T00:00:00"^^xsd:dateTime .
+  }
+} WHERE {
+    <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/39854196-f214-4688-87a1-d6ad12baa2fa> skos:prefLabel ?classificationLabel .
+    BIND(CONCAT(?classificationLabel, " merelbeke_melle") AS ?governingBodyLabel)
+
+    BIND(SHA256(CONCAT("http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/39854196-f214-4688-87a1-d6ad12baa2fa", " 2025 ", STR(<http://data.lblod.info/id/bestuurseenheden/5d94b2fd-60ee-4e56-a1f0-a586d596adf6>))) AS ?governingBodyUuid)
+    BIND(IRI(CONCAT("http://data.lblod.info/id/bestuursorganen/", STR(?governingBodyUuid))) AS ?governingBody)
+
+    BIND(SHA256(CONCAT(STR(?governingBodyClassification), " 2025 ", STR(?governingBody),  STR(?organizationUuid))) AS ?timedGoverningBodyUuid)
+    BIND(IRI(CONCAT("http://data.lblod.info/id/bestuursorganen/", STR(?timedGoverningBodyUuid))) AS ?timedGoverningBody)
+}
+;
+# Adjunct-algemeen directeur
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    # Abstract governing body
+    ?governingBody a besluit:Bestuursorgaan ;
+      mu:uuid ?governingBodyUuid ;
+      skos:prefLabel ?governingBodyLabel ;
+      besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/5d94b2fd-60ee-4e56-a1f0-a586d596adf6> ;
+      org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/11f0af9e-016c-4e0b-983a-d8bc73804abc> .
+
+    # Timed specialisation for governing body
+    ?timedGoverningBody a besluit:Bestuursorgaan ;
+      mu:uuid ?timedGoverningBodyUuid ;
+      generiek:isTijdspecialisatieVan ?governingBody ;
+      mandaat:bindingStart "2025-01-01T00:00:00"^^xsd:dateTime .
+  }
+} WHERE {
+    <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/11f0af9e-016c-4e0b-983a-d8bc73804abc> skos:prefLabel ?classificationLabel .
+    BIND(CONCAT(?classificationLabel, " merelbeke_melle") AS ?governingBodyLabel)
+
+    BIND(SHA256(CONCAT("http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/11f0af9e-016c-4e0b-983a-d8bc73804abc", " 2025 ", STR(<http://data.lblod.info/id/bestuurseenheden/5d94b2fd-60ee-4e56-a1f0-a586d596adf6>))) AS ?governingBodyUuid)
+    BIND(IRI(CONCAT("http://data.lblod.info/id/bestuursorganen/", STR(?governingBodyUuid))) AS ?governingBody)
+
+    BIND(SHA256(CONCAT(STR(?governingBodyClassification), " 2025 ", STR(?governingBody),  STR(?organizationUuid))) AS ?timedGoverningBodyUuid)
+    BIND(IRI(CONCAT("http://data.lblod.info/id/bestuursorganen/", STR(?timedGoverningBodyUuid))) AS ?timedGoverningBody)
+}
+;
+# Financieel directeur
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    # Abstract governing body
+    ?governingBody a besluit:Bestuursorgaan ;
+      mu:uuid ?governingBodyUuid ;
+      skos:prefLabel ?governingBodyLabel ;
+      besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/5d94b2fd-60ee-4e56-a1f0-a586d596adf6> ;
+      org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/62644b9c-4514-41dd-a660-4c35257f2b35> .
+
+    # Timed specialisation for governing body
+    ?timedGoverningBody a besluit:Bestuursorgaan ;
+      mu:uuid ?timedGoverningBodyUuid ;
+      generiek:isTijdspecialisatieVan ?governingBody ;
+      mandaat:bindingStart "2025-01-01T00:00:00"^^xsd:dateTime .
+  }
+} WHERE {
+    <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/62644b9c-4514-41dd-a660-4c35257f2b35> skos:prefLabel ?classificationLabel .
+    BIND(CONCAT(?classificationLabel, " merelbeke_melle") AS ?governingBodyLabel)
+
+    BIND(SHA256(CONCAT("http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/62644b9c-4514-41dd-a660-4c35257f2b35", " 2025 ", STR(<http://data.lblod.info/id/bestuurseenheden/5d94b2fd-60ee-4e56-a1f0-a586d596adf6>))) AS ?governingBodyUuid)
+    BIND(IRI(CONCAT("http://data.lblod.info/id/bestuursorganen/", STR(?governingBodyUuid))) AS ?governingBody)
+
+    BIND(SHA256(CONCAT(STR(?governingBodyClassification), " 2025 ", STR(?governingBody),  STR(?organizationUuid))) AS ?timedGoverningBodyUuid)
+    BIND(IRI(CONCAT("http://data.lblod.info/id/bestuursorganen/", STR(?timedGoverningBodyUuid))) AS ?timedGoverningBody)
+}
+;
+# Adjunct-financieel directeur
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    # Abstract governing body
+    ?governingBody a besluit:Bestuursorgaan ;
+      mu:uuid ?governingBodyUuid ;
+      skos:prefLabel ?governingBodyLabel ;
+      besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/5d94b2fd-60ee-4e56-a1f0-a586d596adf6> ;
+      org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/ed40469e-3b6f-4f38-99ba-18912ee352b0> .
+
+    # Timed specialisation for governing body
+    ?timedGoverningBody a besluit:Bestuursorgaan ;
+      mu:uuid ?timedGoverningBodyUuid ;
+      generiek:isTijdspecialisatieVan ?governingBody ;
+      mandaat:bindingStart "2025-01-01T00:00:00"^^xsd:dateTime .
+  }
+} WHERE {
+    <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/ed40469e-3b6f-4f38-99ba-18912ee352b0> skos:prefLabel ?classificationLabel .
+    BIND(CONCAT(?classificationLabel, " merelbeke_melle") AS ?governingBodyLabel)
+
+    BIND(SHA256(CONCAT("http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/ed40469e-3b6f-4f38-99ba-18912ee352b0", " 2025 ", STR(<http://data.lblod.info/id/bestuurseenheden/5d94b2fd-60ee-4e56-a1f0-a586d596adf6>))) AS ?governingBodyUuid)
+    BIND(IRI(CONCAT("http://data.lblod.info/id/bestuursorganen/", STR(?governingBodyUuid))) AS ?governingBody)
+
+    BIND(SHA256(CONCAT(STR(?governingBodyClassification), " 2025 ", STR(?governingBody),  STR(?organizationUuid))) AS ?timedGoverningBodyUuid)
+    BIND(IRI(CONCAT("http://data.lblod.info/id/bestuursorganen/", STR(?timedGoverningBodyUuid))) AS ?timedGoverningBody)
+}

--- a/config/migrations/2024/20240828104739-governing-bodies-mandates-2025-legislation/20240829160210-add-missing-governing-bodies-merged-ocmw-nazareth_de_pinte.sparql
+++ b/config/migrations/2024/20240828104739-governing-bodies-mandates-2025-legislation/20240829160210-add-missing-governing-bodies-merged-ocmw-nazareth_de_pinte.sparql
@@ -1,0 +1,113 @@
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+
+# Algemeen directeur
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    # Abstract governing body
+    ?governingBody a besluit:Bestuursorgaan ;
+      mu:uuid ?governingBodyUuid ;
+      skos:prefLabel ?governingBodyLabel ;
+      besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/7d53f659-3a3b-44b1-9e77-3ea067678c0e> ;
+      org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/39854196-f214-4688-87a1-d6ad12baa2fa> .
+
+    # Timed specialisation for governing body
+    ?timedGoverningBody a besluit:Bestuursorgaan ;
+      mu:uuid ?timedGoverningBodyUuid ;
+      generiek:isTijdspecialisatieVan ?governingBody ;
+      mandaat:bindingStart "2025-01-01T00:00:00"^^xsd:dateTime .
+  }
+} WHERE {
+    <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/39854196-f214-4688-87a1-d6ad12baa2fa> skos:prefLabel ?classificationLabel .
+    BIND(CONCAT(?classificationLabel, " nazareth_de_pinte") AS ?governingBodyLabel)
+
+    BIND(SHA256(CONCAT("http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/39854196-f214-4688-87a1-d6ad12baa2fa", " 2025 ", STR(<http://data.lblod.info/id/bestuurseenheden/7d53f659-3a3b-44b1-9e77-3ea067678c0e>))) AS ?governingBodyUuid)
+    BIND(IRI(CONCAT("http://data.lblod.info/id/bestuursorganen/", STR(?governingBodyUuid))) AS ?governingBody)
+
+    BIND(SHA256(CONCAT(STR(?governingBodyClassification), " 2025 ", STR(?governingBody),  STR(?organizationUuid))) AS ?timedGoverningBodyUuid)
+    BIND(IRI(CONCAT("http://data.lblod.info/id/bestuursorganen/", STR(?timedGoverningBodyUuid))) AS ?timedGoverningBody)
+}
+;
+# Adjunct-algemeen directeur
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    # Abstract governing body
+    ?governingBody a besluit:Bestuursorgaan ;
+      mu:uuid ?governingBodyUuid ;
+      skos:prefLabel ?governingBodyLabel ;
+      besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/7d53f659-3a3b-44b1-9e77-3ea067678c0e> ;
+      org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/11f0af9e-016c-4e0b-983a-d8bc73804abc> .
+
+    # Timed specialisation for governing body
+    ?timedGoverningBody a besluit:Bestuursorgaan ;
+      mu:uuid ?timedGoverningBodyUuid ;
+      generiek:isTijdspecialisatieVan ?governingBody ;
+      mandaat:bindingStart "2025-01-01T00:00:00"^^xsd:dateTime .
+  }
+} WHERE {
+    <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/11f0af9e-016c-4e0b-983a-d8bc73804abc> skos:prefLabel ?classificationLabel .
+    BIND(CONCAT(?classificationLabel, " nazareth_de_pinte") AS ?governingBodyLabel)
+
+    BIND(SHA256(CONCAT("http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/11f0af9e-016c-4e0b-983a-d8bc73804abc", " 2025 ", STR(<http://data.lblod.info/id/bestuurseenheden/7d53f659-3a3b-44b1-9e77-3ea067678c0e>))) AS ?governingBodyUuid)
+    BIND(IRI(CONCAT("http://data.lblod.info/id/bestuursorganen/", STR(?governingBodyUuid))) AS ?governingBody)
+
+    BIND(SHA256(CONCAT(STR(?governingBodyClassification), " 2025 ", STR(?governingBody),  STR(?organizationUuid))) AS ?timedGoverningBodyUuid)
+    BIND(IRI(CONCAT("http://data.lblod.info/id/bestuursorganen/", STR(?timedGoverningBodyUuid))) AS ?timedGoverningBody)
+}
+;
+# Financieel directeur
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    # Abstract governing body
+    ?governingBody a besluit:Bestuursorgaan ;
+      mu:uuid ?governingBodyUuid ;
+      skos:prefLabel ?governingBodyLabel ;
+      besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/7d53f659-3a3b-44b1-9e77-3ea067678c0e> ;
+      org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/62644b9c-4514-41dd-a660-4c35257f2b35> .
+
+    # Timed specialisation for governing body
+    ?timedGoverningBody a besluit:Bestuursorgaan ;
+      mu:uuid ?timedGoverningBodyUuid ;
+      generiek:isTijdspecialisatieVan ?governingBody ;
+      mandaat:bindingStart "2025-01-01T00:00:00"^^xsd:dateTime .
+  }
+} WHERE {
+    <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/62644b9c-4514-41dd-a660-4c35257f2b35> skos:prefLabel ?classificationLabel .
+    BIND(CONCAT(?classificationLabel, " nazareth_de_pinte") AS ?governingBodyLabel)
+
+    BIND(SHA256(CONCAT("http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/62644b9c-4514-41dd-a660-4c35257f2b35", " 2025 ", STR(<http://data.lblod.info/id/bestuurseenheden/7d53f659-3a3b-44b1-9e77-3ea067678c0e>))) AS ?governingBodyUuid)
+    BIND(IRI(CONCAT("http://data.lblod.info/id/bestuursorganen/", STR(?governingBodyUuid))) AS ?governingBody)
+
+    BIND(SHA256(CONCAT(STR(?governingBodyClassification), " 2025 ", STR(?governingBody),  STR(?organizationUuid))) AS ?timedGoverningBodyUuid)
+    BIND(IRI(CONCAT("http://data.lblod.info/id/bestuursorganen/", STR(?timedGoverningBodyUuid))) AS ?timedGoverningBody)
+}
+;
+# Adjunct-financieel directeur
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    # Abstract governing body
+    ?governingBody a besluit:Bestuursorgaan ;
+      mu:uuid ?governingBodyUuid ;
+      skos:prefLabel ?governingBodyLabel ;
+      besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/7d53f659-3a3b-44b1-9e77-3ea067678c0e> ;
+      org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/ed40469e-3b6f-4f38-99ba-18912ee352b0> .
+
+    # Timed specialisation for governing body
+    ?timedGoverningBody a besluit:Bestuursorgaan ;
+      mu:uuid ?timedGoverningBodyUuid ;
+      generiek:isTijdspecialisatieVan ?governingBody ;
+      mandaat:bindingStart "2025-01-01T00:00:00"^^xsd:dateTime .
+  }
+} WHERE {
+    <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/ed40469e-3b6f-4f38-99ba-18912ee352b0> skos:prefLabel ?classificationLabel .
+    BIND(CONCAT(?classificationLabel, " nazareth_de_pinte") AS ?governingBodyLabel)
+
+    BIND(SHA256(CONCAT("http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/ed40469e-3b6f-4f38-99ba-18912ee352b0", " 2025 ", STR(<http://data.lblod.info/id/bestuurseenheden/7d53f659-3a3b-44b1-9e77-3ea067678c0e>))) AS ?governingBodyUuid)
+    BIND(IRI(CONCAT("http://data.lblod.info/id/bestuursorganen/", STR(?governingBodyUuid))) AS ?governingBody)
+
+    BIND(SHA256(CONCAT(STR(?governingBodyClassification), " 2025 ", STR(?governingBody),  STR(?organizationUuid))) AS ?timedGoverningBodyUuid)
+    BIND(IRI(CONCAT("http://data.lblod.info/id/bestuursorganen/", STR(?timedGoverningBodyUuid))) AS ?timedGoverningBody)
+}

--- a/config/migrations/2024/20240828104739-governing-bodies-mandates-2025-legislation/20240829160211-add-missing-governing-bodies-merged-ocmw-pajottegem.sparql
+++ b/config/migrations/2024/20240828104739-governing-bodies-mandates-2025-legislation/20240829160211-add-missing-governing-bodies-merged-ocmw-pajottegem.sparql
@@ -1,0 +1,113 @@
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+
+# Algemeen directeur
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    # Abstract governing body
+    ?governingBody a besluit:Bestuursorgaan ;
+      mu:uuid ?governingBodyUuid ;
+      skos:prefLabel ?governingBodyLabel ;
+      besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/650378e7-1bee-4737-91ff-5b20ac4623cf> ;
+      org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/39854196-f214-4688-87a1-d6ad12baa2fa> .
+
+    # Timed specialisation for governing body
+    ?timedGoverningBody a besluit:Bestuursorgaan ;
+      mu:uuid ?timedGoverningBodyUuid ;
+      generiek:isTijdspecialisatieVan ?governingBody ;
+      mandaat:bindingStart "2025-01-01T00:00:00"^^xsd:dateTime .
+  }
+} WHERE {
+    <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/39854196-f214-4688-87a1-d6ad12baa2fa> skos:prefLabel ?classificationLabel .
+    BIND(CONCAT(?classificationLabel, " pajottegem") AS ?governingBodyLabel)
+
+    BIND(SHA256(CONCAT("http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/39854196-f214-4688-87a1-d6ad12baa2fa", " 2025 ", STR(<http://data.lblod.info/id/bestuurseenheden/650378e7-1bee-4737-91ff-5b20ac4623cf>))) AS ?governingBodyUuid)
+    BIND(IRI(CONCAT("http://data.lblod.info/id/bestuursorganen/", STR(?governingBodyUuid))) AS ?governingBody)
+
+    BIND(SHA256(CONCAT(STR(?governingBodyClassification), " 2025 ", STR(?governingBody),  STR(?organizationUuid))) AS ?timedGoverningBodyUuid)
+    BIND(IRI(CONCAT("http://data.lblod.info/id/bestuursorganen/", STR(?timedGoverningBodyUuid))) AS ?timedGoverningBody)
+}
+;
+# Adjunct-algemeen directeur
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    # Abstract governing body
+    ?governingBody a besluit:Bestuursorgaan ;
+      mu:uuid ?governingBodyUuid ;
+      skos:prefLabel ?governingBodyLabel ;
+      besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/650378e7-1bee-4737-91ff-5b20ac4623cf> ;
+      org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/11f0af9e-016c-4e0b-983a-d8bc73804abc> .
+
+    # Timed specialisation for governing body
+    ?timedGoverningBody a besluit:Bestuursorgaan ;
+      mu:uuid ?timedGoverningBodyUuid ;
+      generiek:isTijdspecialisatieVan ?governingBody ;
+      mandaat:bindingStart "2025-01-01T00:00:00"^^xsd:dateTime .
+  }
+} WHERE {
+    <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/11f0af9e-016c-4e0b-983a-d8bc73804abc> skos:prefLabel ?classificationLabel .
+    BIND(CONCAT(?classificationLabel, " pajottegem") AS ?governingBodyLabel)
+
+    BIND(SHA256(CONCAT("http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/11f0af9e-016c-4e0b-983a-d8bc73804abc", " 2025 ", STR(<http://data.lblod.info/id/bestuurseenheden/650378e7-1bee-4737-91ff-5b20ac4623cf>))) AS ?governingBodyUuid)
+    BIND(IRI(CONCAT("http://data.lblod.info/id/bestuursorganen/", STR(?governingBodyUuid))) AS ?governingBody)
+
+    BIND(SHA256(CONCAT(STR(?governingBodyClassification), " 2025 ", STR(?governingBody),  STR(?organizationUuid))) AS ?timedGoverningBodyUuid)
+    BIND(IRI(CONCAT("http://data.lblod.info/id/bestuursorganen/", STR(?timedGoverningBodyUuid))) AS ?timedGoverningBody)
+}
+;
+# Financieel directeur
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    # Abstract governing body
+    ?governingBody a besluit:Bestuursorgaan ;
+      mu:uuid ?governingBodyUuid ;
+      skos:prefLabel ?governingBodyLabel ;
+      besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/650378e7-1bee-4737-91ff-5b20ac4623cf> ;
+      org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/62644b9c-4514-41dd-a660-4c35257f2b35> .
+
+    # Timed specialisation for governing body
+    ?timedGoverningBody a besluit:Bestuursorgaan ;
+      mu:uuid ?timedGoverningBodyUuid ;
+      generiek:isTijdspecialisatieVan ?governingBody ;
+      mandaat:bindingStart "2025-01-01T00:00:00"^^xsd:dateTime .
+  }
+} WHERE {
+    <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/62644b9c-4514-41dd-a660-4c35257f2b35> skos:prefLabel ?classificationLabel .
+    BIND(CONCAT(?classificationLabel, " pajottegem") AS ?governingBodyLabel)
+
+    BIND(SHA256(CONCAT("http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/62644b9c-4514-41dd-a660-4c35257f2b35", " 2025 ", STR(<http://data.lblod.info/id/bestuurseenheden/650378e7-1bee-4737-91ff-5b20ac4623cf>))) AS ?governingBodyUuid)
+    BIND(IRI(CONCAT("http://data.lblod.info/id/bestuursorganen/", STR(?governingBodyUuid))) AS ?governingBody)
+
+    BIND(SHA256(CONCAT(STR(?governingBodyClassification), " 2025 ", STR(?governingBody),  STR(?organizationUuid))) AS ?timedGoverningBodyUuid)
+    BIND(IRI(CONCAT("http://data.lblod.info/id/bestuursorganen/", STR(?timedGoverningBodyUuid))) AS ?timedGoverningBody)
+}
+;
+# Adjunct-financieel directeur
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    # Abstract governing body
+    ?governingBody a besluit:Bestuursorgaan ;
+      mu:uuid ?governingBodyUuid ;
+      skos:prefLabel ?governingBodyLabel ;
+      besluit:bestuurt <http://data.lblod.info/id/bestuurseenheden/650378e7-1bee-4737-91ff-5b20ac4623cf> ;
+      org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/ed40469e-3b6f-4f38-99ba-18912ee352b0> .
+
+    # Timed specialisation for governing body
+    ?timedGoverningBody a besluit:Bestuursorgaan ;
+      mu:uuid ?timedGoverningBodyUuid ;
+      generiek:isTijdspecialisatieVan ?governingBody ;
+      mandaat:bindingStart "2025-01-01T00:00:00"^^xsd:dateTime .
+  }
+} WHERE {
+    <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/ed40469e-3b6f-4f38-99ba-18912ee352b0> skos:prefLabel ?classificationLabel .
+    BIND(CONCAT(?classificationLabel, " pajottegem") AS ?governingBodyLabel)
+
+    BIND(SHA256(CONCAT("http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/ed40469e-3b6f-4f38-99ba-18912ee352b0", " 2025 ", STR(<http://data.lblod.info/id/bestuurseenheden/650378e7-1bee-4737-91ff-5b20ac4623cf>))) AS ?governingBodyUuid)
+    BIND(IRI(CONCAT("http://data.lblod.info/id/bestuursorganen/", STR(?governingBodyUuid))) AS ?governingBody)
+
+    BIND(SHA256(CONCAT(STR(?governingBodyClassification), " 2025 ", STR(?governingBody),  STR(?organizationUuid))) AS ?timedGoverningBodyUuid)
+    BIND(IRI(CONCAT("http://data.lblod.info/id/bestuursorganen/", STR(?timedGoverningBodyUuid))) AS ?timedGoverningBody)
+}

--- a/config/migrations/2024/20240828104739-governing-bodies-mandates-2025-legislation/20240829171504-mandates-burgemeester.sparql
+++ b/config/migrations/2024/20240828104739-governing-bodies-mandates-2025-legislation/20240829171504-mandates-burgemeester.sparql
@@ -1,0 +1,32 @@
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?governingBodyInTime org:hasPost ?mandate .
+
+    ?mandate a mandaat:Mandaat , org:Post ;
+      mu:uuid ?mandateUuid ;
+      org:role ?mandateRole .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?governingBodyInTime a besluit:Bestuursorgaan ;
+      generiek:isTijdspecialisatieVan ?governingBody ;
+      mandaat:bindingStart "2025-01-01T00:00:00"^^xsd:dateTime .
+
+    ?governingBody org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/4955bd72cd0e4eb895fdbfab08da0284> . # Burgemeester
+  }
+
+  VALUES ?mandateRole {
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000013> # Burgemeester
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/7b038cc40bba10bec833ecfe6f15bc7a> # Aangewezen burgemeester
+
+  }
+
+  BIND(SHA256(CONCAT(STR(?governingBody), STR(?governingBodyInTime), STR(?mandateRole), " 2025")) AS ?mandateUuid)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/mandaten/", ?mandateUuid)) AS ?mandate)
+}

--- a/config/migrations/2024/20240828104739-governing-bodies-mandates-2025-legislation/20240829171505-mandates-gemeenteraad.sparql
+++ b/config/migrations/2024/20240828104739-governing-bodies-mandates-2025-legislation/20240829171505-mandates-gemeenteraad.sparql
@@ -1,0 +1,32 @@
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?governingBodyInTime org:hasPost ?mandate .
+
+    ?mandate a mandaat:Mandaat , org:Post ;
+      mu:uuid ?mandateUuid ;
+      org:role ?mandateRole .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?governingBodyInTime a besluit:Bestuursorgaan ;
+      generiek:isTijdspecialisatieVan ?governingBody ;
+      mandaat:bindingStart "2025-01-01T00:00:00"^^xsd:dateTime .
+
+    ?governingBody org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000005> . # Gemeenteraad
+  }
+
+  VALUES ?mandateRole {
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000012> # Voorzitter van de gemeenteraad
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000011> # Gemeenteraadslid
+
+  }
+
+  BIND(SHA256(CONCAT(STR(?governingBody), STR(?governingBodyInTime), STR(?mandateRole), " 2025")) AS ?mandateUuid)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/mandaten/", ?mandateUuid)) AS ?mandate)
+}

--- a/config/migrations/2024/20240828104739-governing-bodies-mandates-2025-legislation/20240829171506-mandates-college_van_burgemeester_en_schepenen.sparql
+++ b/config/migrations/2024/20240828104739-governing-bodies-mandates-2025-legislation/20240829171506-mandates-college_van_burgemeester_en_schepenen.sparql
@@ -1,0 +1,67 @@
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?governingBodyInTime org:hasPost ?mandate .
+
+    ?mandate a mandaat:Mandaat , org:Post ;
+      mu:uuid ?mandateUuid ;
+      org:role ?mandateRole .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?governingBodyInTime a besluit:Bestuursorgaan ;
+      generiek:isTijdspecialisatieVan ?governingBody ;
+      mandaat:bindingStart "2025-01-01T00:00:00"^^xsd:dateTime .
+
+    ?governingBody org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000006> . # College van Burgemeester en Schepenen
+  }
+
+  VALUES ?mandateRole {
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000014> # Schepen
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/59a90e03-4f22-4bb9-8c91-132618db4b38> # Toegevoegde schepen
+
+  }
+
+  BIND(SHA256(CONCAT(STR(?governingBody), STR(?governingBodyInTime), STR(?mandateRole), " 2025")) AS ?mandateUuid)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/mandaten/", ?mandateUuid)) AS ?mandate)
+}
+;
+# Link mandates shared with Burgemeester governing body
+# !! Make sure the Burgemeester governing body and its mandates are !!
+# !! already created, otherwise this will not work correctly. !!
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?governingBodyInTime org:hasPost ?mandate .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+
+    ?governingBodyInTime a besluit:Bestuursorgaan ;
+      generiek:isTijdspecialisatieVan ?governingBody ;
+      mandaat:bindingStart "2025-01-01T00:00:00"^^xsd:dateTime .
+
+    ?governingBody org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000006> . # College van Burgemeester en Schepenen
+
+    # Find the other governing body as it is needed to determine correct UUID and URI
+    ?governingBody besluit:bestuurt ?organisation .
+
+    ?governingBodyOther besluit:bestuurt ?organisation ;
+      org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/4955bd72cd0e4eb895fdbfab08da0284> . # Burgemeester
+    ?governingBodyInTimeOther a besluit:Bestuursorgaan ;
+      generiek:isTijdspecialisatieVan ?governingBodyOther ;
+      mandaat:bindingStart "2025-01-01T00:00:00"^^xsd:dateTime .
+  }
+  VALUES ?mandateRole {
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000013> # Burgemeester
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/7b038cc40bba10bec833ecfe6f15bc7a> # Aangewezen burgemeester
+
+  }
+
+  BIND(SHA256(CONCAT(STR(?governingBodyOther), STR(?governingBodyInTimeOther), STR(?mandateRole), " 2025")) AS ?mandateUuid)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/mandaten/", ?mandateUuid)) AS ?mandate)
+}

--- a/config/migrations/2024/20240828104739-governing-bodies-mandates-2025-legislation/20240829171507-mandates-voorzitter_van_het_bijzonder_comite_voor_de_sociale_dienst.sparql
+++ b/config/migrations/2024/20240828104739-governing-bodies-mandates-2025-legislation/20240829171507-mandates-voorzitter_van_het_bijzonder_comite_voor_de_sociale_dienst.sparql
@@ -1,0 +1,31 @@
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?governingBodyInTime org:hasPost ?mandate .
+
+    ?mandate a mandaat:Mandaat , org:Post ;
+      mu:uuid ?mandateUuid ;
+      org:role ?mandateRole .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?governingBodyInTime a besluit:Bestuursorgaan ;
+      generiek:isTijdspecialisatieVan ?governingBody ;
+      mandaat:bindingStart "2025-01-01T00:00:00"^^xsd:dateTime .
+
+    ?governingBody org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/53c0d8cd-f3a2-411d-bece-4bd83ae2bbc9> . # Voorzitter van het Bijzonder Comité voor de Sociale Dienst
+  }
+
+  VALUES ?mandateRole {
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e00001a> # Voorzitter van het Bijzonder Comité voor de Sociale Dienst
+
+  }
+
+  BIND(SHA256(CONCAT(STR(?governingBody), STR(?governingBodyInTime), STR(?mandateRole), " 2025")) AS ?mandateUuid)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/mandaten/", ?mandateUuid)) AS ?mandate)
+}

--- a/config/migrations/2024/20240828104739-governing-bodies-mandates-2025-legislation/20240829171508-mandates-raad_voor_maatschappelijk_welzijn.sparql
+++ b/config/migrations/2024/20240828104739-governing-bodies-mandates-2025-legislation/20240829171508-mandates-raad_voor_maatschappelijk_welzijn.sparql
@@ -1,0 +1,32 @@
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?governingBodyInTime org:hasPost ?mandate .
+
+    ?mandate a mandaat:Mandaat , org:Post ;
+      mu:uuid ?mandateUuid ;
+      org:role ?mandateRole .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?governingBodyInTime a besluit:Bestuursorgaan ;
+      generiek:isTijdspecialisatieVan ?governingBody ;
+      mandaat:bindingStart "2025-01-01T00:00:00"^^xsd:dateTime .
+
+    ?governingBody org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000007> . # Raad voor Maatschappelijk Welzijn
+  }
+
+  VALUES ?mandateRole {
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000016> # Voorzitter van de Raad voor Maatschappelijk Welzijn
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000015> # Lid van de Raad voor Maatschappelijk Welzijn
+
+  }
+
+  BIND(SHA256(CONCAT(STR(?governingBody), STR(?governingBodyInTime), STR(?mandateRole), " 2025")) AS ?mandateUuid)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/mandaten/", ?mandateUuid)) AS ?mandate)
+}

--- a/config/migrations/2024/20240828104739-governing-bodies-mandates-2025-legislation/20240829171509-mandates-vast_bureau.sparql
+++ b/config/migrations/2024/20240828104739-governing-bodies-mandates-2025-legislation/20240829171509-mandates-vast_bureau.sparql
@@ -1,0 +1,32 @@
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?governingBodyInTime org:hasPost ?mandate .
+
+    ?mandate a mandaat:Mandaat , org:Post ;
+      mu:uuid ?mandateUuid ;
+      org:role ?mandateRole .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?governingBodyInTime a besluit:Bestuursorgaan ;
+      generiek:isTijdspecialisatieVan ?governingBody ;
+      mandaat:bindingStart "2025-01-01T00:00:00"^^xsd:dateTime .
+
+    ?governingBody org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000008> . # Vast Bureau
+  }
+
+  VALUES ?mandateRole {
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000018> # Voorzitter van het Vast bureau
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000017> # Lid van het Vast Bureau
+
+  }
+
+  BIND(SHA256(CONCAT(STR(?governingBody), STR(?governingBodyInTime), STR(?mandateRole), " 2025")) AS ?mandateUuid)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/mandaten/", ?mandateUuid)) AS ?mandate)
+}

--- a/config/migrations/2024/20240828104739-governing-bodies-mandates-2025-legislation/20240829171510-mandates-bijzonder_comite_voor_de_sociale_dienst.sparql
+++ b/config/migrations/2024/20240828104739-governing-bodies-mandates-2025-legislation/20240829171510-mandates-bijzonder_comite_voor_de_sociale_dienst.sparql
@@ -1,0 +1,65 @@
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?governingBodyInTime org:hasPost ?mandate .
+
+    ?mandate a mandaat:Mandaat , org:Post ;
+      mu:uuid ?mandateUuid ;
+      org:role ?mandateRole .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?governingBodyInTime a besluit:Bestuursorgaan ;
+      generiek:isTijdspecialisatieVan ?governingBody ;
+      mandaat:bindingStart "2025-01-01T00:00:00"^^xsd:dateTime .
+
+    ?governingBody org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000009> . # Bijzonder Comité voor de Sociale Dienst
+  }
+
+  VALUES ?mandateRole {
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000019> # Lid van het Bijzonder Comité voor de Sociale Dienst
+
+  }
+
+  BIND(SHA256(CONCAT(STR(?governingBody), STR(?governingBodyInTime), STR(?mandateRole), " 2025")) AS ?mandateUuid)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/mandaten/", ?mandateUuid)) AS ?mandate)
+}
+;
+# Link mandates shared with Voorzitter van het Bijzonder Comité voor de Sociale Dienst governing body
+# !! Make sure the Voorzitter van het Bijzonder Comité voor de Sociale Dienst governing body and its mandates are !!
+# !! already created, otherwise this will not work correctly. !!
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?governingBodyInTime org:hasPost ?mandate .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+
+    ?governingBodyInTime a besluit:Bestuursorgaan ;
+      generiek:isTijdspecialisatieVan ?governingBody ;
+      mandaat:bindingStart "2025-01-01T00:00:00"^^xsd:dateTime .
+
+    ?governingBody org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000009> . # Bijzonder Comité voor de Sociale Dienst
+
+    # Find the other governing body as it is needed to determine correct UUID and URI
+    ?governingBody besluit:bestuurt ?organisation .
+
+    ?governingBodyOther besluit:bestuurt ?organisation ;
+      org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/53c0d8cd-f3a2-411d-bece-4bd83ae2bbc9> . # Voorzitter van het Bijzonder Comité voor de Sociale Dienst
+    ?governingBodyInTimeOther a besluit:Bestuursorgaan ;
+      generiek:isTijdspecialisatieVan ?governingBodyOther ;
+      mandaat:bindingStart "2025-01-01T00:00:00"^^xsd:dateTime .
+  }
+  VALUES ?mandateRole {
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e00001a> # Voorzitter van het Bijzonder Comité voor de Sociale Dienst
+
+  }
+
+  BIND(SHA256(CONCAT(STR(?governingBodyOther), STR(?governingBodyInTimeOther), STR(?mandateRole), " 2025")) AS ?mandateUuid)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/mandaten/", ?mandateUuid)) AS ?mandate)
+}

--- a/config/migrations/2024/20240828104739-governing-bodies-mandates-2025-legislation/20240829171511-mandates-provincieraad.sparql
+++ b/config/migrations/2024/20240828104739-governing-bodies-mandates-2025-legislation/20240829171511-mandates-provincieraad.sparql
@@ -1,0 +1,32 @@
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?governingBodyInTime org:hasPost ?mandate .
+
+    ?mandate a mandaat:Mandaat , org:Post ;
+      mu:uuid ?mandateUuid ;
+      org:role ?mandateRole .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?governingBodyInTime a besluit:Bestuursorgaan ;
+      generiek:isTijdspecialisatieVan ?governingBody ;
+      mandaat:bindingStart "2025-01-01T00:00:00"^^xsd:dateTime .
+
+    ?governingBody org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000c> . # Provincieraad
+  }
+
+  VALUES ?mandateRole {
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000027> # Voorzitter van de provincieraad
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e00001f> # Provincieraadslid
+
+  }
+
+  BIND(SHA256(CONCAT(STR(?governingBody), STR(?governingBodyInTime), STR(?mandateRole), " 2025")) AS ?mandateUuid)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/mandaten/", ?mandateUuid)) AS ?mandate)
+}

--- a/config/migrations/2024/20240828104739-governing-bodies-mandates-2025-legislation/20240829171512-mandates-gouverneur.sparql
+++ b/config/migrations/2024/20240828104739-governing-bodies-mandates-2025-legislation/20240829171512-mandates-gouverneur.sparql
@@ -1,0 +1,31 @@
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?governingBodyInTime org:hasPost ?mandate .
+
+    ?mandate a mandaat:Mandaat , org:Post ;
+      mu:uuid ?mandateUuid ;
+      org:role ?mandateRole .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?governingBodyInTime a besluit:Bestuursorgaan ;
+      generiek:isTijdspecialisatieVan ?governingBody ;
+      mandaat:bindingStart "2025-01-01T00:00:00"^^xsd:dateTime .
+
+    ?governingBody org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/180a2fba-6ca9-4766-9b94-82006bb9c709> . # Gouverneur
+  }
+
+  VALUES ?mandateRole {
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/d7c00cd1-baf1-4346-83c0-6796c0bedd85> # Gouverneur
+
+  }
+
+  BIND(SHA256(CONCAT(STR(?governingBody), STR(?governingBodyInTime), STR(?mandateRole), " 2025")) AS ?mandateUuid)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/mandaten/", ?mandateUuid)) AS ?mandate)
+}

--- a/config/migrations/2024/20240828104739-governing-bodies-mandates-2025-legislation/20240829171513-mandates-deputatie.sparql
+++ b/config/migrations/2024/20240828104739-governing-bodies-mandates-2025-legislation/20240829171513-mandates-deputatie.sparql
@@ -1,0 +1,31 @@
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?governingBodyInTime org:hasPost ?mandate .
+
+    ?mandate a mandaat:Mandaat , org:Post ;
+      mu:uuid ?mandateUuid ;
+      org:role ?mandateRole .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?governingBodyInTime a besluit:Bestuursorgaan ;
+      generiek:isTijdspecialisatieVan ?governingBody ;
+      mandaat:bindingStart "2025-01-01T00:00:00"^^xsd:dateTime .
+
+    ?governingBody org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000d> . # Deputatie
+  }
+
+  VALUES ?mandateRole {
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000020> # Gedeputeerde
+
+  }
+
+  BIND(SHA256(CONCAT(STR(?governingBody), STR(?governingBodyInTime), STR(?mandateRole), " 2025")) AS ?mandateUuid)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/mandaten/", ?mandateUuid)) AS ?mandate)
+}

--- a/config/migrations/2024/20240828104739-governing-bodies-mandates-2025-legislation/20240829171514-mandates-districtsraad.sparql
+++ b/config/migrations/2024/20240828104739-governing-bodies-mandates-2025-legislation/20240829171514-mandates-districtsraad.sparql
@@ -1,0 +1,32 @@
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?governingBodyInTime org:hasPost ?mandate .
+
+    ?mandate a mandaat:Mandaat , org:Post ;
+      mu:uuid ?mandateUuid ;
+      org:role ?mandateRole .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?governingBodyInTime a besluit:Bestuursorgaan ;
+      generiek:isTijdspecialisatieVan ?governingBody ;
+      mandaat:bindingStart "2025-01-01T00:00:00"^^xsd:dateTime .
+
+    ?governingBody org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000a> . # Districtsraad
+  }
+
+  VALUES ?mandateRole {
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e00001c> # Voorzitter van de districtsraad
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e00001b> # Districtsraadslid
+
+  }
+
+  BIND(SHA256(CONCAT(STR(?governingBody), STR(?governingBodyInTime), STR(?mandateRole), " 2025")) AS ?mandateUuid)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/mandaten/", ?mandateUuid)) AS ?mandate)
+}

--- a/config/migrations/2024/20240828104739-governing-bodies-mandates-2025-legislation/20240829171515-mandates-districtsburgemeester.sparql
+++ b/config/migrations/2024/20240828104739-governing-bodies-mandates-2025-legislation/20240829171515-mandates-districtsburgemeester.sparql
@@ -1,0 +1,31 @@
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?governingBodyInTime org:hasPost ?mandate .
+
+    ?mandate a mandaat:Mandaat , org:Post ;
+      mu:uuid ?mandateUuid ;
+      org:role ?mandateRole .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?governingBodyInTime a besluit:Bestuursorgaan ;
+      generiek:isTijdspecialisatieVan ?governingBody ;
+      mandaat:bindingStart "2025-01-01T00:00:00"^^xsd:dateTime .
+
+    ?governingBody org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/9314533e-891f-4d84-a492-0338af104065> . # Districtsburgemeester
+  }
+
+  VALUES ?mandateRole {
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e00001d> # Districtsburgemeester
+
+  }
+
+  BIND(SHA256(CONCAT(STR(?governingBody), STR(?governingBodyInTime), STR(?mandateRole), " 2025")) AS ?mandateUuid)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/mandaten/", ?mandateUuid)) AS ?mandate)
+}

--- a/config/migrations/2024/20240828104739-governing-bodies-mandates-2025-legislation/20240829171516-mandates-districtscollege.sparql
+++ b/config/migrations/2024/20240828104739-governing-bodies-mandates-2025-legislation/20240829171516-mandates-districtscollege.sparql
@@ -1,0 +1,65 @@
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?governingBodyInTime org:hasPost ?mandate .
+
+    ?mandate a mandaat:Mandaat , org:Post ;
+      mu:uuid ?mandateUuid ;
+      org:role ?mandateRole .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?governingBodyInTime a besluit:Bestuursorgaan ;
+      generiek:isTijdspecialisatieVan ?governingBody ;
+      mandaat:bindingStart "2025-01-01T00:00:00"^^xsd:dateTime .
+
+    ?governingBody org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000b> . # Districtscollege
+  }
+
+  VALUES ?mandateRole {
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e00001e> # Districtsschepen
+
+  }
+
+  BIND(SHA256(CONCAT(STR(?governingBody), STR(?governingBodyInTime), STR(?mandateRole), " 2025")) AS ?mandateUuid)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/mandaten/", ?mandateUuid)) AS ?mandate)
+}
+;
+# Link mandates shared with Districtsburgemeester governing body
+# !! Make sure the Districtsburgemeester governing body and its mandates are !!
+# !! already created, otherwise this will not work correctly. !!
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?governingBodyInTime org:hasPost ?mandate .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+
+    ?governingBodyInTime a besluit:Bestuursorgaan ;
+      generiek:isTijdspecialisatieVan ?governingBody ;
+      mandaat:bindingStart "2025-01-01T00:00:00"^^xsd:dateTime .
+
+    ?governingBody org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e00000b> . # Districtscollege
+
+    # Find the other governing body as it is needed to determine correct UUID and URI
+    ?governingBody besluit:bestuurt ?organisation .
+
+    ?governingBodyOther besluit:bestuurt ?organisation ;
+      org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/9314533e-891f-4d84-a492-0338af104065> . # Districtsburgemeester
+    ?governingBodyInTimeOther a besluit:Bestuursorgaan ;
+      generiek:isTijdspecialisatieVan ?governingBodyOther ;
+      mandaat:bindingStart "2025-01-01T00:00:00"^^xsd:dateTime .
+  }
+  VALUES ?mandateRole {
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e00001d> # Districtsburgemeester
+
+  }
+
+  BIND(SHA256(CONCAT(STR(?governingBodyOther), STR(?governingBodyInTimeOther), STR(?mandateRole), " 2025")) AS ?mandateUuid)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/mandaten/", ?mandateUuid)) AS ?mandate)
+}

--- a/config/migrations/2024/20240828104739-governing-bodies-mandates-2025-legislation/20240829171539-functions-algemeen_directeur.sparql
+++ b/config/migrations/2024/20240828104739-governing-bodies-mandates-2025-legislation/20240829171539-functions-algemeen_directeur.sparql
@@ -1,0 +1,32 @@
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+PREFIX lblodlg: <http://data.lblod.info/vocabularies/leidinggevenden/>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?governingBodyInTime lblodlg:heeftBestuursfunctie ?function .
+
+    ?function a lblodlg:Bestuursfunctie , org:Post ;
+      mu:uuid ?functionUuid ;
+      org:role ?functionRole .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?governingBodyInTime a besluit:Bestuursorgaan ;
+      generiek:isTijdspecialisatieVan ?governingBody ;
+      mandaat:bindingStart "2025-01-01T00:00:00"^^xsd:dateTime .
+
+    ?governingBody org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/39854196-f214-4688-87a1-d6ad12baa2fa> . # Algemeen directeur
+  }
+
+  VALUES ?functionRole {
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/39e08271-68db-4282-897f-5cba88c71862> # Algemeen directeur
+
+  }
+
+  BIND(SHA256(CONCAT(STR(?governingBody), STR(?governingBodyInTime), STR(?functionRole), " 2025")) AS ?functionUuid)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/bestuursfuncties/", ?functionUuid)) AS ?function)
+}

--- a/config/migrations/2024/20240828104739-governing-bodies-mandates-2025-legislation/20240829171540-functions-adjunct-algemeen_directeur.sparql
+++ b/config/migrations/2024/20240828104739-governing-bodies-mandates-2025-legislation/20240829171540-functions-adjunct-algemeen_directeur.sparql
@@ -1,0 +1,32 @@
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+PREFIX lblodlg: <http://data.lblod.info/vocabularies/leidinggevenden/>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?governingBodyInTime lblodlg:heeftBestuursfunctie ?function .
+
+    ?function a lblodlg:Bestuursfunctie , org:Post ;
+      mu:uuid ?functionUuid ;
+      org:role ?functionRole .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?governingBodyInTime a besluit:Bestuursorgaan ;
+      generiek:isTijdspecialisatieVan ?governingBody ;
+      mandaat:bindingStart "2025-01-01T00:00:00"^^xsd:dateTime .
+
+    ?governingBody org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/11f0af9e-016c-4e0b-983a-d8bc73804abc> . # Adjunct-algemeen directeur
+  }
+
+  VALUES ?functionRole {
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/f7b4e17b-6f4e-48e7-a558-bce61669f59a> # Adjunct algemeen directeur
+
+  }
+
+  BIND(SHA256(CONCAT(STR(?governingBody), STR(?governingBodyInTime), STR(?functionRole), " 2025")) AS ?functionUuid)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/bestuursfuncties/", ?functionUuid)) AS ?function)
+}

--- a/config/migrations/2024/20240828104739-governing-bodies-mandates-2025-legislation/20240829171541-functions-financieel_directeur.sparql
+++ b/config/migrations/2024/20240828104739-governing-bodies-mandates-2025-legislation/20240829171541-functions-financieel_directeur.sparql
@@ -1,0 +1,32 @@
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+PREFIX lblodlg: <http://data.lblod.info/vocabularies/leidinggevenden/>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?governingBodyInTime lblodlg:heeftBestuursfunctie ?function .
+
+    ?function a lblodlg:Bestuursfunctie , org:Post ;
+      mu:uuid ?functionUuid ;
+      org:role ?functionRole .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?governingBodyInTime a besluit:Bestuursorgaan ;
+      generiek:isTijdspecialisatieVan ?governingBody ;
+      mandaat:bindingStart "2025-01-01T00:00:00"^^xsd:dateTime .
+
+    ?governingBody org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/62644b9c-4514-41dd-a660-4c35257f2b35> . # Financieel directeur
+  }
+
+  VALUES ?functionRole {
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/6d4cf4dd-2080-4752-8733-d02a036b2df0> # Financieel directeur
+
+  }
+
+  BIND(SHA256(CONCAT(STR(?governingBody), STR(?governingBodyInTime), STR(?functionRole), " 2025")) AS ?functionUuid)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/bestuursfuncties/", ?functionUuid)) AS ?function)
+}

--- a/config/migrations/2024/20240828104739-governing-bodies-mandates-2025-legislation/20240829171542-functions-adjunct-financieel_directeur.sparql
+++ b/config/migrations/2024/20240828104739-governing-bodies-mandates-2025-legislation/20240829171542-functions-adjunct-financieel_directeur.sparql
@@ -1,0 +1,32 @@
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+PREFIX lblodlg: <http://data.lblod.info/vocabularies/leidinggevenden/>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?governingBodyInTime lblodlg:heeftBestuursfunctie ?function .
+
+    ?function a lblodlg:Bestuursfunctie , org:Post ;
+      mu:uuid ?functionUuid ;
+      org:role ?functionRole .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?governingBodyInTime a besluit:Bestuursorgaan ;
+      generiek:isTijdspecialisatieVan ?governingBody ;
+      mandaat:bindingStart "2025-01-01T00:00:00"^^xsd:dateTime .
+
+    ?governingBody org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/ed40469e-3b6f-4f38-99ba-18912ee352b0> . # Adjunct-financieel directeur
+  }
+
+  VALUES ?functionRole {
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/3200ffc1-bb72-4235-a81c-64aa578b0789> # Adjunct financieel directeur
+
+  }
+
+  BIND(SHA256(CONCAT(STR(?governingBody), STR(?governingBodyInTime), STR(?functionRole), " 2025")) AS ?functionUuid)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/bestuursfuncties/", ?functionUuid)) AS ?function)
+}

--- a/config/migrations/2024/20240828104739-governing-bodies-mandates-2025-legislation/20240829171543-functions-griffier.sparql
+++ b/config/migrations/2024/20240828104739-governing-bodies-mandates-2025-legislation/20240829171543-functions-griffier.sparql
@@ -1,0 +1,32 @@
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+PREFIX lblodlg: <http://data.lblod.info/vocabularies/leidinggevenden/>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?governingBodyInTime lblodlg:heeftBestuursfunctie ?function .
+
+    ?function a lblodlg:Bestuursfunctie , org:Post ;
+      mu:uuid ?functionUuid ;
+      org:role ?functionRole .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?governingBodyInTime a besluit:Bestuursorgaan ;
+      generiek:isTijdspecialisatieVan ?governingBody ;
+      mandaat:bindingStart "2025-01-01T00:00:00"^^xsd:dateTime .
+
+    ?governingBody org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab19107-82d2-4273-a986-3da86fda050d> . # Griffier
+  }
+
+  VALUES ?functionRole {
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/63195ec6-02cb-4f86-ac8e-29c5183a11dc> # Griffier
+
+  }
+
+  BIND(SHA256(CONCAT(STR(?governingBody), STR(?governingBodyInTime), STR(?functionRole), " 2025")) AS ?functionUuid)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/bestuursfuncties/", ?functionUuid)) AS ?function)
+}

--- a/config/migrations/2024/20240828104739-governing-bodies-mandates-2025-legislation/20240829171544-functions-financieel_beheerder.sparql
+++ b/config/migrations/2024/20240828104739-governing-bodies-mandates-2025-legislation/20240829171544-functions-financieel_beheerder.sparql
@@ -1,0 +1,32 @@
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+PREFIX lblodlg: <http://data.lblod.info/vocabularies/leidinggevenden/>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?governingBodyInTime lblodlg:heeftBestuursfunctie ?function .
+
+    ?function a lblodlg:Bestuursfunctie , org:Post ;
+      mu:uuid ?functionUuid ;
+      org:role ?functionRole .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?governingBodyInTime a besluit:Bestuursorgaan ;
+      generiek:isTijdspecialisatieVan ?governingBody ;
+      mandaat:bindingStart "2025-01-01T00:00:00"^^xsd:dateTime .
+
+    ?governingBody org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/3e9f22c1-0d35-445b-8a37-494addedf2d8> . # Financieel beheerder
+  }
+
+  VALUES ?functionRole {
+    <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/b213c870-c762-4e39-9f78-3abdeda4b64a> # Financieel beheerder
+
+  }
+
+  BIND(SHA256(CONCAT(STR(?governingBody), STR(?governingBodyInTime), STR(?functionRole), " 2025")) AS ?functionUuid)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/bestuursfuncties/", ?functionUuid)) AS ?function)
+}


### PR DESCRIPTION
## Summary
In preparation for the new legislature for local governments, OP requires new time specialised governing bodies, along with their mandates and functions. This concerns organisations with the following classifications:
- municipality
- OCMW
- district
- province

The migrations added by this PR create the necessary data. The added migrations can be roughly divided in three groups which must be executed in the listed order:
- `TIMESTAMP-timed-governing-bodies-CLASSIFICATION-2025.sparql`: add the necessary time specialised governing bodies for (almost all) active organisations of the above classifications
- `TIMESTAMP-add-missing-governing-bodies-merged-ocmw-NAME.sparql`: add some extra governing bodies to OCMWs that were missing in their initial import in #442
- `TIMESTAMP-mandates-BODY_CLASSIFICATION.sparql` and `TIMESTAMP-functions-BODY_CLASSIFICATION.sparql`: add the necessary mandates and functions for the governing bodies that were created by the previous migrations

## Related tickets
- OP-3345
- OP-3355

## Calculating the new UUIDs
This newly created data will be shared with the [LMB app](https://github.com/lblod/app-lokaal-mandatenbeheer) very soon. Therefore, it is important that the introduced UUIDs do **not** change in between sharing the exported data with LMB and OP deploying these migration in production. (The order of these events is not necessarily fixed.) For that reason I have opted to calculate new UUIDs in the migrations as the SHA256 hash of data that should not change. So any calculated UUID should remain identical irrelevant of when you execute the migrations.

For example, the UUID of a new time specialised governing body is the hash value of the concatenation of the URIs of the related abstract governing body and its classification, along with a constant "2025" to ensure uniqueness. The used URIs should not change at any time so the resulting hash should always be the same irrelevant of when the migration is executed.

## Overview of the migrations
The following sections contain some background explanation on the different kinds of migrations. The scripts used to generate the migrations will be added to ticket OP-3345.

### Add governing body
These migrations create new time specialised bodies for any existing abstract governing body that governs an active organisation of one of the above-mentioned classifications. An advantage of writing the migrations this way is that it relies on the already available information concerning which kinds of organisations require which kinds of governing bodies.
There is one migration per organisation classification.

For municipalities and OCMWs there is an additional filter to exclude 19 organisations. These 19 organisations will merge with other ones as of January 2025 and will no longer active after that. Therefore, they do not require new governing bodies for the next legislature. The list is based on the data provided by business and the Excel sheet can be found in the matching tickets.

For districts and province no such mergers will take place, so no additional filtering is needed in their migrations.

The result of these migrations can be verified via the frontend. The table in governing bodies tab (nl. "Bestuursorganen") of each affected organisation should have inactive governing bodies listed for the period "2025 - ".

### Add missing governing bodies for OCMWs in formation
In #442 some new municipalities and OCMWs in formation were introduced to OP. To recap, these new organisations had to be imported manually as they are the result of upcoming mergers **and** will have a different KBO number than the organisations they merge from.

While creating the migrations in the PR your are currently reading I noticed that the previous PR contained an oversight. Namely, for the new OCMWs the governing bodies required for their functions were not created. This is corrected with the migrations in this group. For each OCMW there is one migration.

### Add mandates and functions
The last set of migrations adds all mandates (functions) to the governing bodies introduced by the above migrations. The mapping between governing bodies and mandates (functions) is based on the relations already present in production data and the configuration logic in OP's [construct-organization-relationships-service](https://github.com/lblod/construct-organization-relationships-service/blob/master/lib/config.js). There is one migration per governing body classification.

These migrations are written such that they only match governing bodies with the correct starting date (`2025-01-01T00:00:00`). This assumes there are no organisations of irrelevant classifications with such governing bodies, which is currently true. By writing these migrations in such a way they also match the governing bodies for the new organisations in formation that were added in #445 and #442. This is intentional as those organisations will become active for the new legislature and require the appropriate mandates and functions.


There are some additional constraints on the execution order of some migrations in this group. Some governing bodies share the same mandate instances. For example the *"Burgemeester"* and *"College van Burgemeester en Schepenen"* governing bodies have to refer to the same *"Burgemeester"* and *"Waarnemend burgemeester"* mandates. In such cases the shared mandate will be created once by the migrations executing first. The migration executing second contains an additional `INSERT` query that depends on being able to find the mandate that was inserted by the first migration.

Specifically:
- `mandates-burgemeester` should execute **before** `mandates-college_van_burgemeester_en_schepenen`
- `mandates-districtsburgemeester` should execute **before** `mandates-districtscollege`
- `mandates-voorzitter_van_het_bijzonder_comite_voor_de_sociale_dienst` should execute **before** `mandates-bijzonder_comite_voor_de_sociale_dienst`


Note, the results of these migrations are not visible via the frontend. It requires some digging in the triplestore to check whether the results are as expected.

## Useful(?) SPARQL queries
Some SPARQL queries I found useful to inspect the required and resulting data are listed below.

Notes:
- To query for functions instead of mandates replace the `org:hasPost` predicate with `lblodlg:heeftBestuursfunctie`.
- The UUID for municipalities and provinces is located in a special graph `<http://mu.semte.ch/graphs/shared>`, not in the normally used `<http://mu.semte.ch/graphs/administrative-unit>`.
- Any UUIDs I used are semi-randomly selected to cover different classifications of affected organisations.


Get an overview of the mapping between organisation classifications, related governing body classifications, and their mandate classifications.
``` sparql
SELECT DISTINCT ?orgClassLabel ?bodyClassLabel ?roleLabel
WHERE {
  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
    ?body besluit:bestuurt ?org ;
      org:classification ?bodyClass .
    ?timedBody generiek:isTijdspecialisatieVan ?body ;
      org:hasPost ?post .

    ?org org:classification ?orgClass .
    ?post org:role ?role .
  }
  ?bodyClass skos:prefLabel ?bodyClassLabel .
  ?orgClass skos:prefLabel ?orgClassLabel .
  ?role skos:prefLabel ?roleLabel .
} ORDER BY ?orgClassLabel ?bodyClassLabel ?roleLabel
```

List all governing bodies, their start date, related mandates, and mandate roles for a municipality or province. (For OCMW or districts, modify the shared graph line to use the regular graph.)
``` sparql
SELECT DISTINCT ?classBodyLabel ?startDate ?post ?roleLabel
WHERE {
  GRAPH <http://mu.semte.ch/graphs/shared> {
    ?org mu:uuid ?uuid .
  }
  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
    ?governingBody besluit:bestuurt ?org ;
      org:classification ?classBody .
    ?timedGoverningBody generiek:isTijdspecialisatieVan ?governingBody ;
      mandaat:bindingStart ?startDate ;
      org:hasPost ?post .
    ?post org:role ?role .
  }
  ?classBody skos:prefLabel ?classBodyLabel .
  ?role skos:prefLabel ?roleLabel .
  VALUES ?uuid {
    #"011a6ad0efca0b7e03ca9b99bd6c636a26cbde49aa0d6844b9ebc434dc58216c" # Affligem gemeente
    #"add1e4eb-9ec7-4ea6-af82-335aa76b7d48" # Pajottegem gemeente (fusie, in oprichting)
    "14278813524c762255aeba149e7d7134ddecfbb43e7d56910731bd4e13e34f39" # Limburg
  }
} ORDER BY ?startDate ?classBodyLabel ?roleLabel
```