### PR TITLE
fix: remove superfluous line in drc dev configuration

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -48,7 +48,6 @@ services:
     restart: "no"
   adressenregister:
     restart: "no"
-   image: lblod/frontend-organization-portal:latest
   frontend:
     restart: "no"
   uri-info:


### PR DESCRIPTION
The most recent merge [commit](   image: lblod/frontend-organization-portal:latest
) from master to branch contained error were a
removed line was reinserted at a wrong place with an incorrect indentation. This
causes (some) drc commands to fail with an error