### PR TITLE
fix: remove incorrect change event

### DIFF
--- a/config/migrations/2024/20241023075148-delete-change-event-dodoens.sparql
+++ b/config/migrations/2024/20241023075148-delete-change-event-dodoens.sparql
@@ -1,0 +1,13 @@
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX code: <http://lblod.data.gift/vocabularies/organisatie/>
+
+DELETE WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?changeEvent a <http://www.w3.org/ns/org#ChangeEvent> ;
+    mu:uuid "66C494CB6ABCA6E6BF2DBB94" ;
+    code:veranderingsgebeurtenisResultaat ?changeEventResult ;
+    ?eventP ?eventO .
+
+    ?changeEventResult ?resultP ?resultO .
+  }
+}


### PR DESCRIPTION
A user entered a faulty change event, this migration removes it again.
Note: the change event is only present in the production data.

# Related ticket
OP-3363