### PR TITLE
Add queries to remove organizations

### DIFF
--- a/config/migrations/2024/20240916161553-remove-organizations/20240916161554-remove-limgrond-be-data.sparql
+++ b/config/migrations/2024/20240916161553-remove-organizations/20240916161554-remove-limgrond-be-data.sparql
@@ -1,0 +1,129 @@
+DELETE {
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+WHERE {
+  VALUES ?s {
+    <http://data.lblod.info/id/adressen/cb091a60-2397-11ef-bbd8-0fbcdf882161>
+  }
+
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+
+;
+
+DELETE {
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+WHERE {
+  VALUES ?s {
+    <http://data.lblod.info/id/bestuursorganen/688a6c6ee994118067e951daf5ae36a61a5006727fcb245d2275c4dfd1f560df>
+    <http://data.lblod.info/id/bestuursorganen/26ad3d6848a85b60ddf95c1abf0cca7cde7eaa9b62b44e04daa37eb99c951dbe>
+    <http://data.lblod.info/id/bestuursorganen/8ed710c24ece66d6aa9f31ca209d89cba2070521c74cdb7fed9149c2a08553f8>
+    <http://data.lblod.info/id/bestuursorganen/2a6533fc650e80a10af547dedde0eb162eda0715835fb056f265da847d88a154>
+    <http://data.lblod.info/id/bestuursorganen/3cc108abec6c37a6e56fc04d78ba162a3c8412b0507711b576945d146bac3b32>
+    <http://data.lblod.info/id/bestuursorganen/7bacffa8fb9d5d83b16ab5c79d6c52e6f5bb11941eb9256d993c5ef091ed9211>
+    <http://data.lblod.info/id/bestuursorganen/02b9d64da7cf5c9ef20b3b036400aeb2c5fc7078ee0b0cb0b9429ca07ad5c93c>
+    <http://data.lblod.info/id/bestuursorganen/2df471c3c8a592d527220d612538e4cc3d722398d80e28d159c0ce3417a7c382>
+    <http://data.lblod.info/id/bestuursorganen/d0ff01118d5b6aee2260754bd14bbd59c6b2347dd3501d501bfae4def2a22032>
+    <http://data.lblod.info/id/bestuursorganen/8075960c2054f38245e14c106d276ed8ca90ad67d89c68d0d89253d2f576b748>
+  }
+
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+
+;
+
+DELETE {
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+WHERE {
+  VALUES ?s {
+    <http://data.lblod.info/id/kboOrganisaties/cb091a64-2397-11ef-bbd8-0fbcdf882161>
+  }
+
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+
+;
+
+DELETE {
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+WHERE {
+  VALUES ?s {
+    <http://data.lblod.info/id/identificatoren/06f4d030-834a-11ee-8e4b-c582e0b3e4df>
+    <http://data.lblod.info/id/identificatoren/c23b22d46df71b01700172c440cef58b>
+    <http://data.lblod.info/id/identificatoren/cb091a62-2397-11ef-bbd8-0fbcdf882161>
+  }
+
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+
+;
+
+DELETE {
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+WHERE {
+  VALUES ?s {
+    <http://data.lblod.info/id/bestuurseenheden/9af828073bb4c53989fe0693526a31aec47d85a4bc6ac9d485ca6878eb3b3f1c>
+  }
+
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+
+;
+
+DELETE {
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+WHERE {
+  VALUES ?s {
+    <http://data.lblod.info/id/contact-punten/cb091a61-2397-11ef-bbd8-0fbcdf882161>
+  }
+
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+
+;
+
+DELETE {
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+WHERE {
+  VALUES ?s {
+    <http://data.lblod.info/id/gestructureerdeIdentificatoren/06f4d031-834a-11ee-8e4b-c582e0b3e4df>
+    <http://data.lblod.info/id/gestructureerdeIdentificator/7fdaf88760a2fe54f93281fbd815aa40>
+    <http://data.lblod.info/id/gestructureerdeIdentificator/cb091a63-2397-11ef-bbd8-0fbcdf882161>
+  }
+
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}

--- a/config/migrations/2024/20240916161553-remove-organizations/20240916161554-remove-limgrond-be-data.sparql
+++ b/config/migrations/2024/20240916161553-remove-organizations/20240916161554-remove-limgrond-be-data.sparql
@@ -48,6 +48,23 @@ DELETE {
 }
 WHERE {
   VALUES ?s {
+    <http://data.lblod.info/id/bestuursfuncties/0da9c13a61c6a7d9b1585573607aa1910bab5a0cb4694d2039db72de34a9aa72>
+  }
+
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+
+;
+
+DELETE {
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+WHERE {
+  VALUES ?s {
     <http://data.lblod.info/id/kboOrganisaties/cb091a64-2397-11ef-bbd8-0fbcdf882161>
   }
 

--- a/config/migrations/2024/20240916161553-remove-organizations/20240918143141-remove-intercommunale-maatschappij-opera-voor-vlaanderen-data.sparql
+++ b/config/migrations/2024/20240916161553-remove-organizations/20240918143141-remove-intercommunale-maatschappij-opera-voor-vlaanderen-data.sparql
@@ -1,0 +1,129 @@
+DELETE {
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+WHERE {
+  VALUES ?s {
+    <http://data.lblod.info/id/bestuursorganen/00f340a3-7b5e-4408-9100-2834595ea89d>
+    <http://data.lblod.info/id/bestuursorganen/945bcb0e4a90a96af7410e06df53cdb912e11919dfce25b680dcb250f96dbd47>
+    <http://data.lblod.info/id/bestuursorganen/53ec55f7-e9ed-45e2-b9c0-df75ed35a26e>
+    <http://data.lblod.info/id/bestuursorganen/3cb6342d-c7b6-4b38-bfe8-83f62f4b303c>
+    <http://data.lblod.info/id/bestuursorganen/e4b96110-28cb-438d-bf63-f0d6ebf25ecf>
+    <http://data.lblod.info/id/bestuursorganen/1d56660e7657f66c1763fde4c021c5589f5aa2e467f4d7677580b1153dd275d2>
+    <http://data.lblod.info/id/bestuursorganen/6c4d9ebf-249e-41d3-8a09-c6b642071ce4>
+    <http://data.lblod.info/id/bestuursorganen/3e0046d2-5d99-49b3-9881-9c3cfb719da5>
+    <http://data.lblod.info/id/bestuursorganen/b2b36c3c-587a-48c1-8493-1f79f1f72825>
+    <http://data.lblod.info/id/bestuursorganen/f013c879-5d2e-43fc-8b35-6ce932214afd>
+  }
+
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+
+;
+
+DELETE {
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+WHERE {
+  VALUES ?s {
+    <http://data.lblod.info/id/contact-punten/88dd9981-2398-11ef-bbd8-0fbcdf882161>
+  }
+
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+
+;
+
+DELETE {
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+WHERE {
+  VALUES ?s {
+    <http://data.lblod.info/id/kboOrganisaties/88dd9984-2398-11ef-bbd8-0fbcdf882161>
+  }
+
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+
+;
+
+DELETE {
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+WHERE {
+  VALUES ?s {
+    <http://data.lblod.info/id/bestuurseenheden/cadbde55-c68c-47c1-8da1-905a171b844b>
+  }
+
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+
+;
+
+DELETE {
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+WHERE {
+  VALUES ?s {
+    <http://data.lblod.info/id/identificatoren/05446110-834a-11ee-8e4b-c582e0b3e4df>
+    <http://data.lblod.info/id/identificatoren/4fedb1a294f5603eb57247fa7b296697>
+    <http://data.lblod.info/id/identificatoren/88dd9982-2398-11ef-bbd8-0fbcdf882161>
+  }
+
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+
+;
+
+DELETE {
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+WHERE {
+  VALUES ?s {
+    <http://data.lblod.info/id/gestructureerdeIdentificator/b449f47111558a5386ad28e1c80623a0>
+    <http://data.lblod.info/id/gestructureerdeIdentificator/88dd9983-2398-11ef-bbd8-0fbcdf882161>
+    <http://data.lblod.info/id/gestructureerdeIdentificatoren/05446111-834a-11ee-8e4b-c582e0b3e4df>
+  }
+
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+
+;
+
+DELETE {
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+WHERE {
+  VALUES ?s {
+    <http://data.lblod.info/id/adressen/88dd9980-2398-11ef-bbd8-0fbcdf882161>
+  }
+
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}

--- a/config/migrations/2024/20240916161553-remove-organizations/20240918143141-remove-intercommunale-maatschappij-opera-voor-vlaanderen-data.sparql
+++ b/config/migrations/2024/20240916161553-remove-organizations/20240918143141-remove-intercommunale-maatschappij-opera-voor-vlaanderen-data.sparql
@@ -31,6 +31,23 @@ DELETE {
 }
 WHERE {
   VALUES ?s {
+    <http://data.lblod.info/id/bestuursfuncties/0fc5c952a6136b49721d9ce5794c6c262a38188a4b57cede9d9aea0f91f62d23>
+  }
+
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+
+;
+
+DELETE {
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+WHERE {
+  VALUES ?s {
     <http://data.lblod.info/id/contact-punten/88dd9981-2398-11ef-bbd8-0fbcdf882161>
   }
 

--- a/config/migrations/2024/20240916161553-remove-organizations/20240918220856-remove-fluvius-data.sparql
+++ b/config/migrations/2024/20240916161553-remove-organizations/20240918220856-remove-fluvius-data.sparql
@@ -1,0 +1,74 @@
+DELETE {
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+WHERE {
+  VALUES ?s {
+    <http://data.lblod.info/id/identificatoren/9d9db143b43e1f295da41118ef4aee6f>
+  }
+
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+
+;
+
+DELETE {
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+WHERE {
+  VALUES ?s {
+    <http://data.lblod.info/id/gestructureerdeIdentificator/037364b2a398a5449ea864c9d2040385>
+  }
+
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+
+;
+
+DELETE {
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+WHERE {
+  VALUES ?s {
+    <http://data.lblod.info/id/bestuursorganen/5ff0ba8bfb12ca4d9db49c25c120c4f21d41e9d34bec021a1ba4850012d1659b>
+    <http://data.lblod.info/id/bestuursorganen/b77e152f212b08ccbf109a33e102898f34a0190b932259065960deda0cb327db>
+    <http://data.lblod.info/id/bestuursorganen/8d09dfd3541fca32168df7c5dc0d25aa670d4dd31dcdf816199a0217a8988925>
+    <http://data.lblod.info/id/bestuursorganen/eb0d25900cebf0cca13e8eb19407d336a2eb7974cab850e59a2751463f13a190>
+    <http://data.lblod.info/id/bestuursorganen/b7ca71fd52e235aa3a8c5daf598db8d743e5c6e13a6b10590ea4a1897ebfdb48>
+    <http://data.lblod.info/id/bestuursorganen/63f28f66b955fb8a7ef22044111294a592d58c04677894dc5f4d982d8f8ccb23>
+    <http://data.lblod.info/id/bestuursorganen/56359589cfe7818209112862b1a8780f33ae33581919e128fb122db33e35dfa4>
+    <http://data.lblod.info/id/bestuursorganen/8750a24ef3ecd21ffbaae5846a3a72870fff576bfad8d309d9399e42a5277e84>
+    <http://data.lblod.info/id/bestuursorganen/a8e61b544549054ac977ef0f7aa8e34c44089ca7299bb19e6a20da3cffe1d4d9>
+    <http://data.lblod.info/id/bestuursorganen/a7b2c9b2c8d470ce3137c8606b6b8b585ddbbed0490811f22dab69151bd637e8>
+  }
+
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+
+;
+
+DELETE {
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+WHERE {
+  VALUES ?s {
+    <http://data.lblod.info/id/bestuurseenheden/c5774766b2549ebd3590b1c9ae955636a8f1b90f01b06c1713aeb0a9ccd0845b>
+  }
+
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}

--- a/config/migrations/2024/20240916161553-remove-organizations/20240918220856-remove-fluvius-data.sparql
+++ b/config/migrations/2024/20240916161553-remove-organizations/20240918220856-remove-fluvius-data.sparql
@@ -65,6 +65,23 @@ DELETE {
 }
 WHERE {
   VALUES ?s {
+    <http://data.lblod.info/id/bestuursfuncties/bb5df2d9fcdff9d9d49da656d8f46f7ae7ed3f0af2323568471351b691f7793c>
+  }
+
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+
+;
+
+DELETE {
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+WHERE {
+  VALUES ?s {
     <http://data.lblod.info/id/bestuurseenheden/c5774766b2549ebd3590b1c9ae955636a8f1b90f01b06c1713aeb0a9ccd0845b>
   }
 

--- a/config/migrations/2024/20240916161553-remove-organizations/20240918221021-remove-intercommunaal-samenwerkingscomite-van-waterbedrijven-data.sparql
+++ b/config/migrations/2024/20240916161553-remove-organizations/20240918221021-remove-intercommunaal-samenwerkingscomite-van-waterbedrijven-data.sparql
@@ -65,6 +65,23 @@ DELETE {
 }
 WHERE {
   VALUES ?s {
+    <http://data.lblod.info/id/bestuursfuncties/6d1459b94e32f5338d83fcf83625390be07b607fb911b2cbf0c4f4eda74ea526>
+  }
+
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+
+;
+
+DELETE {
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+WHERE {
+  VALUES ?s {
     <http://data.lblod.info/id/gestructureerdeIdentificator/b8fc242e00b69088d3f5cc4c68cea5db>
   }
 

--- a/config/migrations/2024/20240916161553-remove-organizations/20240918221021-remove-intercommunaal-samenwerkingscomite-van-waterbedrijven-data.sparql
+++ b/config/migrations/2024/20240916161553-remove-organizations/20240918221021-remove-intercommunaal-samenwerkingscomite-van-waterbedrijven-data.sparql
@@ -1,0 +1,74 @@
+DELETE {
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+WHERE {
+  VALUES ?s {
+    <http://data.lblod.info/id/identificatoren/86065994a24bd307d2d4fecc5dd3f980>
+  }
+
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+
+;
+
+DELETE {
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+WHERE {
+  VALUES ?s {
+    <http://data.lblod.info/id/bestuurseenheden/ad5b386c0cb68ca51133b8e689e21ba6d3dc94726f2578f14631a61caaeaf8ac>
+  }
+
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+
+;
+
+DELETE {
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+WHERE {
+  VALUES ?s {
+    <http://data.lblod.info/id/bestuursorganen/67bcfd3785b7bac768f63441179b454320dae9643f5c8330135a8d33655451b5>
+    <http://data.lblod.info/id/bestuursorganen/270c30ec3c5333fb3d6d8fba7d308116ea4cc6b938b13a44b2cbb49bfad10695>
+    <http://data.lblod.info/id/bestuursorganen/6fcbd46463225c08b5d18ea4352f96b3abc02b8b7c0edec8683011cff8bd3139>
+    <http://data.lblod.info/id/bestuursorganen/45aac0dd02c2819acdaf3e35eb7e1347abff810570544d132fd225a5d849ac71>
+    <http://data.lblod.info/id/bestuursorganen/9c0bcf0597a73715ee872e0585bc32c375abb457bce86ce56361845ff18a31de>
+    <http://data.lblod.info/id/bestuursorganen/29cef84016679926ae4972f07ec64e547161dbdb767d0a9273b5a3c1f0bf9ba2>
+    <http://data.lblod.info/id/bestuursorganen/57b9846b8f46781b911ddf4b0fb59c7f885e9f29c04fbc16c69756867c1b9856>
+    <http://data.lblod.info/id/bestuursorganen/6af413c25a1cb3e27aacc0f09527a700fd660c4b0c2532e5a79f900c6545be13>
+    <http://data.lblod.info/id/bestuursorganen/453d783f600a6ed661f9f85ad6d56992f6d6e6c3552270368f85c34484755003>
+    <http://data.lblod.info/id/bestuursorganen/af067097648b6018170d9cf49670ca4bda04db29671bf76b533036e6c8edf343>
+  }
+
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+
+;
+
+DELETE {
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+WHERE {
+  VALUES ?s {
+    <http://data.lblod.info/id/gestructureerdeIdentificator/b8fc242e00b69088d3f5cc4c68cea5db>
+  }
+
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}

--- a/config/migrations/2024/20240916161553-remove-organizations/20240918221245-intercommunale-van-brabant-voor-gas-data.sparql
+++ b/config/migrations/2024/20240916161553-remove-organizations/20240918221245-intercommunale-van-brabant-voor-gas-data.sparql
@@ -72,3 +72,20 @@ WHERE {
     ?s ?p ?o .
   }
 }
+
+;
+
+DELETE {
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+WHERE {
+  VALUES ?s {
+    <http://data.lblod.info/id/bestuursfuncties/d9efd2b03d6645c72a43f684f11a2b2e9c9f26bce0e549f7df397d1256e572aa>
+  }
+
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}

--- a/config/migrations/2024/20240916161553-remove-organizations/20240918221245-intercommunale-van-brabant-voor-gas-data.sparql
+++ b/config/migrations/2024/20240916161553-remove-organizations/20240918221245-intercommunale-van-brabant-voor-gas-data.sparql
@@ -1,0 +1,74 @@
+DELETE {
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+WHERE {
+  VALUES ?s {
+    <http://data.lblod.info/id/bestuurseenheden/71dc3947-975f-4540-bd50-1f50f29d7567>
+  }
+
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+
+;
+
+DELETE {
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+WHERE {
+  VALUES ?s {
+    <http://data.lblod.info/id/gestructureerdeIdentificator/0e28e5e2153feee0bc4546037c41a2a6>
+  }
+
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+
+;
+
+DELETE {
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+WHERE {
+  VALUES ?s {
+    <http://data.lblod.info/id/identificatoren/dc9d186cba7b3c0c1da655a2de68be5d>
+  }
+
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+
+;
+
+DELETE {
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+WHERE {
+  VALUES ?s {
+    <http://data.lblod.info/id/bestuursorganen/05ceb71b-0fc8-4ed0-bbd0-02ff2ee0aa2e>
+    <http://data.lblod.info/id/bestuursorganen/60aae03fc563203e27a979355813b67a9bb9aa51ae5c1c7301582dfaf1d77bb3>
+    <http://data.lblod.info/id/bestuursorganen/7dac3a02-e217-476f-8fee-aa2eab5187df>
+    <http://data.lblod.info/id/bestuursorganen/1e1f655a-89d2-4cad-be7c-a69132b5a82e>
+    <http://data.lblod.info/id/bestuursorganen/7979918afb0b0428825280d92af8d20ca9cfc4554f3c291bb24dba2314b67bd1>
+    <http://data.lblod.info/id/bestuursorganen/36715ba0-f50a-431e-943b-041933df4d01>
+    <http://data.lblod.info/id/bestuursorganen/e7b395c5-4bd2-43c5-acc4-3a3feb66953f>
+    <http://data.lblod.info/id/bestuursorganen/44195d20-2b99-4d7d-b0d4-a4db1696ff7d>
+    <http://data.lblod.info/id/bestuursorganen/9d62e9af-6ce7-4f27-9426-b587243db9e3>
+    <http://data.lblod.info/id/bestuursorganen/909e64a8-a2d6-4dbc-bac4-0f445a05af6e>
+  }
+
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}

--- a/config/migrations/2024/20240916161553-remove-organizations/20240918221637-tussengemeentelijke-electriciteitsvereniging-van-kampenhout-en-steenokkerzeel-data.sparql
+++ b/config/migrations/2024/20240916161553-remove-organizations/20240918221637-tussengemeentelijke-electriciteitsvereniging-van-kampenhout-en-steenokkerzeel-data.sparql
@@ -1,0 +1,74 @@
+DELETE {
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+WHERE {
+  VALUES ?s {
+    <http://data.lblod.info/id/bestuurseenheden/ba8ffc97-5490-4ecc-b24e-aab26b23c026>
+  }
+
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+
+;
+
+DELETE {
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+WHERE {
+  VALUES ?s {
+    <http://data.lblod.info/id/identificatoren/6e8a9d7c55868b80d176fe00db97816b>
+  }
+
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+
+;
+
+DELETE {
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+WHERE {
+  VALUES ?s {
+    <http://data.lblod.info/id/bestuursorganen/be697a9b-248f-431e-90cd-474ee79a5c6a>
+    <http://data.lblod.info/id/bestuursorganen/dddb39fb-a19b-491b-b1bf-a431406e383f>
+    <http://data.lblod.info/id/bestuursorganen/e5645fd6-ef7b-4705-8eed-9ee7de102f8c>
+    <http://data.lblod.info/id/bestuursorganen/bfc5523b-6fe8-425e-a65f-6202f73c7d42>
+    <http://data.lblod.info/id/bestuursorganen/ea7ecf04-ad05-486e-b77e-437b8577b7df>
+    <http://data.lblod.info/id/bestuursorganen/4824c430-9c4f-4258-842e-bd631d910377>
+    <http://data.lblod.info/id/bestuursorganen/a974b0dc-cbd6-4f9b-8211-cd487c4ede35>
+    <http://data.lblod.info/id/bestuursorganen/f5e8775d-b723-4fa3-9ddd-66751057ea34>
+    <http://data.lblod.info/id/bestuursorganen/0c0b86269ddc09cbcffc2cb4e39f458df15265f24d7a46f3a8f45c9567a1b44d>
+    <http://data.lblod.info/id/bestuursorganen/4a7c956f6d418d0031de1a1b15de74d6a87edf824f464caf02a1145b461cd1d9>
+  }
+
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+
+;
+
+DELETE {
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+WHERE {
+  VALUES ?s {
+    <http://data.lblod.info/id/gestructureerdeIdentificator/e6795bc0c5c2cf66591e7ff62e770bf5>
+  }
+
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}

--- a/config/migrations/2024/20240916161553-remove-organizations/20240918221637-tussengemeentelijke-electriciteitsvereniging-van-kampenhout-en-steenokkerzeel-data.sparql
+++ b/config/migrations/2024/20240916161553-remove-organizations/20240918221637-tussengemeentelijke-electriciteitsvereniging-van-kampenhout-en-steenokkerzeel-data.sparql
@@ -65,6 +65,23 @@ DELETE {
 }
 WHERE {
   VALUES ?s {
+    <http://data.lblod.info/id/bestuursfuncties/fbb286f45244f2cc64d40987bab1645acd78e3637f4a7a5f8c4dd33f9a7a3541>
+  }
+
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+
+;
+
+DELETE {
+  GRAPH ?g {
+    ?s ?p ?o .
+  }
+}
+WHERE {
+  VALUES ?s {
     <http://data.lblod.info/id/gestructureerdeIdentificator/e6795bc0c5c2cf66591e7ff62e770bf5>
   }
 


### PR DESCRIPTION
## Ticket ID

OP-3124 + OP-3125

## Ticket Description

This PR deletes organization URIs (+ other related URIs) as this data is deemed to be unneeded.

## How to test

The best way to test this would be:
* Tunnel to production, use `DESCRIBE <bestuurseenheid_URI>` and follow the links.
* Do a quick skim between the URIs connected to the bestuurseenheid URI and cross-check with the queries.

The cross-checking part is a bit annoying, but there aren't many resources attached to these organizations, so it should be fairly quick.