### PR TITLE
Added migration to add besluit:Bestuurseenheid to centrale besturen

### DIFF
--- a/config/migrations/2024/20241018111200-add-type-bestuurseenheid-to-centrale-besturen.sparql
+++ b/config/migrations/2024/20241018111200-add-type-bestuurseenheid-to-centrale-besturen.sparql
@@ -1,0 +1,10 @@
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?s a <http://data.vlaanderen.be/ns/besluit#Bestuurseenheid>.
+  }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?s a <http://data.lblod.info/vocabularies/erediensten/CentraalBestuurVanDeEredienst>.
+  }
+}


### PR DESCRIPTION
According to the model they should be `besluit:Bestuurseenheid`.