### PR TITLE
chore: Update addresses for 2025 municipality mergers

### DIFF
--- a/config/migrations-triggering-indexing/2024/20241217082404-mergers-2025--update-addresses/20241217082404-change-zwijndrecht-to-province-east-flanders.sparql
+++ b/config/migrations-triggering-indexing/2024/20241217082404-mergers-2025--update-addresses/20241217082404-change-zwijndrecht-to-province-east-flanders.sparql
@@ -1,0 +1,27 @@
+PREFIX locn: <http://www.w3.org/ns/locn#>
+PREFIX adres: <https://data.vlaanderen.be/ns/adres#>
+PREFIX organisatie: <https://data.vlaanderen.be/ns/organisatie#>
+PREFIX org: <http://www.w3.org/ns/org#>
+
+DELETE {
+  GRAPH ?g {
+    ?address locn:adminUnitL2 "Antwerpen".
+  }
+} INSERT {
+  GRAPH ?g {
+    ?address locn:adminUnitL2 "Oost-Vlaanderen".
+  }
+} WHERE {
+  GRAPH ?g {
+    ?address a locn:Address;
+             adres:gemeentenaam "Zwijndrecht";
+             locn:adminUnitL2 "Antwerpen"
+    FILTER (EXISTS { ?site organisatie:bestaatUit ?address. } ||
+            EXISTS { ?site org:siteAddress/locn:address ?address. })
+
+  }
+  VALUES ?g {
+    <http://mu.semte.ch/graphs/worship-service>
+    <http://mu.semte.ch/graphs/administrative-unit>
+  }
+}

--- a/config/migrations-triggering-indexing/2024/20241217082404-mergers-2025--update-addresses/20241217082944-update-address-municipality-to-merged-municipality-name.sparql
+++ b/config/migrations-triggering-indexing/2024/20241217082404-mergers-2025--update-addresses/20241217082944-update-address-municipality-to-merged-municipality-name.sparql
@@ -1,0 +1,51 @@
+PREFIX adres: <https://data.vlaanderen.be/ns/adres#>
+PREFIX locn: <http://www.w3.org/ns/locn#>
+PREFIX organisatie: <https://data.vlaanderen.be/ns/organisatie#>
+PREFIX org: <http://www.w3.org/ns/org#>
+
+DELETE {
+  GRAPH ?g {
+    ?address adres:gemeentenaam ?oldMunicipality.
+  }
+}
+INSERT {
+  GRAPH ?g {
+    ?address adres:gemeentenaam ?newMunicipality.
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?address a locn:Address;
+             adres:gemeentenaam ?oldMunicipality.
+    FILTER (EXISTS { ?site organisatie:bestaatUit ?address. } ||
+            EXISTS { ?site org:siteAddress/locn:address ?address. })
+  }
+  VALUES ?g {
+    <http://mu.semte.ch/graphs/administrative-unit>
+    <http://mu.semte.ch/graphs/worship-service>
+  }
+  VALUES (?oldMunicipality ?newMunicipality) {
+    ("Borsbeek" "Antwerpen")
+    ("Galmaarden" "Pajottegem")
+    ("Gooik" "Pajottegem")
+    ("Herne" "Pajottegem")
+    ("Ruiselede" "Wingene")
+    ("Meulebeke" "Tielt")
+    ("De Pinte" "Nazareth-De Pinte")
+    ("Nazareth" "Nazareth-De Pinte")
+    ("Wachtebeke" "Lochristi")
+    ("Moerbeke" "Lokeren")
+    ("Melle" "Merelbeke-Melle")
+    ("Merelbeke" "Merelbeke-Melle")
+    ("Beveren" "Beveren-Kruibeke-Zwijndrecht")
+    ("Kruibeke" "Beveren-Kruibeke-Zwijndrecht")
+    ("Zwijndrecht" "Beveren-Kruibeke-Zwijndrecht")
+    ("Bilzen" "Bilzen-Hoeselt")
+    ("Hoeselt" "Bilzen-Hoeselt")
+    ("Borgloon" "Tongeren-Borgloon")
+    ("Tongeren" "Tongeren-Borgloon")
+    ("Ham" "Tessenderlo-Ham")
+    ("Tessenderlo" "Tessenderlo-Ham")
+    ("Kortessem" "Hasselt")
+  }
+}

--- a/config/migrations-triggering-indexing/2024/20241217082404-mergers-2025--update-addresses/20241217083314-regenerate-full-address-triple-for-changed-addresses.sparql
+++ b/config/migrations-triggering-indexing/2024/20241217082404-mergers-2025--update-addresses/20241217083314-regenerate-full-address-triple-for-changed-addresses.sparql
@@ -1,0 +1,92 @@
+PREFIX locn: <http://www.w3.org/ns/locn#>
+PREFIX adres: <https://data.vlaanderen.be/ns/adres#>
+PREFIX organisatie: <https://data.vlaanderen.be/ns/organisatie#>
+PREFIX org: <http://www.w3.org/ns/org#>
+
+DELETE {
+  GRAPH ?g {
+    ?address locn:fullAddress ?fullAddress.
+  }
+} INSERT {
+  GRAPH ?g {
+    ?address locn:fullAddress ?newFullAddress.
+  }
+} WHERE {
+  GRAPH ?g {
+    ?address locn:fullAddress ?fullAddress;
+             locn:thoroughfare ?street;
+             adres:Adresvoorstelling.huisnummer ?buildingNo;
+             locn:postCode ?postalCode;
+             adres:gemeentenaam ?municipality;
+             adres:land ?country.
+    FILTER NOT EXISTS { ?address adres:Adresvoorstelling.busnummer ?boxNo. }
+    FILTER (EXISTS { ?site organisatie:bestaatUit ?address. } ||
+            EXISTS { ?site org:siteAddress/locn:address ?address. })
+    FILTER (?municipality IN (
+                              "Antwerpen",
+                              "Pajottegem",
+                              "Wingene",
+                              "Tielt",
+                              "Nazareth-De Pinte",
+                              "Lochristi",
+                              "Lokeren",
+                              "Merelbeke-Melle",
+                              "Beveren-Kruibeke-Zwijndrecht",
+                              "Bilzen-Hoeselt",
+                              "Tongeren-Borgloon",
+                              "Tessenderlo-Ham",
+                              "Hasselt"
+                              ))
+    BIND (CONCAT(?street, " ", ?buildingNo, ", ", ?postalCode, " ", ?municipality, ", ", ?country) AS ?newFullAddress)
+    FILTER (?fullAddress != ?newFullAddress)
+  }
+
+  VALUES ?g {
+    <http://mu.semte.ch/graphs/administrative-unit>
+    <http://mu.semte.ch/graphs/worship-service>
+  }
+}
+;
+DELETE {
+  GRAPH ?g {
+    ?address locn:fullAddress ?fullAddress.
+  }
+} INSERT {
+  GRAPH ?g {
+    ?address locn:fullAddress ?newFullAddress.
+  }
+} WHERE {
+  GRAPH ?g {
+    ?address locn:fullAddress ?fullAddress;
+             locn:thoroughfare ?street;
+             adres:Adresvoorstelling.huisnummer ?buildingNo;
+             adres:Adresvoorstelling.busnummer ?boxNo;
+             locn:postCode ?postalCode;
+             adres:gemeentenaam ?municipality;
+             adres:land ?country.
+    FILTER (EXISTS { ?site organisatie:bestaatUit ?address. } ||
+            EXISTS { ?site org:siteAddress/locn:address ?address. })
+    FILTER (?municipality IN (
+                              "Antwerpen",
+                              "Pajottegem",
+                              "Wingene",
+                              "Tielt",
+                              "Nazareth-De Pinte",
+                              "Lochristi",
+                              "Lokeren",
+                              "Merelbeke-Melle",
+                              "Beveren-Kruibeke-Zwijndrecht",
+                              "Bilzen-Hoeselt",
+                              "Tongeren-Borgloon",
+                              "Tessenderlo-Ham",
+                              "Hasselt"
+                              ))
+    BIND (CONCAT(?street, " ", ?buildingNo, " ", ?boxNo, ", ", ?postalCode, " ", ?municipality, ", ", ?country) AS ?newFullAddress)
+    FILTER (?fullAddress != ?newFullAddress)
+  }
+
+  VALUES ?g {
+    <http://mu.semte.ch/graphs/administrative-unit>
+    <http://mu.semte.ch/graphs/worship-service>
+  }
+}


### PR DESCRIPTION
As part of the 2025 municipality mergers the address for a number of organisations changes. This PR updates the municipality names in the addresses for affected organisations and, for organisations located in Zwijndrecht, also updates the province. Additional updates such as street name, building number, or box number are left up to the users.

The migrations in this PR perform the needed address changes in three steps:

1. Change the addresses located in municipality Zwijndrecht from the province of Antwerp to East Flanders.
2. Change the municipality for all addresses located in a municipality whose names change as part of a merger:

  | Original municipality name | Merged municipality name     |
  |----------------------------|------------------------------|
  | Borsbeek                   | Antwerpen                    |
  | Galmaarden                 | Pajottegem                   |
  | Gooik                      | Pajottegem                   |
  | Herne                      | Pajottegem                   |
  | Ruiselede                  | Wingene                      |
  | Meulebeke                  | Tielt                        |
  | De Pinte                   | Nazareth-De Pinte            |
  | Nazareth                   | Nazareth-De Pinte            |
  | Wachtebeke                 | Lochristi                    |
  | Moerbeke                   | Lokeren                      |
  | Melle                      | Merelbeke-Melle              |
  | Merelbeke                  | Merelbeke-Melle              |
  | Beveren                    | Beveren-Kruibeke-Zwijndrecht |
  | Kruibeke                   | Beveren-Kruibeke-Zwijndrecht |
  | Zwijndrecht                | Beveren-Kruibeke-Zwijndrecht |
  | Bilzen                     | Bilzen-Hoeselt               |
  | Hoeselt                    | Bilzen-Hoeselt               |
  | Borgloon                   | Tongeren-Borgloon            |
  | Tongeren                   | Tongeren-Borgloon            |
  | Ham                        | Tessenderlo-Ham              |
  | Tessenderlo                | Tessenderlo-Ham              |
  | Kortessem                  | Hasselt                      |

4. Regenerate the full address triples (predicate `locn:fullAddress`) for affected addresses.

## Notes
- The order of the migrations is important, and they should be executed in the order specified by the timestamps in their filename.
- Post codes are **not** changed as part of municipality mergers[1]
- This PR only updates addresses related to organisations, addresses related to persons or positions should be updated in other apps. To limit the migrations to organisation addresses the following filter statement is used:

``` sparql
FILTER (EXISTS { ?site organisatie:bestaatUit ?address. } ||
        EXISTS { ?site org:siteAddress/locn:address ?address. })
```

- The search indices are automatically updated but this might take a while depending on the load and available resources of the machine the stack is running on.
- In the existing full address triples two different notations are used to separate the box and building number. OP currently separates them simply by a   space, which is what this migration matches for. But some historical data uses a dash "-" to separate building and box number. Consequently, the last migration might match more address resources than strictly updated for the municipality merges.

## Related tickets
- OP-3410

[1]: https://www.vlaanderen.be/digitaal-vlaanderen/onze-diensten-en-platformen/gebouwen-en-adressenregister/heradressering-bij-vrijwillige-gemeentefusies