### PR TITLE
Fix skos:notation ADMS:identifier language tags

### DIFF
--- a/config/migrations/2024/20241211101235-align-skos-notation-identifier.sparql
+++ b/config/migrations/2024/20241211101235-align-skos-notation-identifier.sparql
@@ -1,0 +1,20 @@
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s <http://www.w3.org/2004/02/skos/core#notation> ?notation.
+  }
+}
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s <http://www.w3.org/2004/02/skos/core#notation> ?plainNotation.
+  }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+   ?s a <http://www.w3.org/ns/adms#Identifier>;
+     <http://www.w3.org/2004/02/skos/core#notation> ?notation.
+   }
+
+   BIND(LANG(?notation) as ?lang)
+   BIND(STR(?notation) as ?plainNotation)
+   FILTER(?lang != "")
+}


### PR DESCRIPTION
It seems there were language tagged and non-languaged versions used for the skos:notation from ADMS:identifier.
This migrations alings it, we don't want typed strings here. See also DL-6343