### PR TITLE
Remove empty URIs

### DIFF
--- a/config/migrations/2024/20241212201809-remove-empty-uris-received-by-kalliope.sparql
+++ b/config/migrations/2024/20241212201809-remove-empty-uris-received-by-kalliope.sparql
@@ -1,0 +1,22 @@
+DELETE {
+  GRAPH ?g {
+    ?org ?orgP ?orgO .
+  }
+}
+WHERE {
+  VALUES ?org {
+    <http://data.lblod.info/id/bestuurseenheden/6584318A90264E79DCA99E67>
+    <http://data.lblod.info/id/bestuurseenheden/658432DF90264E79DCA99E69>
+    <http://data.lblod.info/id/bestuurseenheden/6584351590264E79DCA99E6B>
+    <http://data.lblod.info/id/bestuurseenheden/6584361290264E79DCA99E70>
+    <http://data.lblod.info/id/bestuurseenheden/6584395890264E79DCA99E73>
+    <http://data.lblod.info/id/bestuurseenheden/6584396790264E79DCA99E76>
+    <http://data.lblod.info/id/bestuurseenheden/65843A8090264E79DCA99E79>
+    <http://data.lblod.info/id/bestuurseenheden/65843B0090264E79DCA99E7B>
+    <http://data.lblod.info/id/bestuurseenheden/65CD2F939E3C83CF14AEEC59>
+  }
+
+  GRAPH ?g {
+    ?org ?orgP ?orgO .
+  }
+}

--- a/config/migrations/2024/20241212201809-remove-empty-uris-received-by-kalliope.sparql
+++ b/config/migrations/2024/20241212201809-remove-empty-uris-received-by-kalliope.sparql
@@ -14,6 +14,7 @@ WHERE {
     <http://data.lblod.info/id/bestuurseenheden/65843A8090264E79DCA99E79>
     <http://data.lblod.info/id/bestuurseenheden/65843B0090264E79DCA99E7B>
     <http://data.lblod.info/id/bestuurseenheden/65CD2F939E3C83CF14AEEC59>
+    <http://data.lblod.info/id/bestuurseenheden/3183ade3-7ee8-409c-8394-296b1fbfe478>
   }
 
   GRAPH ?g {


### PR DESCRIPTION
## Ticket ID

OP-3426

## Description

The Kalliope team notified us of empty URIs they received; these URIs only have `http://www.w3.org/1999/02/22-rdf-syntax-ns#type` and `http://mu.semte.ch/vocabularies/core/uuid` properties attached to them. So, they can be safely deleted.

## How to test

Run the migration and make sure these URIs no longer have any data.