### PR TITLE
DumpfilePublisher needs to fetch from publication-triplestore

### DIFF
--- a/config/delta-producer/dump-file-publisher/config.json
+++ b/config/delta-producer/dump-file-publisher/config.json
@@ -39,7 +39,7 @@
     "dcatDataSetSubject": "http://data.lblod.info/datasets/delta-producer/dumps/PublicCacheGraphDump",
     "targetGraph": "http://redpencil.data.gift/id/deltas/producer/public",
     "fileBaseName": "dump-public",
-    "publicationGraphEndpoint": "http://triplestore:8890/sparql",
+    "publicationGraphEndpoint": "http://publication-triplestore:8890/sparql",
     "targetDcatGraph": "http://mu.semte.ch/graphs/public",
     "targetFilesGraph": "http://mu.semte.ch/graphs/public",
     "cleanupOldDumps": true
@@ -48,7 +48,7 @@
     "dcatDataSetSubject": "http://data.lblod.info/datasets/delta-producer/dumps/PublicCacheGraphDump",
     "targetGraph": "http://redpencil.data.gift/id/deltas/producer/public",
     "fileBaseName": "dump-public",
-    "publicationGraphEndpoint": "http://triplestore:8890/sparql",
+    "publicationGraphEndpoint": "http://publication-triplestore:8890/sparql",
     "targetDcatGraph": "http://mu.semte.ch/graphs/public",
     "targetFilesGraph": "http://mu.semte.ch/graphs/public",
     "cleanupOldDumps": true
@@ -57,7 +57,7 @@
     "dcatDataSetSubject": "http://data.lblod.info/datasets/delta-producer/dumps/WorshipPostsCacheGraphDump",
     "targetGraph": "http://redpencil.data.gift/id/deltas/producer/worship-posts",
     "fileBaseName": "dump-worship-posts",
-    "publicationGraphEndpoint": "http://triplestore:8890/sparql",
+    "publicationGraphEndpoint": "http://publication-triplestore:8890/sparql",
     "targetDcatGraph": "http://mu.semte.ch/graphs/public",
     "targetFilesGraph": "http://mu.semte.ch/graphs/public",
     "cleanupOldDumps": true
@@ -66,7 +66,7 @@
     "dcatDataSetSubject": "http://data.lblod.info/datasets/delta-producer/dumps/WorshipPostsCacheGraphDump",
     "targetGraph": "http://redpencil.data.gift/id/deltas/producer/worship-posts",
     "fileBaseName": "dump-worship-posts",
-    "publicationGraphEndpoint": "http://triplestore:8890/sparql",
+    "publicationGraphEndpoint": "http://publication-triplestore:8890/sparql",
     "targetDcatGraph": "http://mu.semte.ch/graphs/public",
     "targetFilesGraph": "http://mu.semte.ch/graphs/public",
     "cleanupOldDumps": true


### PR DESCRIPTION
The dump-file-publisher was still fetching data from the wrong store. Now that everything is moved to the publication triplestore.