### PR TITLE
fix: delete superfluous relations between APBs and municipalities

### DIFF
--- a/config/migrations/2024/20241024103653-delete-incorrect-links-between-apbs-and-municipalities.sparql
+++ b/config/migrations/2024/20241024103653-delete-incorrect-links-between-apbs-and-municipalities.sparql
@@ -1,0 +1,36 @@
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX organisatie: <https://data.vlaanderen.be/ns/organisatie#>
+PREFIX adres: <https://data.vlaanderen.be/ns/adres#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?municipality org:linkedTo ?apb .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?apb a besluit:Bestuurseenheid;
+         org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/80310756-ce0a-4a1b-9b8e-7c01b6cc7a2d>; # APB
+         org:hasPrimarySite/organisatie:bestaatUit/adres:gemeentenaam ?apbMunicipalityName .
+    ?municipality org:linkedTo ?apb .
+    # Filter APBs with more than 1 linked municipality, this avoids removing
+    # triples for APBs created by users.
+    {
+      SELECT DISTINCT ?apb
+      WHERE {
+        GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+          ?municipality org:linkedTo ?apb .
+        }
+      } GROUP BY ?apb HAVING (COUNT(?municipality) > 1)
+    }
+  }
+  # Filter municipalities that are different from the APB's primary site's
+  # municipality
+  GRAPH <http://mu.semte.ch/graphs/shared> {
+    ?municipality a besluit:Bestuurseenheid;
+                  org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001>; # municipality
+                  skos:prefLabel ?municipalityName .
+  }
+  FILTER (?apbMunicipalityName != ?municipalityName)
+}


### PR DESCRIPTION
A number of APBs were accidentally `org:linkedTo` all municipalities in municipality and an APB for which:
- the APB is linked to more than 1 municipality; and
- the municipality does not match that of the APB's primary site.

The first condition avoids we remove `org:linkedTo` triples for APBs that were created by the users, as these are only linked with a single municipality.

Notes:
- I opted not to use the URIs of the APBs so this migration works on all environments.
- On QA there are 4 APBs created for testing that do not have a site and will  thus not be fixed by this migration. On PROD this situation does not occur.
- This PR is against the master branch in order to include it in the next hotfix (1.27.4). Otherwise. the membership functionality, part of the next full release (1.28.0), would create memberships for each of the `org:linkedTo` triples that are removed in this PR.


## Testing
Example query to count the number of organisations that are `org:linkedTo` each APB:

``` sparql
PREFIX org: <http://www.w3.org/ns/org#>
PREFIX skos: <http://www.w3.org/2004/02/skos/core#>

SELECT DISTINCT ?name ?apb (COUNT (DISTINCT ?s) AS ?count) {
  graph <http://mu.semte.ch/graphs/administrative-unit> {
    ?s org:linkedTo ?apb .
    ?apb skos:prefLabel ?name .
    ?apb org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/80310756-ce0a-4a1b-9b8e-7c01b6cc7a2d> . # APB
  }
}  ORDER BY DESC(?count) ASC(?name)
```

## Related ticket
OP-3446