### PR TITLE
feat: add merger change events for 2025 municipality mergers

### DIFF
--- a/config/migrations-triggering-indexing/2024/20241203144827-mergers-2025-update-organisation-status.sparql
+++ b/config/migrations-triggering-indexing/2024/20241203144827-mergers-2025-update-organisation-status.sparql
@@ -1,0 +1,102 @@
+PREFIX regorg: <http://www.w3.org/ns/regorg#>
+
+DELETE {
+  GRAPH ?g {
+    ?org regorg:orgStatus ?oldStatus.
+  }
+} INSERT {
+  GRAPH ?g {
+    ?org  regorg:orgStatus <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311>.
+  }
+} WHERE {
+  GRAPH ?g {
+    ?org regorg:orgStatus ?oldStatus.
+  }
+  VALUES ?g {
+    <http://mu.semte.ch/graphs/administrative-unit>
+  }
+  VALUES ?org {
+    <http://data.lblod.info/id/bestuurseenheden/e41ffa04f94bb450a79793020e70d55b5fee5033a5280277998608a9d0913117>
+    <http://data.lblod.info/id/bestuurseenheden/7125fcbfb7a08f8c01efbed115cea602db249c04afe9b5a2cc298cc7949cd040>
+
+    <http://data.lblod.info/id/bestuurseenheden/4f0eb4436c88cf831c35f84e7c34ce32f9ee4e99c5139aff62990e5e531aa1e7>
+    <http://data.lblod.info/id/bestuurseenheden/6af55cecaea3621f53bb32417a36ed6e3d41b2aa5b9f6d62ab3d80cc8ec11539>
+    <http://data.lblod.info/id/bestuurseenheden/c362abc58ac4579ff417824ce620962ac57bc344b34fe8f51d21b35ef54da36d>
+    <http://data.lblod.info/id/bestuurseenheden/72bc672ceb6894d8dd31dc2dff2faad2fd93f4b9f5347d556d092516eaa30aa3>
+    <http://data.lblod.info/id/bestuurseenheden/d3c76fd84794dad5e12c9eed6d6332dc5e5c99daf0e4ddd7ceebf13d5d6c0ccd>
+    <http://data.lblod.info/id/bestuurseenheden/bbc23313f4c8585a0c51f15f920d77123356535cd1cad9af38f5707892c7088d>
+
+    <http://data.lblod.info/id/bestuurseenheden/a3bd0845853278f478f90b14436d3efa99e73249a84d462f0ddc2e5b6e37a156>
+    <http://data.lblod.info/id/bestuurseenheden/785e8d5516378c7382ad0e7e356d2301496d810c6cd46d72ccebb455d3ac525e>
+
+    <http://data.lblod.info/id/bestuurseenheden/05441122597e0b20b61a8968ea1247c07f9014aad1f1f0709d0b1234e3dfbc2f>
+    <http://data.lblod.info/id/bestuurseenheden/3834647b5e95ea20f5ffe5a12a09fbd3d7fdf0d187fab385cb7b841422176ad6>
+
+    <http://data.lblod.info/id/bestuurseenheden/0327a51548f73607f8a5ec11b36711a3c96703686ad93a3d632718c135c295db>
+    <http://data.lblod.info/id/bestuurseenheden/e39bc997aa6dd9f240277735efd745b6a0422614d2b36cf01825c86b1b91a9ee>
+    <http://data.lblod.info/id/bestuurseenheden/0a2d980559eb9f3e0820386541274a72692f495204cd6d951ea1907ecc65829b>
+    <http://data.lblod.info/id/bestuurseenheden/144c75e403c5084af57f5c0c86252b8759b56baf9694326abbcb5ea40ab69f1a>
+
+    <http://data.lblod.info/id/bestuurseenheden/00eb231f51bd6b4f5dcc6536b2d09a174ea8583f5bf28b10bc4fc769a07e511d>
+    <http://data.lblod.info/id/bestuurseenheden/c69192b973a3ca11531b9657b3ee20aa6688fa33ea1ef1392310fec751980ab2>
+    <http://data.lblod.info/id/bestuurseenheden/3eb8c9fae32d02359dcd7b22e2a74e67a5b48388df31ad819c27c688fedd10b0>
+    <http://data.lblod.info/id/bestuurseenheden/ba8a253d98ea7d2ab1afc43e5e2cd145a12ccd86b68e71d023e3c13a83d7498f>
+    <http://data.lblod.info/id/bestuurseenheden/76c45d60f05bf8afc8c71859342b69cac6a57ee2b320b900a60afd6ba9b8eb9d>
+    <http://data.lblod.info/id/bestuurseenheden/5d21ccef2f5aa3ccbf3a74c6f25ebe9f0b1ef5a97b87f3d79c86ae9d6d857df8>
+
+    <http://data.lblod.info/id/bestuurseenheden/af8969752f6b28c66b6bc402d7987fa38774901ac72b95c5cb7976570487c3c9>
+    <http://data.lblod.info/id/bestuurseenheden/fb1be873c4b31e391613dfae8e68edd694b1fdf126eeecb502b1e5cad6f2f682>
+
+    <http://data.lblod.info/id/bestuurseenheden/f6b131de5e40a0dfd4fc93fedf3b95c9bf156ece718b87fe00469dea2564b3fb>
+    <http://data.lblod.info/id/bestuurseenheden/3e077115eeb70b649d44e2ebbb218f2cfcac5d84e130c88584f0ec23f7cebbf9>
+
+    <http://data.lblod.info/id/bestuurseenheden/1313d4a58f9ecf52cc7e274e3549a759b35e731973cc9f5e07562e5650f594dd>
+    <http://data.lblod.info/id/bestuurseenheden/7c6b38fa6fc65879cb674a654617de171adfcfacba086fb918da3749dbaa43b5>
+
+    <http://data.lblod.info/id/bestuurseenheden/c5dbb08e35e2d090a05d119fef4cc161b5ee1f322698cb8ea3c8c6643a521cf2>
+    <http://data.lblod.info/id/bestuurseenheden/f2a9a2392d5e4c0f992a84a0871d048a7b91b14681e9980a63aa6ba4b1f7eb8c>
+
+    <http://data.lblod.info/id/bestuurseenheden/c0b6b5cf198cd939251dff8ed052177cfff245074c6b8d43394c8c97f7b6e945>
+    <http://data.lblod.info/id/bestuurseenheden/8ef1e4a43efd913e6b09b0ddea344b7b5d723a344ad559389a55ae1ff0bebc8f>
+    <http://data.lblod.info/id/bestuurseenheden/04895013fe6301f32aa46deae98abfb833a717ece5a33b6c453674c6d0f4cc5e>
+    <http://data.lblod.info/id/bestuurseenheden/f56f068943a99059f5bfc3b905fe8848a25a47cfa30fb3ed3d294b47815b2255>
+
+    <http://data.lblod.info/id/bestuurseenheden/5a4b2b4f1de1f3b91b0348a7eb6d6aa0ef9420b8ec31374970c9ffe933a79515>
+    <http://data.lblod.info/id/bestuurseenheden/3f57a17fbcdfc13def910c54948bec11d71d3f75946b0336fffc0587bf18d783>
+
+    <http://data.lblod.info/id/bestuurseenheden/2564e21e3650f91625189ccb7eb055e47754a0633c54c7582a899171fef60c52>
+    <http://data.lblod.info/id/bestuurseenheden/60daf27c2cf12dd123447aa300dd7320890391dbd8dd6b4dd7ec02258f8281b3>
+  }
+}
+;
+DELETE {
+  GRAPH ?g {
+    ?org regorg:orgStatus ?oldStatus.
+  }
+} INSERT {
+  GRAPH ?g {
+    ?org  regorg:orgStatus <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>.
+  }
+} WHERE {
+  GRAPH ?g {
+    ?org regorg:orgStatus ?oldStatus.
+  }
+  VALUES ?g {
+    <http://mu.semte.ch/graphs/administrative-unit>
+  }
+  VALUES ?org {
+    <http://data.lblod.info/id/bestuurseenheden/4b44e6f1-113b-4692-b149-44a889b215f2>
+
+    <http://data.lblod.info/id/bestuurseenheden/1ca65d65-54ff-4b44-b750-bd70c91191af>
+    <http://data.lblod.info/id/bestuurseenheden/7d53f659-3a3b-44b1-9e77-3ea067678c0e>
+
+    <http://data.lblod.info/id/bestuurseenheden/b8bb293d-aa22-4b43-bda4-0b6af76e9493>
+    <http://data.lblod.info/id/bestuurseenheden/5d94b2fd-60ee-4e56-a1f0-a586d596adf6>
+
+    <http://data.lblod.info/id/bestuurseenheden/19483103-318e-435a-aa37-45e485406ee9>
+    <http://data.lblod.info/id/bestuurseenheden/fd41f573-7d9a-4d9f-b7d0-d5b6114d1622>
+
+    <http://data.lblod.info/id/bestuurseenheden/add1e4eb-9ec7-4ea6-af82-335aa76b7d48>
+    <http://data.lblod.info/id/bestuurseenheden/650378e7-1bee-4737-91ff-5b20ac4623cf>
+  }
+}

--- a/config/migrations/2024/20241203112740-mergers-2025-add-merge-change-events/20241203112740-mergers-2025-add-merge-change-events-results-are-new-organisations.sparql
+++ b/config/migrations/2024/20241203112740-mergers-2025-add-merge-change-events/20241203112740-mergers-2025-add-merge-change-events-results-are-new-organisations.sparql
@@ -1,0 +1,178 @@
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX ch: <http://data.lblod.info/vocabularies/contacthub/>
+PREFIX lblodOrg: <http://lblod.data.gift/vocabularies/organisatie/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX regorg: <http://www.w3.org/ns/regorg#>
+
+# This migration add merger change events for municipalities and OCMWs for which
+# the resulting active organisation is a new, different resource.
+
+## Mergers involving two original organisations
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?changeEvent a org:ChangeEvent;
+                 mu:uuid ?uuidChangeEvent;
+                 org:resultingOrganization ?resultingOrg;
+                 dct:date "2025-01-01"^^xsd:dateTime;
+                 dct:description ?description;
+                 org:originalOrganization ?firstOrgToMerge;
+                 org:originalOrganization ?secondOrgToMerge;
+                 lblodOrg:veranderingsgebeurtenisResultaat ?changeEventFirstNotActiveResult;
+                 lblodOrg:veranderingsgebeurtenisResultaat ?changeEventSecondNotActiveResult;
+                 lblodOrg:veranderingsgebeurtenisResultaat ?changeEventActiveResult;
+                 ch:typeWijziging <http://lblod.data.gift/concepts/fa80032794c841ecac73ff874f856db1>. # Merger
+
+    ?changeEventFirstNotActiveResult a lblodOrg:VeranderingsgebeurtenisResultaat;
+                                     mu:uuid ?uuidChangeEventFirstNotActiveResult;
+                                     ext:resultingOrganization ?firstOrgToMerge;
+                                     lblodOrg:resulterendeStatus <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311>. # not active
+
+    ?changeEventSecondNotActiveResult a lblodOrg:VeranderingsgebeurtenisResultaat;
+                                      mu:uuid ?uuidChangeEventSecondNotActiveResult;
+                                      ext:resultingOrganization ?secondOrgToMerge;
+                                      lblodOrg:resulterendeStatus <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311>. # not active
+
+    ?changeEventActiveResult a lblodOrg:VeranderingsgebeurtenisResultaat;
+                             mu:uuid ?uuidChangeEventActiveResult;
+                             ext:resultingOrganization ?resultingOrg;
+                             lblodOrg:resulterendeStatus <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>. # active
+  }
+} WHERE {
+  VALUES (?firstOrgToMerge ?secondOrgToMerge ?resultingOrg) {
+    # Nazareth (municipality) + De Pinte (municipality) = Nazareth-De Pinte (municipality)
+    (<http://data.lblod.info/id/bestuurseenheden/0327a51548f73607f8a5ec11b36711a3c96703686ad93a3d632718c135c295db>
+     <http://data.lblod.info/id/bestuurseenheden/e39bc997aa6dd9f240277735efd745b6a0422614d2b36cf01825c86b1b91a9ee>
+     <http://data.lblod.info/id/bestuurseenheden/1ca65d65-54ff-4b44-b750-bd70c91191af>)
+    # Nazareth (OCMW) + De Pinte (OCMW) = Nazareth-De Pinte (OCMW)
+    (<http://data.lblod.info/id/bestuurseenheden/0a2d980559eb9f3e0820386541274a72692f495204cd6d951ea1907ecc65829b>
+     <http://data.lblod.info/id/bestuurseenheden/144c75e403c5084af57f5c0c86252b8759b56baf9694326abbcb5ea40ab69f1a>
+     <http://data.lblod.info/id/bestuurseenheden/7d53f659-3a3b-44b1-9e77-3ea067678c0e>)
+
+    # Melle (municipality) + Merelbeke (municipality) = Merelbeke-Melle (municipality)
+    (<http://data.lblod.info/id/bestuurseenheden/c0b6b5cf198cd939251dff8ed052177cfff245074c6b8d43394c8c97f7b6e945>
+     <http://data.lblod.info/id/bestuurseenheden/8ef1e4a43efd913e6b09b0ddea344b7b5d723a344ad559389a55ae1ff0bebc8f>
+     <http://data.lblod.info/id/bestuurseenheden/b8bb293d-aa22-4b43-bda4-0b6af76e9493>)
+    # Melle (OCMW) + Merelbeke (OCMW) = Merelbeke-Melle (OCMW)
+    (<http://data.lblod.info/id/bestuurseenheden/04895013fe6301f32aa46deae98abfb833a717ece5a33b6c453674c6d0f4cc5e>
+     <http://data.lblod.info/id/bestuurseenheden/f56f068943a99059f5bfc3b905fe8848a25a47cfa30fb3ed3d294b47815b2255>
+     <http://data.lblod.info/id/bestuurseenheden/5d94b2fd-60ee-4e56-a1f0-a586d596adf6>)
+  }
+
+  VALUES ?g {
+    <http://mu.semte.ch/graphs/administrative-unit>
+    <http://mu.semte.ch/graphs/shared>
+  }
+
+  GRAPH ?g {
+    ?firstOrgToMerge skos:prefLabel ?labelFirstOrg.
+    ?secondOrgToMerge skos:prefLabel ?labelSecondOrg.
+    ?resultingOrg skos:prefLabel ?labelResultingOrg;
+                  org:classification ?classification.
+  }
+
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?classification skos:prefLabel ?classificationResultingOrg.
+  }
+
+  BIND(CONCAT("Fusie tussen ", ?labelFirstOrg," en ", ?labelSecondOrg, " resulteert in ", ?classificationResultingOrg, " ", ?labelResultingOrg) as ?description)
+
+  BIND(SHA256(CONCAT(STR(?firstOrgToMerge), STR(?secondOrgToMerge), STR(?resultingOrg),"fusieChangeEvent")) AS ?uuidChangeEvent)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/veranderingsgebeurtenissen/", STR(?uuidChangeEvent))) AS ?changeEvent)
+
+  BIND(SHA256(CONCAT(STR(?firstOrgToMerge),"fusieChangeEventFirstNotActiveResult")) AS ?uuidChangeEventFirstNotActiveResult)
+  BIND(IRI(CONCAT("http://lblod.data.info/id/veranderingsgebeurtenis-resultaten/", STR(?uuidChangeEventFirstNotActiveResult))) AS ?changeEventFirstNotActiveResult)
+
+  BIND(SHA256(CONCAT(STR(?secondOrgToMerge),"fusieChangeEventSecondNotActiveResult")) AS ?uuidChangeEventSecondNotActiveResult)
+  BIND(IRI(CONCAT("http://lblod.data.info/id/veranderingsgebeurtenis-resultaten/", STR(?uuidChangeEventSecondNotActiveResult))) AS ?changeEventSecondNotActiveResult)
+
+
+  BIND(SHA256(CONCAT(STR(?firstOrgToMerge), STR(?secondOrgToMerge), STR(?resultingOrg),"fusieChangeEventActiveResult")) AS ?uuidChangeEventActiveResult)
+  BIND(IRI(CONCAT("http://lblod.data.info/id/veranderingsgebeurtenis-resultaten/", STR(?uuidChangeEventActiveResult))) AS ?changeEventActiveResult)
+}
+;
+## Mergers involving three original organisations
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?changeEvent a org:ChangeEvent;
+                 mu:uuid ?uuidChangeEvent;
+                 org:resultingOrganization ?resultingOrg;
+                 dct:date "2025-01-01"^^xsd:dateTime;
+                 dct:description ?description;
+                 org:originalOrganization ?firstOrgToMerge;
+                 org:originalOrganization ?secondOrgToMerge;
+                 org:originalOrganization ?thirdOrgToMerge;
+                 lblodOrg:veranderingsgebeurtenisResultaat ?changeEventFirstNotActiveResult;
+                 lblodOrg:veranderingsgebeurtenisResultaat ?changeEventSecondNotActiveResult;
+                 lblodOrg:veranderingsgebeurtenisResultaat ?changeEventThirdNotActiveResult;
+                 lblodOrg:veranderingsgebeurtenisResultaat ?changeEventActiveResult;
+                 ch:typeWijziging <http://lblod.data.gift/concepts/fa80032794c841ecac73ff874f856db1>. # Merger
+
+  ?changeEventFirstNotActiveResult a lblodOrg:VeranderingsgebeurtenisResultaat;
+                                   mu:uuid ?uuidChangeEventFirstNotActiveResult;
+                                   ext:resultingOrganization ?firstOrgToMerge;
+                                   lblodOrg:resulterendeStatus <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311>. # not active
+
+  ?changeEventSecondNotActiveResult a lblodOrg:VeranderingsgebeurtenisResultaat;
+                                    mu:uuid ?uuidChangeEventSecondNotActiveResult;
+                                    ext:resultingOrganization ?secondOrgToMerge;
+                                    lblodOrg:resulterendeStatus <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311>. # not active
+
+  ?changeEventThirdNotActiveResult a lblodOrg:VeranderingsgebeurtenisResultaat;
+                                   mu:uuid ?uuidChangeEventThirdNotActiveResult;
+                                   ext:resultingOrganization ?thirdOrgToMerge;
+                                   lblodOrg:resulterendeStatus <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311>. # not active
+
+  ?changeEventActiveResult a lblodOrg:VeranderingsgebeurtenisResultaat;
+                           mu:uuid ?uuidChangeEventActiveResult;
+                           ext:resultingOrganization ?resultingOrg;
+                           lblodOrg:resulterendeStatus <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>. # active
+  }
+} WHERE {
+  VALUES (?firstOrgToMerge ?secondOrgToMerge ?thirdOrgToMerge ?resultingOrg) {
+    # Beveren (municipality) + Kruibeke (municipality) + Zwijndrecht (municipality) = Beveren-Kruibeke-Zwijndrecht (municipality)
+    (<http://data.lblod.info/id/bestuurseenheden/4f0eb4436c88cf831c35f84e7c34ce32f9ee4e99c5139aff62990e5e531aa1e7> <http://data.lblod.info/id/bestuurseenheden/6af55cecaea3621f53bb32417a36ed6e3d41b2aa5b9f6d62ab3d80cc8ec11539> <http://data.lblod.info/id/bestuurseenheden/c362abc58ac4579ff417824ce620962ac57bc344b34fe8f51d21b35ef54da36d> <http://data.lblod.info/id/bestuurseenheden/19483103-318e-435a-aa37-45e485406ee9>)
+    # Beveren (OCMW) + Kruibeke (OCMW) + Zwijndrecht (OCMW) = Beveren-Kruibeke-Zwijndrecht (OCMW)
+    (<http://data.lblod.info/id/bestuurseenheden/72bc672ceb6894d8dd31dc2dff2faad2fd93f4b9f5347d556d092516eaa30aa3> <http://data.lblod.info/id/bestuurseenheden/d3c76fd84794dad5e12c9eed6d6332dc5e5c99daf0e4ddd7ceebf13d5d6c0ccd> <http://data.lblod.info/id/bestuurseenheden/bbc23313f4c8585a0c51f15f920d77123356535cd1cad9af38f5707892c7088d> <http://data.lblod.info/id/bestuurseenheden/fd41f573-7d9a-4d9f-b7d0-d5b6114d1622>)
+
+    # Galmaarden (municipality) + Gooik (municipality) + Herne (municipality) = Pajottegem (municipality)
+    (<http://data.lblod.info/id/bestuurseenheden/00eb231f51bd6b4f5dcc6536b2d09a174ea8583f5bf28b10bc4fc769a07e511d> <http://data.lblod.info/id/bestuurseenheden/c69192b973a3ca11531b9657b3ee20aa6688fa33ea1ef1392310fec751980ab2> <http://data.lblod.info/id/bestuurseenheden/3eb8c9fae32d02359dcd7b22e2a74e67a5b48388df31ad819c27c688fedd10b0> <http://data.lblod.info/id/bestuurseenheden/add1e4eb-9ec7-4ea6-af82-335aa76b7d48>)
+    # Galmaarden (OCMW) + Gooik (OCMW) + Herne (OCMW) = Pajottegem (OCMW)
+  (<http://data.lblod.info/id/bestuurseenheden/ba8a253d98ea7d2ab1afc43e5e2cd145a12ccd86b68e71d023e3c13a83d7498f> <http://data.lblod.info/id/bestuurseenheden/76c45d60f05bf8afc8c71859342b69cac6a57ee2b320b900a60afd6ba9b8eb9d> <http://data.lblod.info/id/bestuurseenheden/5d21ccef2f5aa3ccbf3a74c6f25ebe9f0b1ef5a97b87f3d79c86ae9d6d857df8> <http://data.lblod.info/id/bestuurseenheden/650378e7-1bee-4737-91ff-5b20ac4623cf>)
+  }
+
+  VALUES ?g {
+    <http://mu.semte.ch/graphs/administrative-unit>
+    <http://mu.semte.ch/graphs/shared>
+  }
+
+  GRAPH ?g {
+    ?firstOrgToMerge skos:prefLabel ?labelFirstOrg.
+    ?secondOrgToMerge skos:prefLabel ?labelSecondOrg.
+    ?thirdOrgToMerge skos:prefLabel ?labelThirdOrg.
+    ?resultingOrg skos:prefLabel ?labelResultingOrg;
+                  org:classification ?classification.
+  }
+
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?classification skos:prefLabel ?classificationResultingOrg.
+  }
+
+  BIND(CONCAT("Fusie tussen ", ?labelFirstOrg, ", ", ?labelSecondOrg," en ", ?labelThirdOrg, " resulteert in ", ?classificationResultingOrg, " ", ?labelResultingOrg) as ?description)
+
+  BIND(SHA256(CONCAT(STR(?firstOrgToMerge), STR(?secondOrgToMerge), STR(?thirdOrgToMerge), STR(?resultingOrg),"fusieChangeEvent")) AS ?uuidChangeEvent)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/veranderingsgebeurtenissen/", STR(?uuidChangeEvent))) AS ?changeEvent)
+
+  BIND(SHA256(CONCAT(STR(?firstOrgToMerge),"fusieChangeEventFirstNotActiveResult")) AS ?uuidChangeEventFirstNotActiveResult)
+  BIND(IRI(CONCAT("http://lblod.data.info/id/veranderingsgebeurtenis-resultaten/", STR(?uuidChangeEventFirstNotActiveResult))) AS ?changeEventFirstNotActiveResult)
+
+  BIND(SHA256(CONCAT(STR(?secondOrgToMerge),"fusieChangeEventSecondNotActiveResult")) AS ?uuidChangeEventSecondNotActiveResult)
+  BIND(IRI(CONCAT("http://lblod.data.info/id/veranderingsgebeurtenis-resultaten/", STR(?uuidChangeEventSecondNotActiveResult))) AS ?changeEventSecondNotActiveResult)
+
+  BIND(SHA256(CONCAT(STR(?thirdOrgToMerge),"fusieChangeEventThirdNotActiveResult")) AS ?uuidChangeEventThirdNotActiveResult) .
+  BIND(IRI(CONCAT("http://lblod.data.info/id/veranderingsgebeurtenis-resultaten/", STR(?uuidChangeEventThirdNotActiveResult))) AS ?changeEventThirdNotActiveResult)
+
+  BIND(SHA256(CONCAT(STR(?resultingOrg),"fusieChangeEventActiveResult")) AS ?uuidChangeEventActiveResult)
+  BIND(IRI(CONCAT("http://lblod.data.info/id/veranderingsgebeurtenis-resultaten/", STR(?uuidChangeEventActiveResult))) AS ?changeEventActiveResult)
+}

--- a/config/migrations/2024/20241203112740-mergers-2025-add-merge-change-events/20241203141834-mergers-2025-add-merge-change-events-results-are-existing-organisations.sparql
+++ b/config/migrations/2024/20241203112740-mergers-2025-add-merge-change-events/20241203141834-mergers-2025-add-merge-change-events-results-are-existing-organisations.sparql
@@ -1,0 +1,118 @@
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX ch: <http://data.lblod.info/vocabularies/contacthub/>
+PREFIX lblodOrg: <http://lblod.data.gift/vocabularies/organisatie/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+
+# This migration adds merger change events for municipalities and OCMWs for
+# which the resulting active organisation is one of the original organisations.
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?changeEvent a org:ChangeEvent;
+                 mu:uuid ?uuidChangeEvent;
+                 org:resultingOrganization ?resultingOrg;
+                 dct:date "2025-01-01"^^xsd:dateTime;
+                 dct:description ?description;
+                 org:originalOrganization ?resultingOrg;
+                 org:originalOrganization ?notActiveOrganisation;
+                 lblodOrg:veranderingsgebeurtenisResultaat ?changeEventNotActiveResult;
+                 lblodOrg:veranderingsgebeurtenisResultaat ?changeEventActiveResult;
+                 ch:typeWijziging <http://lblod.data.gift/concepts/fa80032794c841ecac73ff874f856db1>. # Merger
+
+    ?changeEventNotActiveResult a lblodOrg:VeranderingsgebeurtenisResultaat;
+                                mu:uuid ?uuidChangeEventNotActiveResult;
+                                ext:resultingOrganization ?notActiveOrganisation;
+                                lblodOrg:resulterendeStatus <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311>. # not active
+
+    ?changeEventActiveResult a lblodOrg:VeranderingsgebeurtenisResultaat;
+                             mu:uuid ?uuidChangeEventActiveResult;
+                             ext:resultingOrganization ?resultingOrg;
+                             lblodOrg:resulterendeStatus <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>. # Active
+  }
+} WHERE {
+  VALUES (?notActiveOrganisation ?resultingOrg) {
+    # Hoeselt (municipality) + Bilzen (municipality) = Bilzen (municipality)
+    (<http://data.lblod.info/id/bestuurseenheden/a3bd0845853278f478f90b14436d3efa99e73249a84d462f0ddc2e5b6e37a156>
+     <http://data.lblod.info/id/bestuurseenheden/99da98a7a0087d3429b084ebfc4eb5d488c593790d4d5af7253982a2e21a6a5f>)
+    # Hoeselt (OCMW) + Bilzen (OCMW) = Bilzen (OCMW)
+    (<http://data.lblod.info/id/bestuurseenheden/785e8d5516378c7382ad0e7e356d2301496d810c6cd46d72ccebb455d3ac525e>
+     <http://data.lblod.info/id/bestuurseenheden/9ae900a5447b7d727ca6496910220d4389aba7f1869923f1bbf9729bdeca28e2>)
+
+    # Borgloon (municipality) + Tongeren (municipality) = Tongeren (municipality)
+    (<http://data.lblod.info/id/bestuurseenheden/05441122597e0b20b61a8968ea1247c07f9014aad1f1f0709d0b1234e3dfbc2f>
+     <http://data.lblod.info/id/bestuurseenheden/104f32d7fb8d4b8b61b71717301656f136fe046eabaf126fb3325896b5c2d625>)
+    # Borgloon (OCMW) + Tongeren (OCMW) = Tongeren (OCMW)
+    (<http://data.lblod.info/id/bestuurseenheden/3834647b5e95ea20f5ffe5a12a09fbd3d7fdf0d187fab385cb7b841422176ad6>
+     <http://data.lblod.info/id/bestuurseenheden/ab684633d605d93dbbe6b9ea40667e2bcf03a0856cafe1825e95b7829ed502a3>)
+
+    # Tessenderlo (municipality) + Ham (municipality) = Ham (municipality)
+    (<http://data.lblod.info/id/bestuurseenheden/af8969752f6b28c66b6bc402d7987fa38774901ac72b95c5cb7976570487c3c9>
+     <http://data.lblod.info/id/bestuurseenheden/05099fa1f6524b8b994d86f61549455d2c00b2a956d5308683ac2d1f810fc729>)
+    # Tessenderlo (OCMW) + Ham (OCMW) = Ham (OCMW)
+    (<http://data.lblod.info/id/bestuurseenheden/fb1be873c4b31e391613dfae8e68edd694b1fdf126eeecb502b1e5cad6f2f682>
+     <http://data.lblod.info/id/bestuurseenheden/42a43591e0db1dca9432f480f0f49f9bd4056c2b131e2fc997497130f5e099d0>)
+
+    # Kortessem (municipality) + Hasselt (municipality) = Hasselt (municipality)
+    (<http://data.lblod.info/id/bestuurseenheden/f6b131de5e40a0dfd4fc93fedf3b95c9bf156ece718b87fe00469dea2564b3fb>
+     <http://data.lblod.info/id/bestuurseenheden/9db1b46874a57fe63c08fb5f16b117e6f61fdd98e7f64f745d0fceb9d3731169>)
+    # Kortessem (OCMW) + Hasselt (OCMW) = Hasselt (OCMW)
+    (<http://data.lblod.info/id/bestuurseenheden/3e077115eeb70b649d44e2ebbb218f2cfcac5d84e130c88584f0ec23f7cebbf9>
+     <http://data.lblod.info/id/bestuurseenheden/026509cf3b4eeb7ad88fe57a270060574f60abd1c3524837d36700e40809d210>)
+
+    # Wachtebeke (municipality) + Lochristi (municipality) = Lochristi (municipality)
+    (<http://data.lblod.info/id/bestuurseenheden/1313d4a58f9ecf52cc7e274e3549a759b35e731973cc9f5e07562e5650f594dd>
+     <http://data.lblod.info/id/bestuurseenheden/2ac1bb2a7d7bbd98e2e7a24be2c67e42171788a71c2436a33060626593bb2f78>)
+    # Wachtebeke (OCMW) + Lochristi (OCMW) = Lochristi (OCMW)
+    (<http://data.lblod.info/id/bestuurseenheden/7c6b38fa6fc65879cb674a654617de171adfcfacba086fb918da3749dbaa43b5>
+     <http://data.lblod.info/id/bestuurseenheden/ee5d6d9da5fcf9e7bbd5c60931e37451f6bc816233c9c269565d79c2b2a37af5>)
+
+    # Moerbeke (municipality) + Lokeren (municipality) = Lokeren (municipality)
+    (<http://data.lblod.info/id/bestuurseenheden/c5dbb08e35e2d090a05d119fef4cc161b5ee1f322698cb8ea3c8c6643a521cf2>
+     <http://data.lblod.info/id/bestuurseenheden/cb2a6e0a490ee881ddd0d9ded7f2b3d1dc2df7e57a19d014caac054bfa355f5a>)
+    # Moerbeke (OCMW) + Lokeren (OCMW) = Lokeren (OCMW)
+    (<http://data.lblod.info/id/bestuurseenheden/f2a9a2392d5e4c0f992a84a0871d048a7b91b14681e9980a63aa6ba4b1f7eb8c>
+     <http://data.lblod.info/id/bestuurseenheden/323a24f2fe81ee0b6586ec78be36760e478092e07386b2785992ea8b61941833>)
+
+    # Meulebeke (municipality) + Tielt (municipality) = Tielt (municipality)
+    (<http://data.lblod.info/id/bestuurseenheden/5a4b2b4f1de1f3b91b0348a7eb6d6aa0ef9420b8ec31374970c9ffe933a79515>
+     <http://data.lblod.info/id/bestuurseenheden/b36da606fba6dd4dc99ae1ef5f4a52bba3268d33f4bc2cd1e65b87f01f35101a>)
+    # Meulebeke (OCMW) + Tielt (OCMW) = Tielt (OCMW)
+    (<http://data.lblod.info/id/bestuurseenheden/3f57a17fbcdfc13def910c54948bec11d71d3f75946b0336fffc0587bf18d783>
+     <http://data.lblod.info/id/bestuurseenheden/f6ef0202c1dca780c66e269f2d21aa39a690f4c57ad05ece63f178b629bbb98e>)
+
+    # Ruiselede (municipality) + Wingene (municipality) = Wingene (municipality)
+    (<http://data.lblod.info/id/bestuurseenheden/2564e21e3650f91625189ccb7eb055e47754a0633c54c7582a899171fef60c52>
+     <http://data.lblod.info/id/bestuurseenheden/99ed6eee81a7aca47517cbffb46eaba38f3987eeb4ad32c020898644769eb615>)
+    # Ruiselede (OCMW) + Wingene (OCMW) = Wingene (OCMW)
+    (<http://data.lblod.info/id/bestuurseenheden/60daf27c2cf12dd123447aa300dd7320890391dbd8dd6b4dd7ec02258f8281b3>
+     <http://data.lblod.info/id/bestuurseenheden/518c31a6e89f514c075e0927bce9fb2c91a552b6d65208c04a687d4bcb81148c>)
+  }
+
+  VALUES ?g {
+    <http://mu.semte.ch/graphs/administrative-unit>
+    <http://mu.semte.ch/graphs/shared>
+  }
+
+  GRAPH ?g {
+    ?notActiveOrganisation skos:prefLabel ?labelNotActiveOrganisation.
+    ?resultingOrg skos:prefLabel ?labelResultingOrg;
+                  org:classification ?classification.
+  }
+
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?classification skos:prefLabel ?classificationResultingOrg.
+  }
+
+  BIND(CONCAT("Fusie tussen ", ?labelResultingOrg," en ", ?labelNotActiveOrganisation, " resulteert in ", ?classificationResultingOrg, " ", ?labelResultingOrg) as ?description)
+
+  BIND(SHA256(CONCAT(STR(?notActiveOrganisation), STR(?resultingOrg),"fusieChangeEvent")) AS ?uuidChangeEvent)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/veranderingsgebeurtenissen/", STR(?uuidChangeEvent))) AS ?changeEvent)
+
+  BIND(SHA256(CONCAT(STR(?notActiveOrganisation),"fusieChangeEventNotActiveResult")) AS ?uuidChangeEventNotActiveResult)
+  BIND(IRI(CONCAT("http://lblod.data.info/id/veranderingsgebeurtenis-resultaten/", STR(?uuidChangeEventNotActiveResult))) AS ?changeEventNotActiveResult)
+
+
+  BIND(SHA256(CONCAT(STR(?notActiveOrganisation), STR(?resultingOrg),"fusieChangeEventActiveResult")) AS ?uuidChangeEventActiveResult)
+  BIND(IRI(CONCAT("http://lblod.data.info/id/veranderingsgebeurtenis-resultaten/", STR(?uuidChangeEventActiveResult))) AS ?changeEventActiveResult)
+}

--- a/config/migrations/2024/20241203112740-mergers-2025-add-merge-change-events/20241203164934-mergers-2025-antwerp-and-borsbeek.sparql
+++ b/config/migrations/2024/20241203112740-mergers-2025-add-merge-change-events/20241203164934-mergers-2025-antwerp-and-borsbeek.sparql
@@ -1,0 +1,137 @@
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX ch: <http://data.lblod.info/vocabularies/contacthub/>
+PREFIX lblodOrg: <http://lblod.data.gift/vocabularies/organisatie/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+
+# Add merger change event for Borsbeek (municipality) + Antwerpen (municipality) = Borsbeek (district) + Antwerpen (municipality)
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?changeEvent a org:ChangeEvent;
+                 mu:uuid ?uuidChangeEvent;
+                 ch:typeWijziging <http://lblod.data.gift/concepts/fa80032794c841ecac73ff874f856db1>; # Merger
+    dct:date "2025-01-01"^^xsd:dateTime;
+    dct:description ?description;
+    org:originalOrganization ?borsbeekMunicipality;
+    org:originalOrganization ?antwerpMunicipality;
+    org:resultingOrganization ?borsbeekDistrict;
+    org:resultingOrganization ?antwerpMunicipality;
+    lblodOrg:veranderingsgebeurtenisResultaat ?borsbeekMunicipalityResult;
+    lblodOrg:veranderingsgebeurtenisResultaat ?borsbeekDistrictResult;
+    lblodOrg:veranderingsgebeurtenisResultaat ?antwerpMunicipalityResult.
+
+    ?borsbeekMunicipalityResult a lblodOrg:VeranderingsgebeurtenisResultaat;
+                                mu:uuid ?uuidBorsbeekMunicipalityResult;
+                                lblodOrg:resulterendeStatus <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311>; # not active
+    ext:resultingOrganization ?borsbeekMunicipality.
+
+    ?borsbeekDistrictResult a lblodOrg:VeranderingsgebeurtenisResultaat;
+                            mu:uuid ?uuidBorsbeekDistrictResult;
+                            lblodOrg:resulterendeStatus <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>; # Active
+    ext:resultingOrganization ?borsbeekDistrict.
+
+    ?antwerpMunicipalityResult a lblodOrg:VeranderingsgebeurtenisResultaat;
+                               mu:uuid ?uuidAntwerpMunicipalityResult;
+                               lblodOrg:resulterendeStatus <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>; # Active
+    ext:resultingOrganization ?antwerpMunicipality.
+  }
+} WHERE {
+  VALUES (?borsbeekMunicipality ?antwerpMunicipality ?borsbeekDistrict) {
+    (<http://data.lblod.info/id/bestuurseenheden/e41ffa04f94bb450a79793020e70d55b5fee5033a5280277998608a9d0913117> # Borsbeek (municipality)
+     <http://data.lblod.info/id/bestuurseenheden/670db1d66c0de3b931962e1044033ccfa9d6e3023aa9828a5f252c3bc69bd32c> # Antwerpen (municipality)
+     <http://data.lblod.info/id/bestuurseenheden/4b44e6f1-113b-4692-b149-44a889b215f2>) # Borsbeek (district)
+  }
+
+  VALUES ?g {
+    <http://mu.semte.ch/graphs/administrative-unit>
+    <http://mu.semte.ch/graphs/shared>
+  }
+
+  GRAPH ?g {
+    ?antwerpMunicipality skos:prefLabel ?antwerpMunicipalityLabel;
+                         org:classification ?antwerpClassification.
+
+    ?borsbeekMunicipality skos:prefLabel ?borsbeekMunicipalityLabel.
+
+
+  }
+
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?borsbeekDistrict skos:prefLabel ?borsbeekDistrictLabel;
+                      org:classification ?borsbeekDistrictClassification.
+  }
+
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?antwerpClassification skos:prefLabel ?antwerpClassificationLabel.
+    ?borsbeekDistrictClassification skos:prefLabel ?borsbeekDistrictClassificationLabel.
+  }
+
+  BIND(CONCAT("Fusie tussen ", ?borsbeekMunicipalityLabel," en ", ?antwerpMunicipalityLabel, " resulteert in ", ?borsbeekDistrictClassificationLabel, " ", ?borsbeekDistrictLabel, " en ", ?antwerpClassificationLabel, " ", ?antwerpMunicipalityLabel) as ?description)
+
+  BIND(SHA256(CONCAT(STR(?borsbeekMunicipality), STR(?antwerpMunicipality), STR(?borsbeekDistrict),"fusieChangeEvent")) AS ?uuidChangeEvent)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/veranderingsgebeurtenissen/", STR(?uuidChangeEvent))) AS ?changeEvent)
+
+  BIND(SHA256(CONCAT(STR(?borsbeekMunicipality),"mergerBorsbeekMunicipalityChangeEventResult")) AS ?uuidBorsbeekMunicipalityResult)
+  BIND(IRI(CONCAT("http://lblod.data.info/id/veranderingsgebeurtenis-resultaten/", STR(?uuidBorsbeekMunicipalityResult))) AS ?borsbeekMunicipalityResult)
+
+  BIND(SHA256(CONCAT(STR(?borsbeekDistrict),"mergerBorsbeekDistrictChangeEventResult")) AS ?uuidBorsbeekDistrictResult)
+  BIND(IRI(CONCAT("http://lblod.data.info/id/veranderingsgebeurtenis-resultaten/", STR(?uuidBorsbeekDistrictResult))) AS ?borsbeekDistrictResult)
+
+  BIND(SHA256(CONCAT(STR(?antwerpMunicipality),"mergerAntwerpMunicipalityChangeEventResult")) AS ?uuidAntwerpMunicipalityResult)
+  BIND(IRI(CONCAT("http://lblod.data.info/id/veranderingsgebeurtenis-resultaten/", STR(?uuidAntwerpMunicipalityResult))) AS ?antwerpMunicipalityResult)
+}
+;
+# Add merger change event for Borsbeek (OCMW) + Antwerp (OCMW) = Antwerp (OCMW)
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?changeEvent a org:ChangeEvent;
+                 mu:uuid ?uuidChangeEvent;
+                 org:resultingOrganization ?resultingOrg;
+                 dct:date "2025-01-01"^^xsd:dateTime;
+                 dct:description ?description;
+                 org:originalOrganization ?resultingOrg;
+                 org:originalOrganization ?notActiveOrganisation;
+                 lblodOrg:veranderingsgebeurtenisResultaat ?changeEventNotActiveResult;
+                 lblodOrg:veranderingsgebeurtenisResultaat ?changeEventActiveResult;
+                 ch:typeWijziging <http://lblod.data.gift/concepts/fa80032794c841ecac73ff874f856db1>. # Merger
+
+    ?changeEventNotActiveResult a lblodOrg:VeranderingsgebeurtenisResultaat;
+                                mu:uuid ?uuidChangeEventNotActiveResult;
+                                ext:resultingOrganization ?notActiveOrganisation;
+                                lblodOrg:resulterendeStatus <http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311>. # not active
+
+    ?changeEventActiveResult a lblodOrg:VeranderingsgebeurtenisResultaat;
+                             mu:uuid ?uuidChangeEventActiveResult;
+                             ext:resultingOrganization ?resultingOrg;
+                             lblodOrg:resulterendeStatus <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6>. # Active
+  }
+} WHERE {
+  VALUES (?notActiveOrganisation ?resultingOrg) {
+    # Borsbeek (OCMW) + Antwerp (OCMW) = Antwerp (OCMW)
+    (<http://data.lblod.info/id/bestuurseenheden/7125fcbfb7a08f8c01efbed115cea602db249c04afe9b5a2cc298cc7949cd040>
+     <http://data.lblod.info/id/bestuurseenheden/83c7a12a4a8ac8dd82895715095a866dc4794e60de61b967419bdfc1e207ad96>)
+  }
+
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?notActiveOrganisation skos:prefLabel ?labelNotActiveOrganisation.
+    ?resultingOrg skos:prefLabel ?labelResultingOrg;
+                  org:classification ?classification.
+  }
+
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?classification skos:prefLabel ?classificationResultingOrg.
+  }
+
+  BIND(CONCAT("Fusie tussen ", ?labelResultingOrg," en ", ?labelNotActiveOrganisation, " resulteert in ", ?classificationResultingOrg, " ", ?labelResultingOrg) as ?description)
+
+  BIND(SHA256(CONCAT(STR(?notActiveOrganisation), STR(?resultingOrg),"fusieChangeEvent")) AS ?uuidChangeEvent)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/veranderingsgebeurtenissen/", STR(?uuidChangeEvent))) AS ?changeEvent)
+
+  BIND(SHA256(CONCAT(STR(?notActiveOrganisation),"fusieChangeEventNotActiveResult")) AS ?uuidChangeEventNotActiveResult)
+  BIND(IRI(CONCAT("http://lblod.data.info/id/veranderingsgebeurtenis-resultaten/", STR(?uuidChangeEventNotActiveResult))) AS ?changeEventNotActiveResult)
+
+
+  BIND(SHA256(CONCAT(STR(?notActiveOrganisation), STR(?resultingOrg),"fusieChangeEventActiveResult")) AS ?uuidChangeEventActiveResult)
+  BIND(IRI(CONCAT("http://lblod.data.info/id/veranderingsgebeurtenis-resultaten/", STR(?uuidChangeEventActiveResult))) AS ?changeEventActiveResult)
+}


### PR DESCRIPTION
These migrations insert the merger change events that are needed for the 2025 municipality mergers and update the status of the appropriate organisations. These mergers involve municipalities, OCMWs, and 1 new district.

## Detailed overview
### [Mergers resulting in different, new organisations](https://github.com/lblod/app-organization-portal/blob/707bb7bd9a103aa4625c05c9825eb56894e83853/config/migrations/2024/20241203112740-mergers-2025-add-merge-change-events/20241203112740-mergers-2025-add-merge-change-events-results-are-new-organisations.sparql)
This migration involves mergers where the resulting organisation is different from the original organisations. This concerns mergers involving the organisation added in #442. This situation is the same as for the previous municipality mergers (see #365).

### [Mergers resulting in already existing organisations](https://github.com/lblod/app-organization-portal/blob/707bb7bd9a103aa4625c05c9825eb56894e83853/config/migrations/2024/20241203112740-mergers-2025-add-merge-change-events/20241203141834-mergers-2025-add-merge-change-events-results-are-existing-organisations.sparql)
This migration involves mergers where the resulting organisation is one of the original organisations. In this case there is only one change event result for organisation that is both an original and resulting organisation.

### [Merger of Antwerp and Borsbeek](https://github.com/lblod/app-organization-portal/blob/707bb7bd9a103aa4625c05c9825eb56894e83853/config/migrations/2024/20241203112740-mergers-2025-add-merge-change-events/20241203164934-mergers-2025-antwerp-and-borsbeek.sparql)
This migration handles the special case of the merger of Borsbeek and Antwerp. For the municipalities this merger change event has two resulting organisations:
- the already existing municipality of Antwerp; and
- the new **district** Borsbeek (added in #445)

For the OCMWs, Borsbeek's OCMW merges into the one for Antwerp, this is the same scenario as other OCMWs.

### [Update status for organisations](https://github.com/lblod/app-organization-portal/blob/707bb7bd9a103aa4625c05c9825eb56894e83853/config/migrations-triggering-indexing/2024/20241203144827-mergers-2025-update-organisation-status.sparql)
This migration updates the status of the appropriate organisations. More specifically this means
- For the resulting organisation of the first migration **and** district Borsbeek: change status from "In oprichting" to "Active"
- For original organisations that are not also a resulting organisation in the migrations above: change status from "Active" to "Not active"
- The remaining organisations are (also) resulting organisations and keep their "Active" status.

## How to test
1. Run the 4 migrations by (re)starting the `migrations` and `migrations-triggering-indexing` services. For the latter it may take a few minutes before the indexing is done, afterwards the organisation's status displayed in the organisations overview table should update.
2. Check whether the necessary organisations all have an merger change event and whether their status is changed correctly:
 - Each change event should have 01/01/2025 as date.
 - For the first 4 rows in the table below, the original organisations should all be not active and the resulting organisation should be active.
 - For the 2 rows concerning Borsbeek, the resulting organisations should all be active. Borsbeek municipality and OCMW should be not active.
 - For the table's remaining 8 rows, the resulting organisation should remain active and the other original organisation should be not active.

| Original organisations                            | Resulting organisation                            |
|---------------------------------------------------|---------------------------------------------------|
| Beveren, Kruibeke, Zwijndrecht                    | Beveren-Kruibeke-Zwijndrecht                      |
| De Pinte, Nazareth                                | Nazareth-De Pinte                                 |
| Galmaarden, Gooik, Herne                          | Pajottegem                                        |
| Melle, Merelbeke                                  | Merelbeke-Melle                                   |
|                                                   |                                                   |
| Borsbeek (municipality), Antwerpen (municipality) | Borsbeek (**district**), Antwerpen (municipality) |
| Borsbeek (OCMW), Antwerpen (OCMW)                 | Antwerpen (OCMW)                                  |
|                                                   |                                                   |
| Bilzen, Hoeselt                                   | Bilzen                                            |
| Borgloon, Tongeren                                | Tongeren                                          |
| Ham, Tessenderlo                                  | Ham                                               |
| Hasselt, Kortessem                                | Hasselt                                           |
| Lochristi, Wachtebeke                             | Lochristi                                         |
| Lokeren, Moerbeke                                 | Lokeren                                           |
| Meulebeke, Tielt                                  | Tielt                                             |
| Ruiselede, Wingene                                | Wingene                                           |

## Related PR
- Frontend [PR](https://github.com/lblod/frontend-organization-portal/pull/661) to show multiple resulting organisations for merger change events. (Needed for the Borsbeek case)

## Related ticket
- OP-3412