### PR TITLE
DO NOT MERGE: example audit trail service

### DIFF
--- a/config/access-with-audit-trail/config.json
+++ b/config/access-with-audit-trail/config.json
@@ -1,0 +1,43 @@
+{
+  "prefixes": {
+    "dc_terms": "http://purl.org/dc/terms/",
+    "schema": "http://schema.org/",
+    "person": "http://www.w3.org/ns/person#",
+    "foaf": "http://xmlns.com/foaf/0.1/",
+    "persoon": "https://data.vlaanderen.be/ns/persoon#"
+  },
+  "resources": {
+    "people": {
+      "rdfType": "person:Person",
+      "attributes": {
+        "given-name": {
+          "label": "Given Name",
+          "type": "string",
+          "path": [
+            "foaf:givenName"
+          ]
+        },
+        "gender": {
+          "label": "Gender",
+          "type": "string",
+          "path": [
+            "persoon:geslacht",
+            "http://www.w3.org/2004/02/skos/core#prefLabel"
+          ]
+        },
+        "family-name": {
+          "label": "Family Name",
+          "type": "string",
+          "path": [
+            "foaf:familyName"
+          ]
+        },
+        "first-name-used": {
+          "label": "First name used",
+          "type": "string",
+          "path": "persoon:gebruikteVoornaam"
+        }
+      }
+    }
+  }
+}

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -130,7 +130,9 @@ defmodule Dispatcher do
   match "/identifiers/*path", %{accept: [:json], layer: :api} do
     Proxy.forward(conn, path, "http://cache/identifiers/")
   end
-
+  match "/access-with-audit-trail/*path", %{ layer: :api_services, accept: %{ json: true } } do
+    forward conn, path, "http://access-with-audit-trail"
+  end
   match "/structured-identifiers/*path", %{accept: [:json], layer: :api} do
     Proxy.forward(conn, path, "http://cache/structured-identifiers/")
   end


### PR DESCRIPTION
CLB-751 for context.

this PR is only an example on how we could use the new [audit trail service](https://github.com/lblod/access-with-audit-trail-service/pull/1) in OP

This service works a bit like the privacy service, but logs the `dcterms:identifier` of the logged in user (`vo-id` on acmidm).

In order to test it, you would need to login with an user that has a `dcterms:identifer` in its `foaf:OnlineAccount`.

MOCK LOGIN users don't have it, so you would need to add it manually (through a migration, or directly on virtuoso)

Once logged in, copy the `Cookie`, then you can use `curl` to try it out.

Example for getting the `family-name` and `given-name` of person with id `fa346447ef3262f90217c8534e49e9f7` and reason `3aeec145-acf3-4b6e-9c00-5b8e285736e0` : 

```
curl 'http://localhost/access-with-audit-trail/people/fa346447ef3262f90217c8534e49e9f7?reasonId=3aeec145-acf3-4b6e-9c00-5b8e285736e0&include=given-name,family-name' \
-H 'Accept: application/vnd.api+json'   --compressed  \
-H  'Cookie: proxy_session=<your-session-cookie>
```

Result:

```json
{
  "data": {
    "type": "people",
    "id": "7daa61fcd543c33f63014dd97db0950d0e6475ac40ed553346a9ce58d7775a95",
    "attributes": {
      "given-name": "the given name",
      "family-name": "the family name"
    },
    "relationships": {}
  }
}
```

Audit log:

```turtle
PREFIX sh:   <http://www.w3.org/ns/shacl#>
PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
PREFIX persoon: <https://data.vlaanderen.be/ns/persoon#>
PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
PREFIX person: <http://www.w3.org/ns/person#>
PREFIX session: <http://mu.semte.ch/vocabularies/session/>
PREFIX foaf: <http://xmlns.com/foaf/0.1/>
PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
PREFIX dcterms: <http://purl.org/dc/terms/>
<http://data.lblod.info/id/node-paths/a6cc40d2-adbe-11ef-b5f4-fd38d66e2101>
        a        <http://www.w3.org/1999/02/22-rdf-syntax-ns#List>;
        <http://www.w3.org/1999/02/22-rdf-syntax-ns#first>
                foaf:givenName;
        <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest>
                <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil>;
        mu:uuid  "a6cc40d2-adbe-11ef-b5f4-fd38d66e2101" .

<http://data.lblod.info/id/node-shapes/a6cc40d3-adbe-11ef-b5f4-fd38d66e2101>
        a        sh:NodeShape;
        mu:uuid  "a6cc40d3-adbe-11ef-b5f4-fd38d66e2101";
        sh:path  <http://data.lblod.info/id/node-paths/a6cc40d4-adbe-11ef-b5f4-fd38d66e2101> .

<http://data.lblod.info/id/node-shapes/a6cc40d1-adbe-11ef-b5f4-fd38d66e2101>
        a        sh:NodeShape;
        mu:uuid  "a6cc40d1-adbe-11ef-b5f4-fd38d66e2101";
        sh:path  <http://data.lblod.info/id/node-paths/a6cc40d2-adbe-11ef-b5f4-fd38d66e2101> .

<http://data.lblod.info/id/node-paths/a6cc40d4-adbe-11ef-b5f4-fd38d66e2101>
        a        <http://www.w3.org/1999/02/22-rdf-syntax-ns#List>;
        <http://www.w3.org/1999/02/22-rdf-syntax-ns#first>
                foaf:familyName;
        <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest>
                <http://www.w3.org/1999/02/22-rdf-syntax-ns#nil>;
        mu:uuid  "a6cc40d4-adbe-11ef-b5f4-fd38d66e2101" .

<http://data.lblod.info/id/audit-trail-entries/a6cc40d0-adbe-11ef-b5f4-fd38d66e2101>
        a                   ext:AuditTrailEntry;
        mu:uuid             "a6cc40d0-adbe-11ef-b5f4-fd38d66e2101";
        ext:code            <http://data.lblod.info/id/information-request-reason/3aeec145-acf3-4b6e-9c00-5b8e285736e0>;
        ext:requester       <http://data.lblod.info/id/account/cd52ed34-7bcd-41df-a7d4-c805c1d1a197>;
        ext:shape           <http://data.lblod.info/id/node-shapes/a6cc40d3-adbe-11ef-b5f4-fd38d66e2101> , <http://data.lblod.info/id/node-shapes/a6cc40d1-adbe-11ef-b5f4-fd38d66e2101>;
        ext:subject         <http://data.lblod.info/id/personen/fa346447ef3262f90217c8534e49e9f7>;
        dcterms:created     "2024-11-28T19:26:22.556Z"^^xsd:dateTime;
        dcterms:identifier  "b838f67c-6c4c-44b2-8297-c9eefccc5e35" .

```
