### PR TITLE
Ensure types and subtypes are added to EredienstBestuurseenheid

### DIFF
--- a/config/migrations/2024/20241022120000-add-type-bestuurseenheid-to-eredienstbestuurseenheid.sparql
+++ b/config/migrations/2024/20241022120000-add-type-bestuurseenheid-to-eredienstbestuurseenheid.sparql
@@ -1,0 +1,16 @@
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?s a <http://data.vlaanderen.be/ns/besluit#Bestuurseenheid>;
+      a <http://data.lblod.info/vocabularies/erediensten/EredienstBestuurseenheid>.
+  }
+}
+WHERE {
+  VALUES ?type {
+    <http://data.lblod.info/vocabularies/erediensten/CentraalBestuurVanDeEredienst>
+    <http://data.lblod.info/vocabularies/erediensten/BestuurVanDeEredienst>
+  }
+
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?s a ?type.
+  }
+}


### PR DESCRIPTION
It seems somehow  (in QA) `besluit:Bestuurseenheid` was removed for a significant amount of `ere:BestuurVandeEredienst`. The cause is unsure; what is sure though; is that all `?types` should correctly be added.