### PR TITLE
Fix classification of Voetbal in de Stad vzw

### DIFF
--- a/config/migrations/2024/20241119101320-fix-classification-Voetbal-in-de-stad-vzw.sparql
+++ b/config/migrations/2024/20241119101320-fix-classification-Voetbal-in-de-stad-vzw.sparql
@@ -1,0 +1,11 @@
+DELETE DATA {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    <http://data.lblod.info/id/geregistreerdeOrganisaties/8b2e8749-98a9-450f-b2f1-7a93115ef513> <http://www.w3.org/ns/org#classification> <http://data.vlaanderen.be/id/concept/GeregistreerdeOrganisatieClassificatieCode/35833ba2-7371-400b-8df2-2912f66fb153> .
+  }
+}
+;
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    <http://data.lblod.info/id/geregistreerdeOrganisaties/8b2e8749-98a9-450f-b2f1-7a93115ef513> <http://www.w3.org/ns/org#classification> <http://data.vlaanderen.be/id/concept/GeregistreerdeOrganisatieClassificatieCode/3e5c8e30-95a7-47b0-b0a4-210d5bd440a7> .
+  }
+}


### PR DESCRIPTION
# Incident OP-3474

The organization Voetbal in de Stad vzw has been wrongly typed, it was `Vereniging of vennootschap voor sociale dienstverlening` and needs to be `Vereniging`.