### PR TITLE
fix: correct governing body start dates for new legislature

### DIFF
--- a/config/migrations/2024/20241017102700-fix-governing-bodies-start-date/20241017102700-district-governing-body-start-date.sparql
+++ b/config/migrations/2024/20241017102700-fix-governing-bodies-start-date/20241017102700-district-governing-body-start-date.sparql
@@ -1,0 +1,28 @@
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?timedGoverningBody mandaat:bindingStart "2025-01-01T00:00:00"^^xsd:dateTime .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?timedGoverningBody mandaat:bindingStart "2024-12-02T00:00:00"^^xsd:dateTime .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?organization org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000003> . # District
+
+    # Filter new district Borsbeek which is the result of municipality Borsbeek
+    # merging into Antwerp
+    FILTER (?organization != <http://data.lblod.info/id/bestuurseenheden/4b44e6f1-113b-4692-b149-44a889b215f2>)
+
+    ?governingBody besluit:bestuurt ?organization .
+
+    ?timedGoverningBody a besluit:Bestuursorgaan ;
+    generiek:isTijdspecialisatieVan ?governingBody ;
+    mandaat:bindingStart "2025-01-01T00:00:00"^^xsd:dateTime .
+  }
+}

--- a/config/migrations/2024/20241017102700-fix-governing-bodies-start-date/20241017112316-municipalities-governing-body-start-date.sparql
+++ b/config/migrations/2024/20241017102700-fix-governing-bodies-start-date/20241017112316-municipalities-governing-body-start-date.sparql
@@ -1,0 +1,46 @@
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?timedGoverningBody mandaat:bindingStart "2025-01-01T00:00:00"^^xsd:dateTime .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?timedGoverningBody mandaat:bindingStart "2024-12-02T00:00:00"^^xsd:dateTime .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/shared> {
+    ?organization org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001> . # Municipality
+
+    # Filter new municipalities that will the result of a merger
+    FILTER (?organization NOT IN
+            (
+             # Merged municipalities with new URIs
+             <http://data.lblod.info/id/bestuurseenheden/19483103-318e-435a-aa37-45e485406ee9> , # Beveren-Kruibeke-Zwijndrecht
+             <http://data.lblod.info/id/bestuurseenheden/b8bb293d-aa22-4b43-bda4-0b6af76e9493> , # Merelbeke-Melle
+             <http://data.lblod.info/id/bestuurseenheden/1ca65d65-54ff-4b44-b750-bd70c91191af> , # Nazareth-De Pinte
+             <http://data.lblod.info/id/bestuurseenheden/add1e4eb-9ec7-4ea6-af82-335aa76b7d48> , # Pajottegem
+             # Merged municipalities that keep URI
+             <http://data.lblod.info/id/bestuurseenheden/670db1d66c0de3b931962e1044033ccfa9d6e3023aa9828a5f252c3bc69bd32c> , # Antwerpen
+             <http://data.lblod.info/id/bestuurseenheden/99da98a7a0087d3429b084ebfc4eb5d488c593790d4d5af7253982a2e21a6a5f> , # Bilzen
+             <http://data.lblod.info/id/bestuurseenheden/05099fa1f6524b8b994d86f61549455d2c00b2a956d5308683ac2d1f810fc729> , # Ham
+             <http://data.lblod.info/id/bestuurseenheden/9db1b46874a57fe63c08fb5f16b117e6f61fdd98e7f64f745d0fceb9d3731169> , # Hasselt
+             <http://data.lblod.info/id/bestuurseenheden/2ac1bb2a7d7bbd98e2e7a24be2c67e42171788a71c2436a33060626593bb2f78> , # Lochristi
+             <http://data.lblod.info/id/bestuurseenheden/cb2a6e0a490ee881ddd0d9ded7f2b3d1dc2df7e57a19d014caac054bfa355f5a> , # Lokeren
+             <http://data.lblod.info/id/bestuurseenheden/b36da606fba6dd4dc99ae1ef5f4a52bba3268d33f4bc2cd1e65b87f01f35101a> , # Tielt
+             <http://data.lblod.info/id/bestuurseenheden/104f32d7fb8d4b8b61b71717301656f136fe046eabaf126fb3325896b5c2d625> , # Tongeren
+             <http://data.lblod.info/id/bestuurseenheden/99ed6eee81a7aca47517cbffb46eaba38f3987eeb4ad32c020898644769eb615> # Wingene
+             )
+            )
+  }
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?governingBody besluit:bestuurt ?organization .
+
+    ?timedGoverningBody a besluit:Bestuursorgaan ;
+    generiek:isTijdspecialisatieVan ?governingBody ;
+    mandaat:bindingStart "2025-01-01T00:00:00"^^xsd:dateTime .
+  }
+}

--- a/config/migrations/2024/20241017102700-fix-governing-bodies-start-date/20241017114628-ocmws-governing-body-start-date.sparql
+++ b/config/migrations/2024/20241017102700-fix-governing-bodies-start-date/20241017114628-ocmws-governing-body-start-date.sparql
@@ -1,0 +1,45 @@
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?timedGoverningBody mandaat:bindingStart "2025-01-01T00:00:00"^^xsd:dateTime .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?timedGoverningBody mandaat:bindingStart "2024-12-02T00:00:00"^^xsd:dateTime .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?organization org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000002> . # OCMW
+
+    # Filter new OCMWs that will the result of a merger
+    FILTER (?organization NOT IN
+            (
+             # Merged OCMWs with new URIs
+             <http://data.lblod.info/id/bestuurseenheden/fd41f573-7d9a-4d9f-b7d0-d5b6114d1622> , # Beveren-Kruibeke-Zwijndrecht
+             <http://data.lblod.info/id/bestuurseenheden/5d94b2fd-60ee-4e56-a1f0-a586d596adf6> , # Merelbeke-Melle
+             <http://data.lblod.info/id/bestuurseenheden/7d53f659-3a3b-44b1-9e77-3ea067678c0e> , # Nazareth-De Pinte
+             <http://data.lblod.info/id/bestuurseenheden/650378e7-1bee-4737-91ff-5b20ac4623cf> , # Pajottegem
+             # Merged OCMWs that keep URI
+             <http://data.lblod.info/id/bestuurseenheden/83c7a12a4a8ac8dd82895715095a866dc4794e60de61b967419bdfc1e207ad96> , # Antwerpen
+             <http://data.lblod.info/id/bestuurseenheden/9ae900a5447b7d727ca6496910220d4389aba7f1869923f1bbf9729bdeca28e2> , # Bilzen
+             <http://data.lblod.info/id/bestuurseenheden/42a43591e0db1dca9432f480f0f49f9bd4056c2b131e2fc997497130f5e099d0> , # Ham
+             <http://data.lblod.info/id/bestuurseenheden/026509cf3b4eeb7ad88fe57a270060574f60abd1c3524837d36700e40809d210> , # Hasselt
+             <http://data.lblod.info/id/bestuurseenheden/ee5d6d9da5fcf9e7bbd5c60931e37451f6bc816233c9c269565d79c2b2a37af5> , # Lochristi
+             <http://data.lblod.info/id/bestuurseenheden/323a24f2fe81ee0b6586ec78be36760e478092e07386b2785992ea8b61941833> , # Lokeren
+             <http://data.lblod.info/id/bestuurseenheden/f6ef0202c1dca780c66e269f2d21aa39a690f4c57ad05ece63f178b629bbb98e> , # Tielt
+             <http://data.lblod.info/id/bestuurseenheden/ab684633d605d93dbbe6b9ea40667e2bcf03a0856cafe1825e95b7829ed502a3> , # Tongeren
+             <http://data.lblod.info/id/bestuurseenheden/518c31a6e89f514c075e0927bce9fb2c91a552b6d65208c04a687d4bcb81148c> # Wingene
+             )
+            )
+
+    ?governingBody besluit:bestuurt ?organization .
+
+    ?timedGoverningBody a besluit:Bestuursorgaan ;
+    generiek:isTijdspecialisatieVan ?governingBody ;
+    mandaat:bindingStart "2025-01-01T00:00:00"^^xsd:dateTime .
+  }
+}

--- a/config/migrations/2024/20241017102700-fix-governing-bodies-start-date/20241017120456-provinces-governing-body-start-date.sparql
+++ b/config/migrations/2024/20241017102700-fix-governing-bodies-start-date/20241017120456-provinces-governing-body-start-date.sparql
@@ -1,0 +1,26 @@
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?timedGoverningBody mandaat:bindingStart "2025-01-01T00:00:00"^^xsd:dateTime .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?timedGoverningBody mandaat:bindingStart "2024-12-02T00:00:00"^^xsd:dateTime .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/shared> {
+    ?organization org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000000> . # Province
+  }
+
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?governingBody besluit:bestuurt ?organization .
+
+    ?timedGoverningBody a besluit:Bestuursorgaan ;
+    generiek:isTijdspecialisatieVan ?governingBody ;
+    mandaat:bindingStart "2025-01-01T00:00:00"^^xsd:dateTime .
+  }
+}

--- a/config/migrations/2024/20241017102700-fix-governing-bodies-start-date/20241017121145-merged-organizations-governing-body-start-date.sparql
+++ b/config/migrations/2024/20241017102700-fix-governing-bodies-start-date/20241017121145-merged-organizations-governing-body-start-date.sparql
@@ -1,0 +1,23 @@
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+
+# Set the start date for governing bodies for organisations that are the result
+# of a merger to 02 January 2025 which is the first working day of the year.
+# Note: this migration assumes that all other `2025-01-01` starting dates have
+# already been replaced by previous migrations. So order matters here!
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?timedGoverningBody mandaat:bindingStart "2025-01-01T00:00:00"^^xsd:dateTime .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?timedGoverningBody mandaat:bindingStart "2025-01-02T00:00:00"^^xsd:dateTime .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?timedGoverningBody a besluit:Bestuursorgaan ;
+    mandaat:bindingStart "2025-01-01T00:00:00"^^xsd:dateTime .
+  }
+}


### PR DESCRIPTION
Originally the starting dates for the new governing bodies for the new
legislature was set to `2025-01-01` for all relevant municipalities, OCMWs,
districts, and provinces.

These migrations change that to more correct starting dates:
* For organisations that are **not** involved in mergers the new starting data
  is `2024-12-02`, the first day installation meetings are allowed[^1].
* For organisations that are involved in mergers the new starting date is
  `2025-01-01`, the first work day of the new year on which the mergers take
  effect. Note: this migration assumes there are no other start dates on
  `2025-01-01`, so the migrations have to be run in the specified order.

[^1]: https://www.vlaanderen.be/lokaal-bestuur/organisatie-en-werking/gemeenteraad/installatie