### PR TITLE
feat: import most recent CLB data

### DIFF
--- a/config/migrations/2024/20241009143404-update-contact-data-from-clb/20241009143404-delete-contact-data-modified-in-clb.sparql
+++ b/config/migrations/2024/20241009143404-update-contact-data-from-clb/20241009143404-delete-contact-data-modified-in-clb.sparql
@@ -1,0 +1,62 @@
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX organisatie: <https://data.vlaanderen.be/ns/organisatie#>
+PREFIX locn: <http://www.w3.org/ns/locn#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+
+DELETE {
+  GRAPH ?g {
+    ?site ?pSite ?oSite .
+    ?contact ?pContact ?oContact .
+    ?address ?pAddress ?oAddress .
+    ?addressContact ?pAddressContact ?oAddressContact .
+  }
+} WHERE {
+  VALUES ?hasSite {
+    <http://www.w3.org/ns/org#hasPrimarySite>
+    <http://www.w3.org/ns/org#hasSite>
+  }
+
+  FILTER (?site IN
+          (
+           <http://data.lblod.info/id/vestigingen/43557b6bd03abd95ad981f3f611777c5> ,
+           <http://data.lblod.info/id/vestigingen/63639DA88DE5818A7C9F439D> ,
+           <http://data.lblod.info/id/vestigingen/d3a88c997bc377fd0172d7555ef2f154> ,
+           <http://data.lblod.info/id/vestigingen/866ca7d5975c853890ba18bb189892c4> ,
+           <http://data.lblod.info/id/vestigingen/d5283487-d4eb-4e57-afef-de1de153b42f> ,
+           <http://data.lblod.info/id/vestigingen/100a61965dc84e9b18a2dd1f1d7c81aa> ,
+           <http://data.lblod.info/id/vestigingen/9d97ea7e82a9821a80c19e136afb2efc> ,
+           <http://data.lblod.info/id/vestigingen/9f0d58d2127987435056229003e18b56>
+           ))
+
+  GRAPH ?organisationGraph {
+    ?organisation ?hasSite ?site .
+  }
+
+  VALUES ?organisationGraph {
+    <http://mu.semte.ch/graphs/administrative-unit>
+    <http://mu.semte.ch/graphs/worship-service>
+    <http://mu.semte.ch/graphs/shared>
+  }
+
+  GRAPH ?g {
+    ?site ?pSite ?oSite .
+    {
+      ?site org:siteAddress ?contact .
+      ?contact ?pContact ?oContact .
+      ?contact locn:address ?addressContact .
+      ?addressContact ?pAddressContact ?oAddressContact .
+    } UNION {
+      ?site org:siteAddress ?contact .
+      ?contact ?pContact ?oContact .
+    } UNION {
+      ?site organisatie:bestaatUit ?address .
+      ?address ?pAddress ?oAddress .
+    }
+  }
+
+  VALUES ?g {
+    <http://mu.semte.ch/graphs/administrative-unit>
+    <http://mu.semte.ch/graphs/worship-service>
+    <http://mu.semte.ch/graphs/shared>
+  }
+}

--- a/config/migrations/2024/20241009143404-update-contact-data-from-clb/20241009161800-clb-prod-contactdata-administrative-units.graph
+++ b/config/migrations/2024/20241009143404-update-contact-data-from-clb/20241009161800-clb-prod-contactdata-administrative-units.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/administrative-unit

--- a/config/migrations/2024/20241009143404-update-contact-data-from-clb/20241009161800-clb-prod-contactdata-administrative-units.ttl
+++ b/config/migrations/2024/20241009143404-update-contact-data-from-clb/20241009161800-clb-prod-contactdata-administrative-units.ttl
@@ -1,0 +1,185 @@
+@prefix rdf:	<http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix ns1:	<http://schema.org/> .
+@prefix ns2:	<http://mu.semte.ch/vocabularies/core/> .
+@prefix ns3:	<http://www.w3.org/ns/locn#> .
+@prefix ns4:	<https://data.vlaanderen.be/ns/adres#> .
+@prefix ns5:	<http://data.lblod.info/id/adressen/> .
+@prefix ns6:	<http://www.w3.org/ns/org#> .
+@prefix ns7:	<http://data.lblod.info/id/vestigingen/> .
+@prefix ns8:	<http://data.lblod.info/id/bestuurseenheden/> .
+@prefix ns9:	<http://data.lblod.info/id/contact-punten/> .
+@prefix ns10:	<https://data.vlaanderen.be/ns/organisatie#> .
+@prefix ns11:	<http://data.lblod.info/vocabularies/erediensten/> .
+@prefix ns12:	<http://lblod.data.gift/concepts/> .
+@prefix foaf:	<http://xmlns.com/foaf/0.1/> .
+
+<http://data.lblod.info/id/contact-punten/66914D256ABB62E36F847154>
+	rdf:type	ns1:ContactPoint ;
+	ns2:uuid	"66914D256ABB62E36F847154" ;
+	ns1:contactType	"Secondary" .
+<http://data.lblod.info/id/adressen/5352f18dfed80644af9e3c98745bab32>
+	rdf:type	ns3:Address ;
+	ns2:uuid	"5352f18dfed80644af9e3c98745bab32" ;
+	<https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer>	"5" ;
+	ns3:thoroughfare	"Kerkstraat" ;
+	ns3:postCode	"2560" ;
+	ns4:gemeentenaam	"Nijlen" ;
+	ns3:fullAddress	"Kerkstraat 5, 2560 Nijlen, Belgi\u00EB" ;
+	ns3:adminUnitL2	"Antwerpen" ;
+	ns4:land	"Belgi\u00EB" ;
+	ns4:verwijstNaar	<https://data.vlaanderen.be/id/adres/1203579> .
+<http://data.lblod.info/id/adressen/57fea19d-27ce-4ecb-b3f6-581ce1f067e7>
+	rdf:type	ns3:Address ;
+	ns2:uuid	"57fea19d-27ce-4ecb-b3f6-581ce1f067e7" ;
+	<https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer>	"2" ;
+	<https://data.vlaanderen.be/ns/adres#Adresvoorstelling.busnummer>	"7" ;
+	ns3:thoroughfare	"Paradeplein" ;
+	ns3:postCode	"2500" ;
+	ns4:gemeentenaam	"Lier" ;
+	ns3:fullAddress	"Paradeplein 2 7, 2500 Lier, Belgi\u00EB" ;
+	ns3:adminUnitL2	"Antwerpen" ;
+	ns4:land	"Belgi\u00EB" .
+<http://data.lblod.info/id/adressen/91eccb9c2abe72ed7127af3d2b09e645>
+	rdf:type	ns3:Address ;
+	ns2:uuid	"91eccb9c2abe72ed7127af3d2b09e645" ;
+	<https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer>	"1" ;
+	ns3:thoroughfare	"Limburgplein" ;
+	ns3:postCode	"3500" ;
+	ns4:gemeentenaam	"Hasselt" ;
+	ns3:fullAddress	"Limburgplein 1, 3500 Hasselt, Belgi\u00EB" ;
+	ns3:adminUnitL2	"Limburg" ;
+	ns4:land	"Belgi\u00EB" .
+ns5:a5f58992810c9e8b7337c2990be2fab8
+	rdf:type	ns3:Address ;
+	ns2:uuid	"a5f58992810c9e8b7337c2990be2fab8" ;
+	<https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer>	"73" ;
+	ns3:thoroughfare	"Heirbaan" ;
+	ns3:postCode	"8570" ;
+	ns4:gemeentenaam	"Anzegem" ;
+	ns3:fullAddress	"Heirbaan 73, 8570 Anzegem, Belgi\u00EB" ;
+	ns3:adminUnitL2	"West-Vlaanderen" ;
+	ns4:land	"Belgi\u00EB" ;
+	ns4:verwijstNaar	<https://data.vlaanderen.be/id/adres/2201555> .
+ns5:a78088dff8a75de324a3c01102caf671
+	rdf:type	ns3:Address ;
+	ns2:uuid	"a78088dff8a75de324a3c01102caf671" ;
+	<https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer>	"66" ;
+	ns3:thoroughfare	"Leopoldstraat" ;
+	ns3:postCode	"8580" ;
+	ns4:gemeentenaam	"Avelgem" ;
+	ns3:fullAddress	"Leopoldstraat 66, 8580 Avelgem, Belgi\u00EB" ;
+	ns3:adminUnitL2	"West-Vlaanderen" ;
+	ns4:land	"Belgi\u00EB" ;
+	ns4:verwijstNaar	<https://data.vlaanderen.be/id/adres/1924818> .
+ns5:e9590a8d28a9b77be05a7a789b3571e5
+	rdf:type	ns3:Address ;
+	ns2:uuid	"e9590a8d28a9b77be05a7a789b3571e5" ;
+	<https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer>	"1A" ;
+	ns3:thoroughfare	"Limburgplein" ;
+	ns3:postCode	"3500" ;
+	ns4:gemeentenaam	"Hasselt" ;
+	ns3:fullAddress	"Limburgplein 1A, 3500 Hasselt, Belgi\u00EB" ;
+	ns3:adminUnitL2	"Limburg" ;
+	ns4:land	"Belgi\u00EB" .
+<http://data.lblod.info/id/bestuurseenheden/9db1b46874a57fe63c08fb5f16b117e6f61fdd98e7f64f745d0fceb9d3731169>
+	ns6:hasPrimarySite	ns7:d3a88c997bc377fd0172d7555ef2f154 .
+<http://data.lblod.info/id/bestuurseenheden/026509cf3b4eeb7ad88fe57a270060574f60abd1c3524837d36700e40809d210>
+	ns6:hasPrimarySite	<http://data.lblod.info/id/vestigingen/866ca7d5975c853890ba18bb189892c4> .
+ns8:a33cb6e858ea9fdd5cc8a6f6f97850094ce8f312b961ec6bd775c3dc024e4801
+	ns6:hasPrimarySite	ns7:d5283487-d4eb-4e57-afef-de1de153b42f .
+<http://data.lblod.info/id/bestuurseenheden/240d6c23ed1488956468b3c2480f3acd1b69fd17a536f6731687d3066e657f45>
+	ns6:hasPrimarySite	<http://data.lblod.info/id/vestigingen/100a61965dc84e9b18a2dd1f1d7c81aa> .
+<http://data.lblod.info/id/vestigingen/866ca7d5975c853890ba18bb189892c4>
+	rdf:type	ns6:Site ;
+	ns2:uuid	"866ca7d5975c853890ba18bb189892c4" ;
+	ns6:siteAddress	ns9:cd895859-617f-4679-9d41-5d9437133280 ;
+	ns10:bestaatUit	ns5:e9590a8d28a9b77be05a7a789b3571e5 ;
+	ns11:vestigingstype	ns12:f1381723dec42c0b6ba6492e41d6f5dd .
+<http://data.lblod.info/id/vestigingen/100a61965dc84e9b18a2dd1f1d7c81aa>
+	rdf:type	ns6:Site ;
+	ns2:uuid	"100a61965dc84e9b18a2dd1f1d7c81aa" ;
+	ns6:siteAddress	<http://data.lblod.info/id/contact-punten/5def8bef-2029-403d-b80e-28a23638fe63> , <http://data.lblod.info/id/contact-punten/66F543EA074D265E9ED3FF10> ;
+	ns10:bestaatUit	<http://data.lblod.info/id/adressen/5352f18dfed80644af9e3c98745bab32> ;
+	ns11:vestigingstype	ns12:f1381723dec42c0b6ba6492e41d6f5dd .
+<http://data.lblod.info/id/bestuurseenheden/8662dc060c121e9d69101062f67daeef8370d38bfe86533752b9e54190dd0e2f>
+	ns6:hasPrimarySite	<http://data.lblod.info/id/vestigingen/9d97ea7e82a9821a80c19e136afb2efc> .
+ns8:b4aa8ca2a4daa74ef8297b0b4dba2ad292e73da5337e20c65066860279751307
+	ns6:hasPrimarySite	<http://data.lblod.info/id/vestigingen/9f0d58d2127987435056229003e18b56> .
+<http://data.lblod.info/id/vestigingen/9f0d58d2127987435056229003e18b56>
+	rdf:type	ns6:Site ;
+	ns2:uuid	"9f0d58d2127987435056229003e18b56" ;
+	ns6:siteAddress	<http://data.lblod.info/id/contact-punten/66914D256ABB62E36F847154> , ns9:fee82ba7-ad64-4310-9257-a99cf52494b0 ;
+	ns10:bestaatUit	ns5:a78088dff8a75de324a3c01102caf671 ;
+	ns11:vestigingstype	ns12:f1381723dec42c0b6ba6492e41d6f5dd .
+<http://data.lblod.info/id/vestigingen/9d97ea7e82a9821a80c19e136afb2efc>
+	rdf:type	ns6:Site ;
+	ns2:uuid	"9d97ea7e82a9821a80c19e136afb2efc" ;
+	ns6:siteAddress	<http://data.lblod.info/id/contact-punten/7e3e2754-efa1-4122-a56e-331b3cab7d2d> , <http://data.lblod.info/id/contact-punten/669148366ABB62E36F847153> ;
+	ns10:bestaatUit	ns5:a5f58992810c9e8b7337c2990be2fab8 ;
+	ns11:vestigingstype	ns12:f1381723dec42c0b6ba6492e41d6f5dd .
+ns7:d3a88c997bc377fd0172d7555ef2f154
+	rdf:type	ns6:Site ;
+	ns2:uuid	"d3a88c997bc377fd0172d7555ef2f154" ;
+	ns6:siteAddress	ns9:f7e104a5-84b5-4982-9d3d-d4bee9508601 ;
+	ns10:bestaatUit	<http://data.lblod.info/id/adressen/91eccb9c2abe72ed7127af3d2b09e645> ;
+	ns11:vestigingstype	ns12:f1381723dec42c0b6ba6492e41d6f5dd .
+ns7:d5283487-d4eb-4e57-afef-de1de153b42f
+	rdf:type	ns6:Site ;
+	ns2:uuid	"d5283487-d4eb-4e57-afef-de1de153b42f" ;
+	ns6:siteAddress	<http://data.lblod.info/id/contact-punten/87ef1d4c-d92d-4834-9ac3-d4bb3c8b9ad4> , ns9:f0dde9ef-4892-49d4-a8c9-2b5cac98b7c1 ;
+	ns10:bestaatUit	<http://data.lblod.info/id/adressen/57fea19d-27ce-4ecb-b3f6-581ce1f067e7> ;
+	ns11:vestigingstype	ns12:f1381723dec42c0b6ba6492e41d6f5dd .
+<http://data.lblod.info/id/contact-punten/5def8bef-2029-403d-b80e-28a23638fe63>
+	rdf:type	ns1:ContactPoint ;
+	ns2:uuid	"5def8bef-2029-403d-b80e-28a23638fe63" ;
+	foaf:page	"https://www.nijlen.be/sociaal-2" ;
+	ns1:contactType	"Primary" ;
+	ns1:email	"info.ocmw@nijlen.be" ;
+	ns1:telephone	"tel:+32 3 410 02 11" .
+<http://data.lblod.info/id/contact-punten/87ef1d4c-d92d-4834-9ac3-d4bb3c8b9ad4>
+	rdf:type	ns1:ContactPoint ;
+	ns2:uuid	"87ef1d4c-d92d-4834-9ac3-d4bb3c8b9ad4" ;
+	ns1:contactType	"Secondary" .
+<http://data.lblod.info/id/contact-punten/7e3e2754-efa1-4122-a56e-331b3cab7d2d>
+	rdf:type	ns1:ContactPoint ;
+	ns2:uuid	"7e3e2754-efa1-4122-a56e-331b3cab7d2d" ;
+	foaf:page	"https://www.anzegem.be" ;
+	ns1:contactType	"Primary" ;
+	ns1:email	"info@anzegem.be" ;
+	ns1:telephone	"tel:+3256694440" .
+ns9:cd895859-617f-4679-9d41-5d9437133280
+	rdf:type	ns1:ContactPoint ;
+	ns2:uuid	"cd895859-617f-4679-9d41-5d9437133280" ;
+	foaf:page	"https://www.hasselt.be/nl/ocmw-sociale-dienst" ;
+	ns1:contactType	"Primary" ;
+	ns1:email	"info@ocmwhasselt.be" ;
+	ns1:telephone	"tel:+3280090280" .
+ns9:f0dde9ef-4892-49d4-a8c9-2b5cac98b7c1
+	rdf:type	ns1:ContactPoint ;
+	ns2:uuid	"f0dde9ef-4892-49d4-a8c9-2b5cac98b7c1" ;
+	foaf:page	"https://www.lier.be/stedelijk-ontwikkelingsbedrijf-lier-solag" ;
+	ns1:contactType	"Primary" ;
+	ns1:email	"info@solag.be" ;
+	ns1:telephone	"tel:+3238000341" .
+ns9:f7e104a5-84b5-4982-9d3d-d4bee9508601
+	rdf:type	ns1:ContactPoint ;
+	ns2:uuid	"f7e104a5-84b5-4982-9d3d-d4bee9508601" ;
+	foaf:page	"https://www.hasselt.be" ;
+	ns1:contactType	"Primary" ;
+	ns1:email	"info@hasselt.be" ;
+	ns1:telephone	"tel:+3211239000" .
+ns9:fee82ba7-ad64-4310-9257-a99cf52494b0
+	rdf:type	ns1:ContactPoint ;
+	ns2:uuid	"fee82ba7-ad64-4310-9257-a99cf52494b0" ;
+	foaf:page	"https://www.avelgem.be" ;
+	ns1:contactType	"Primary" ;
+	ns1:email	"info@avelgem.be" ;
+	ns1:telephone	"tel:+3256653030" .
+<http://data.lblod.info/id/contact-punten/66F543EA074D265E9ED3FF10>
+	rdf:type	ns1:ContactPoint ;
+	ns2:uuid	"66F543EA074D265E9ED3FF10" ;
+	ns1:contactType	"Secondary" .
+<http://data.lblod.info/id/contact-punten/669148366ABB62E36F847153>
+	rdf:type	ns1:ContactPoint ;
+	ns2:uuid	"669148366ABB62E36F847153" ;
+	ns1:contactType	"Secondary" .

--- a/config/migrations/2024/20241009143404-update-contact-data-from-clb/20241009161900-clb-prod-contactdata-worship.graph
+++ b/config/migrations/2024/20241009143404-update-contact-data-from-clb/20241009161900-clb-prod-contactdata-worship.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/worship-service

--- a/config/migrations/2024/20241009143404-update-contact-data-from-clb/20241009161900-clb-prod-contactdata-worship.ttl
+++ b/config/migrations/2024/20241009143404-update-contact-data-from-clb/20241009161900-clb-prod-contactdata-worship.ttl
@@ -1,0 +1,59 @@
+@prefix rdf:	<http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix ns1:	<http://www.w3.org/ns/locn#> .
+@prefix ns2:	<http://mu.semte.ch/vocabularies/core/> .
+@prefix ns3:	<https://data.vlaanderen.be/ns/adres#> .
+@prefix ns4:	<http://www.w3.org/ns/org#> .
+@prefix ns5:	<https://data.vlaanderen.be/ns/organisatie#> .
+@prefix ns6:	<http://data.lblod.info/vocabularies/erediensten/> .
+@prefix ns7:	<http://lblod.data.gift/concepts/> .
+@prefix ns8:	<http://schema.org/> .
+
+<http://data.lblod.info/id/adressen/63639DA88DE5818A7C9F439C>
+	rdf:type	ns1:Address ;
+	ns2:uuid	"63639DA88DE5818A7C9F439C" ;
+	<https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer>	"50" ;
+	ns1:thoroughfare	"Charles de Costerlaan" ;
+	ns1:postCode	"2050" ;
+	ns3:gemeentenaam	"Antwerpen" ;
+	ns1:fullAddress	"Charles de Costerlaan 50, 2050 Antwerpen, Belgi\u00EB" ;
+	ns1:adminUnitL2	"Antwerpen" ;
+	ns3:land	"Belgi\u00EB" .
+<http://data.lblod.info/id/adressen/88f69d7d4753a63ca666c035c574813d>
+	rdf:type	ns1:Address ;
+	ns2:uuid	"88f69d7d4753a63ca666c035c574813d" ;
+	<https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer>	"44" ;
+	ns1:thoroughfare	"Westkapelse Steenweg" ;
+	ns1:postCode	"8380" ;
+	ns3:gemeentenaam	"Brugge" ;
+	ns1:fullAddress	"Westkapelse Steenweg 44, 8380 Brugge, Belgi\u00EB" ;
+	ns1:adminUnitL2	"West-Vlaanderen" ;
+	ns3:land	"Belgi\u00EB" .
+<http://data.lblod.info/id/besturenVanDeEredienst/2b904e3d1917f80a6c53efc32970b9da>
+	ns4:hasPrimarySite	<http://data.lblod.info/id/vestigingen/43557b6bd03abd95ad981f3f611777c5> .
+<http://data.lblod.info/id/vestigingen/43557b6bd03abd95ad981f3f611777c5>
+	rdf:type	ns4:Site ;
+	ns2:uuid	"43557b6bd03abd95ad981f3f611777c5" ;
+	ns4:siteAddress	<http://data.lblod.info/id/contact-punten/6130D091375CFC000A000018> ;
+	ns5:bestaatUit	<http://data.lblod.info/id/adressen/88f69d7d4753a63ca666c035c574813d> ;
+	ns6:vestigingstype	ns7:f1381723dec42c0b6ba6492e41d6f5dd .
+<http://data.lblod.info/id/besturenVanDeEredienst/63639DA88DE5818A7C9F439E>
+	ns4:hasPrimarySite	<http://data.lblod.info/id/vestigingen/63639DA88DE5818A7C9F439D> .
+<http://data.lblod.info/id/vestigingen/63639DA88DE5818A7C9F439D>
+	rdf:type	ns4:Site ;
+	ns2:uuid	"63639DA88DE5818A7C9F439D" ;
+	ns4:siteAddress	<http://data.lblod.info/id/contact-punten/63639DA78DE5818A7C9F439B> , <http://data.lblod.info/id/contact-punten/63639DA78DE5818A7C9F439A> ;
+	ns5:bestaatUit	<http://data.lblod.info/id/adressen/63639DA88DE5818A7C9F439C> ;
+	ns6:vestigingstype	ns7:f1381723dec42c0b6ba6492e41d6f5dd .
+<http://data.lblod.info/id/contact-punten/6130D091375CFC000A000018>
+	rdf:type	ns8:ContactPoint ;
+	ns2:uuid	"6130D091375CFC000A000018" ;
+	ns8:contactType	"Primary" .
+<http://data.lblod.info/id/contact-punten/63639DA78DE5818A7C9F439B>
+	rdf:type	ns8:ContactPoint ;
+	ns2:uuid	"63639DA78DE5818A7C9F439B" ;
+	ns8:contactType	"Secondary" .
+<http://data.lblod.info/id/contact-punten/63639DA78DE5818A7C9F439A>
+	rdf:type	ns8:ContactPoint ;
+	ns2:uuid	"63639DA78DE5818A7C9F439A" ;
+	ns8:contactType	"Primary" ;
+	ns8:telephone	"tel:+32468208676" .

--- a/config/migrations/2024/20241009143404-update-contact-data-from-clb/20241011132019-fix--remove-spaces-in-phone-number.sparql
+++ b/config/migrations/2024/20241009143404-update-contact-data-from-clb/20241011132019-fix--remove-spaces-in-phone-number.sparql
@@ -1,0 +1,9 @@
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    <http://data.lblod.info/id/contact-punten/5def8bef-2029-403d-b80e-28a23638fe63> <http://schema.org/telephone> "tel:+32 3 410 02 11" .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    <http://data.lblod.info/id/contact-punten/5def8bef-2029-403d-b80e-28a23638fe63> <http://schema.org/telephone> "tel:+3234100211" .
+  }
+}


### PR DESCRIPTION
These migrations add the contact data from CLB production that was modified in
that app during the time it was available. These migrations perform the
following actions, in the specified order:

1. Delete all contact data for the 8 modified sites
2. Import the data extracted from CLB production for the relevant organisations
   Done in separate migrations for worship and non-worship organisations.
3. Correct a phone number literal that contained spaces for some reason

These migrations are the same as those mentioned in #457 to be executed as local
migrations on PROD. Since the migrations do not contain private it was decided
to treat them as regular migrations anyway.

Background information on how these migrations were created can be found in [sync-op-clb-prod.zip](https://github.com/user-attachments/files/17394638/sync-op-clb-prod.zip)
