### PR TITLE
chore: bump services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,21 +51,21 @@ services:
       - "logging=true"
     restart: always
     logging: *default-logging
+  db-cleanup:
+    image: lblod/db-cleanup-service:0.5.1
+    environment:
+      MU_SPARQL_ENDPOINT: "http://db:8890/sparql"
+      CRON_PATTERN: "23 */6 * * *"
+    labels:
+      - "logging=true"
+    restart: always
+    logging: *default-logging
   migrations:
     image: semtech/mu-migrations-service:0.7.0
     links:
       - triplestore:database
     volumes:
       - ./config/migrations:/data/migrations
-    labels:
-      - "logging=true"
-    restart: always
-    logging: *default-logging
-  db-cleanup:
-    image: lblod/db-cleanup-service:0.5.1
-    environment:
-      MU_SPARQL_ENDPOINT: "http://db:8890/sparql"
-      CRON_PATTERN: "23 */6 * * *"
     labels:
       - "logging=true"
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ x-logging: &default-logging
 
 services:
   identifier:
-    image: semtech/mu-identifier:1.10.1
+    image: semtech/mu-identifier:1.10.3
     environment:
       DEFAULT_MU_AUTH_ALLOWED_GROUPS_HEADER: '[{"variables":[],"name":"public"}]'
       SESSION_COOKIE_SECURE: "on"
@@ -61,7 +61,7 @@ services:
     restart: always
     logging: *default-logging
   migrations:
-    image: semtech/mu-migrations-service:0.7.0
+    image: semtech/mu-migrations-service:0.9.0
     links:
       - triplestore:database
     volumes:
@@ -71,7 +71,7 @@ services:
     restart: always
     logging: *default-logging
   migrations-triggering-indexing:
-    image: semtech/mu-migrations-service:0.8.0
+    image: semtech/mu-migrations-service:0.9.0
     links:
       - db:database
     volumes:
@@ -81,7 +81,7 @@ services:
     restart: always
     logging: *default-logging
   resource:
-    image: semtech/mu-cl-resources:1.24.0
+    image: semtech/mu-cl-resources:1.25.0
     environment:
       CACHE_CLEAR_PATH: "http://cache/.mu/clear-keys"
     links:
@@ -211,7 +211,7 @@ services:
     restart: always
     logging: *default-logging
   file:
-    image: semtech/mu-file-service:3.2.0
+    image: semtech/mu-file-service:3.4.0
     volumes:
       - ./data/files:/share
     links:


### PR DESCRIPTION
Bump the following services to the most recent versions:
- identifier to v1.10.3
- migrations and migrations-triggering-indexing to v0.9.0
- resource to v1.25.0
- file to v3.4.0

The versions bumped to do not introduce breaking changes or changes requiring additional changes.