### PR TITLE
Import 2025 NIS codes and update werkingsgebieden

### DIFF
--- a/config/migrations/2025/20250107100000-nis-codes-2025/20250107101800-refnis2025.graph
+++ b/config/migrations/2025/20250107100000-nis-codes-2025/20250107101800-refnis2025.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/public

--- a/config/migrations/2025/20250107100000-nis-codes-2025/20250107101800-refnis2025.ttl
+++ b/config/migrations/2025/20250107100000-nis-codes-2025/20250107101800-refnis2025.ttl
@@ -1,0 +1,8767 @@
+@prefix ns1: <https://schema.org/> .
+@prefix ns2: <http://purl.org/dc/terms/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix regorg: <http://www.w3.org/ns/regorg#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://statbel.fgov.be/en/statistics/opendata/licence/> ns2:title "Statbel open data lizenz"@de,
+    "Statbel open data license"@en,
+    "Statbel licence open data"@fr,
+    "Statbel open data licentie"@nl .
+
+<http://vocab.belgif.be/auth/refnis2025/11001> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/11000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/11001>,
+    <http://www.wikidata.org/entity/Q303246>,
+    <https://sws.geonames.org/2803421/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "11001" ;
+  skos:prefLabel "Aartselaar"@de,
+    "Aartselaar"@fr,
+    "Aartselaar"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/11002> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/11000> ;
+  skos:exactMatch <http://www.wikidata.org/entity/Q12892>,
+    <https://sws.geonames.org/2803139/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrowMatch <http://vocab.belgif.be/auth/refnis2019/11002>,
+    <http://vocab.belgif.be/auth/refnis2019/11007> ;
+  skos:notation "11002" ;
+  skos:prefLabel "Antwerpen"@de,
+    "Anvers"@fr,
+    "Antwerpen"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2025-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/11004> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/11000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/11004>,
+    <http://www.wikidata.org/entity/Q723822>,
+    <https://sws.geonames.org/2801744/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "11004" ;
+  skos:prefLabel "Boechout"@de,
+    "Boechout"@fr,
+    "Boechout"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/11005> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/11000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/11005>,
+    <http://www.wikidata.org/entity/Q723972>,
+    <https://sws.geonames.org/2801495/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "11005" ;
+  skos:prefLabel "Boom"@de,
+    "Boom"@fr,
+    "Boom"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/11008> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/11000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/11008>,
+    <http://www.wikidata.org/entity/Q693513>,
+    <https://sws.geonames.org/2801118/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "11008" ;
+  skos:prefLabel "Brasschaat"@de,
+    "Brasschaat"@fr,
+    "Brasschaat"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/11009> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/11000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/11009>,
+    <http://www.wikidata.org/entity/Q724131>,
+    <https://sws.geonames.org/2801107/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "11009" ;
+  skos:prefLabel "Brecht"@de,
+    "Brecht"@fr,
+    "Brecht"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/11013> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/11000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/11013>,
+    <http://www.wikidata.org/entity/Q724238>,
+    <https://sws.geonames.org/2799008/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "11013" ;
+  skos:prefLabel "Edegem"@de,
+    "Edegem"@fr,
+    "Edegem"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/11016> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/11000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/11016>,
+    <http://www.wikidata.org/entity/Q724283>,
+    <https://sws.geonames.org/2798616/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "11016" ;
+  skos:prefLabel "Essen"@de,
+    "Essen"@fr,
+    "Essen"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/11018> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/11000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/11018>,
+    <http://www.wikidata.org/entity/Q724448>,
+    <https://sws.geonames.org/2796086/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "11018" ;
+  skos:prefLabel "Hemiksem"@de,
+    "Hemiksem"@fr,
+    "Hemiksem"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/11021> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/11000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/11021>,
+    <http://www.wikidata.org/entity/Q649982>,
+    <https://sws.geonames.org/2795233/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "11021" ;
+  skos:prefLabel "Hove"@de,
+    "Hove"@fr,
+    "Hove"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/11022> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/11000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/11022>,
+    <http://www.wikidata.org/entity/Q724777>,
+    <https://sws.geonames.org/2794789/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "11022" ;
+  skos:prefLabel "Kalmthout"@de,
+    "Kalmthout"@fr,
+    "Kalmthout"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/11023> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/11000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/11023>,
+    <http://www.wikidata.org/entity/Q724942>,
+    <https://sws.geonames.org/2794733/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "11023" ;
+  skos:prefLabel "Kapellen"@de,
+    "Kapellen"@fr,
+    "Kapellen"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/11024> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/11000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/11024>,
+    <http://www.wikidata.org/entity/Q725074>,
+    <https://sws.geonames.org/2794118/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "11024" ;
+  skos:prefLabel "Kontich"@de,
+    "Kontich"@fr,
+    "Kontich"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/11025> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/11000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/11025>,
+    <http://www.wikidata.org/entity/Q725268>,
+    <https://sws.geonames.org/2792294/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "11025" ;
+  skos:prefLabel "Lint"@de,
+    "Lint"@fr,
+    "Lint"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/11029> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/11000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/11029>,
+    <http://www.wikidata.org/entity/Q688781>,
+    <https://sws.geonames.org/2790677/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "11029" ;
+  skos:prefLabel "Mortsel"@de,
+    "Mortsel"@fr,
+    "Mortsel"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/11030> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/11000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/11030>,
+    <http://www.wikidata.org/entity/Q912054>,
+    <https://sws.geonames.org/2790226/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "11030" ;
+  skos:prefLabel "Niel"@de,
+    "Niel"@fr,
+    "Niel"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/11035> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/11000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/11035>,
+    <http://www.wikidata.org/entity/Q501748>,
+    <https://sws.geonames.org/2788349/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "11035" ;
+  skos:prefLabel "Ranst"@de,
+    "Ranst"@fr,
+    "Ranst"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/11037> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/11000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/11037>,
+    <http://www.wikidata.org/entity/Q943446>,
+    <https://sws.geonames.org/2787522/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "11037" ;
+  skos:prefLabel "Rumst"@de,
+    "Rumst"@fr,
+    "Rumst"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/11038> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/11000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/11038>,
+    <http://www.wikidata.org/entity/Q911968>,
+    <https://sws.geonames.org/2787081/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "11038" ;
+  skos:prefLabel "Schelle"@de,
+    "Schelle"@fr,
+    "Schelle"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/11039> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/11000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/11039>,
+    <http://www.wikidata.org/entity/Q263177>,
+    <https://sws.geonames.org/2787049/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "11039" ;
+  skos:prefLabel "Schilde"@de,
+    "Schilde"@fr,
+    "Schilde"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/11040> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/11000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/11040>,
+    <http://www.wikidata.org/entity/Q655203>,
+    <https://sws.geonames.org/2786964/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "11040" ;
+  skos:prefLabel "Schoten"@de,
+    "Schoten"@fr,
+    "Schoten"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/11044> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/11000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/11044>,
+    <http://www.wikidata.org/entity/Q595654>,
+    <https://sws.geonames.org/2786230/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "11044" ;
+  skos:prefLabel "Stabroek"@de,
+    "Stabroek"@fr,
+    "Stabroek"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/11050> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/11000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/11050>,
+    <http://www.wikidata.org/entity/Q527808>,
+    <https://sws.geonames.org/2783685/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "11050" ;
+  skos:prefLabel "Wijnegem"@de,
+    "Wijnegem"@fr,
+    "Wijnegem"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/11052> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/11000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/11052>,
+    <http://www.wikidata.org/entity/Q839037>,
+    <https://sws.geonames.org/2783463/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "11052" ;
+  skos:prefLabel "Wommelgem"@de,
+    "Wommelgem"@fr,
+    "Wommelgem"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/11053> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/11000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/11053>,
+    <http://www.wikidata.org/entity/Q912045>,
+    <https://sws.geonames.org/2783417/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "11053" ;
+  skos:prefLabel "Wuustwezel"@de,
+    "Wuustwezel"@fr,
+    "Wuustwezel"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/11054> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/11000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/11054>,
+    <http://www.wikidata.org/entity/Q146656>,
+    <https://sws.geonames.org/2783348/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "11054" ;
+  skos:prefLabel "Zandhoven"@de,
+    "Zandhoven"@fr,
+    "Zandhoven"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/11055> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/11000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/11055>,
+    <http://www.wikidata.org/entity/Q218253>,
+    <https://sws.geonames.org/2783205/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "11055" ;
+  skos:prefLabel "Zoersel"@de,
+    "Zoersel"@fr,
+    "Zoersel"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/11057> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/11000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/11057>,
+    <http://www.wikidata.org/entity/Q917591>,
+    <https://sws.geonames.org/2789746/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "11057" ;
+  skos:prefLabel "Malle"@de,
+    "Malle"@fr,
+    "Malle"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/12002> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/12000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/12002>,
+    <http://www.wikidata.org/entity/Q723774>,
+    <https://sws.geonames.org/2802157/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "12002" ;
+  skos:prefLabel "Berlaar"@de,
+    "Berlaar"@fr,
+    "Berlaar"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/12005> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/12000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/12005>,
+    <http://www.wikidata.org/entity/Q528222>,
+    <https://sws.geonames.org/2801540/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "12005" ;
+  skos:prefLabel "Bonheiden"@de,
+    "Bonheiden"@fr,
+    "Bonheiden"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/12007> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/12000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/12007>,
+    <http://www.wikidata.org/entity/Q724025>,
+    <https://sws.geonames.org/2801448/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "12007" ;
+  skos:prefLabel "Bornem"@de,
+    "Bornem"@fr,
+    "Bornem"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/12009> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/12000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/12009>,
+    <http://www.wikidata.org/entity/Q615109>,
+    <https://sws.geonames.org/2799091/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "12009" ;
+  skos:prefLabel "Duffel"@de,
+    "Duffel"@fr,
+    "Duffel"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/12014> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/12000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/12014>,
+    <http://www.wikidata.org/entity/Q257979>,
+    <https://sws.geonames.org/2796154/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "12014" ;
+  skos:prefLabel "Heist-op-den-Berg"@de,
+    "Heist-op-den-Berg"@fr,
+    "Heist-op-den-Berg"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/12021> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/12000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/12021>,
+    <http://www.wikidata.org/entity/Q12460>,
+    <https://sws.geonames.org/2792406/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "12021" ;
+  skos:prefLabel "Lier"@de,
+    "Lierre"@fr,
+    "Lier"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/12025> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/12000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/12025>,
+    <http://www.wikidata.org/entity/Q162022>,
+    <https://sws.geonames.org/2791538/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "12025" ;
+  skos:prefLabel "Mechelen"@de,
+    "Malines"@fr,
+    "Mechelen"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/12026> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/12000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/12026>,
+    <http://www.wikidata.org/entity/Q912084>,
+    <https://sws.geonames.org/2790136/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "12026" ;
+  skos:prefLabel "Nijlen"@de,
+    "Nijlen"@fr,
+    "Nijlen"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/12029> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/12000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/12029>,
+    <http://www.wikidata.org/entity/Q929397>,
+    <https://sws.geonames.org/2788523/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "12029" ;
+  skos:prefLabel "Putte"@de,
+    "Putte"@fr,
+    "Putte"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/12034> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/12000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/12034>,
+    <http://www.wikidata.org/entity/Q912030>,
+    <https://sws.geonames.org/2786747/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "12034" ;
+  skos:prefLabel "Sint-Amands"@de,
+    "Sint-Amands"@fr,
+    "Sint-Amands"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/12035> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/12000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/12035>,
+    <http://www.wikidata.org/entity/Q696578>,
+    <https://sws.geonames.org/2786642/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "12035" ;
+  skos:prefLabel "Sint-Katelijne-Waver"@de,
+    "Sint-Katelijne-Waver"@fr,
+    "Sint-Katelijne-Waver"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/12040> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/12000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/12040>,
+    <http://www.wikidata.org/entity/Q695278>,
+    <https://sws.geonames.org/2783633/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "12040" ;
+  skos:prefLabel "Willebroek"@de,
+    "Willebroek"@fr,
+    "Willebroek"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/12041> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/12000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/12041>,
+    <http://www.wikidata.org/entity/Q45202943> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrowMatch <http://www.wikidata.org/entity/Q908546>,
+    <https://sws.geonames.org/2788507/> ;
+  skos:notation "12041" ;
+  skos:prefLabel "Puurs-Sint-Amands"@de,
+    "Puurs-Sint-Amands"@fr,
+    "Puurs-Sint-Amands"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/13001> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/13000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/13001>,
+    <http://www.wikidata.org/entity/Q641905>,
+    <https://sws.geonames.org/2803084/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "13001" ;
+  skos:prefLabel "Arendonk"@de,
+    "Arendonk"@fr,
+    "Arendonk"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/13002> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/13000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/13002>,
+    <http://www.wikidata.org/entity/Q244959>,
+    <https://sws.geonames.org/2802817/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "13002" ;
+  skos:prefLabel "Baarle-Hertog"@de,
+    "Baerle-Duc"@fr,
+    "Baarle-Hertog"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/13003> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/13000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/13003>,
+    <http://www.wikidata.org/entity/Q723651>,
+    <https://sws.geonames.org/2802744/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "13003" ;
+  skos:prefLabel "Balen"@de,
+    "Balen"@fr,
+    "Balen"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/13004> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/13000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/13004>,
+    <http://www.wikidata.org/entity/Q723728>,
+    <https://sws.geonames.org/2802436/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "13004" ;
+  skos:prefLabel "Beerse"@de,
+    "Beerse"@fr,
+    "Beerse"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/13006> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/13000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/13006>,
+    <http://www.wikidata.org/entity/Q386732>,
+    <https://sws.geonames.org/2799512/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "13006" ;
+  skos:prefLabel "Dessel"@de,
+    "Dessel"@fr,
+    "Dessel"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/13008> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/13000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/13008>,
+    <http://www.wikidata.org/entity/Q464454>,
+    <https://sws.geonames.org/2797780/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "13008" ;
+  skos:prefLabel "Geel"@de,
+    "Geel"@fr,
+    "Geel"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/13010> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/13000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/13010>,
+    <http://www.wikidata.org/entity/Q724389>,
+    <https://sws.geonames.org/2797095/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "13010" ;
+  skos:prefLabel "Grobbendonk"@de,
+    "Grobbendonk"@fr,
+    "Grobbendonk"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/13011> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/13000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/13011>,
+    <http://www.wikidata.org/entity/Q383723>,
+    <https://sws.geonames.org/2796010/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "13011" ;
+  skos:prefLabel "Herentals"@de,
+    "Herentals"@fr,
+    "Herentals"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/13012> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/13000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/13012>,
+    <http://www.wikidata.org/entity/Q724534>,
+    <https://sws.geonames.org/2796006/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "13012" ;
+  skos:prefLabel "Herenthout"@de,
+    "Herenthout"@fr,
+    "Herenthout"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/13013> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/13000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/13013>,
+    <http://www.wikidata.org/entity/Q280182>,
+    <https://sws.geonames.org/2795934/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "13013" ;
+  skos:prefLabel "Herselt"@de,
+    "Herselt"@fr,
+    "Herselt"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/13014> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/13000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/13014>,
+    <http://www.wikidata.org/entity/Q724638>,
+    <https://sws.geonames.org/2795399/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "13014" ;
+  skos:prefLabel "Hoogstraten"@de,
+    "Hoogstraten"@fr,
+    "Hoogstraten"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/13016> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/13000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/13016>,
+    <http://www.wikidata.org/entity/Q518758>,
+    <https://sws.geonames.org/2795171/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "13016" ;
+  skos:prefLabel "Hulshout"@de,
+    "Hulshout"@fr,
+    "Hulshout"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/13017> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/13000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/13017>,
+    <http://www.wikidata.org/entity/Q725029>,
+    <https://sws.geonames.org/2794664/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "13017" ;
+  skos:prefLabel "Kasterlee"@de,
+    "Kasterlee"@fr,
+    "Kasterlee"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/13019> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/13000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/13019>,
+    <http://www.wikidata.org/entity/Q725235>,
+    <https://sws.geonames.org/2792361/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "13019" ;
+  skos:prefLabel "Lille"@de,
+    "Lille"@fr,
+    "Lille"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/13021> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/13000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/13021>,
+    <http://www.wikidata.org/entity/Q846207>,
+    <https://sws.geonames.org/2791495/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "13021" ;
+  skos:prefLabel "Meerhout"@de,
+    "Meerhout"@fr,
+    "Meerhout"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/13023> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/13000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/13023>,
+    <http://www.wikidata.org/entity/Q532277>,
+    <https://sws.geonames.org/2791298/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "13023" ;
+  skos:prefLabel "Merksplas"@de,
+    "Merksplas"@fr,
+    "Merksplas"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/13025> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/13000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/13025>,
+    <http://www.wikidata.org/entity/Q465710>,
+    <https://sws.geonames.org/2791068/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "13025" ;
+  skos:prefLabel "Mol"@de,
+    "Mol"@fr,
+    "Mol"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/13029> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/13000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/13029>,
+    <http://www.wikidata.org/entity/Q839044>,
+    <https://sws.geonames.org/2789887/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "13029" ;
+  skos:prefLabel "Olen"@de,
+    "Olen"@fr,
+    "Olen"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/13031> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/13000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/13031>,
+    <http://www.wikidata.org/entity/Q943555>,
+    <https://sws.geonames.org/2789484/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "13031" ;
+  skos:prefLabel "Oud-Turnhout"@de,
+    "Oud-Turnhout"@fr,
+    "Oud-Turnhout"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/13035> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/13000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/13035>,
+    <http://www.wikidata.org/entity/Q839119>,
+    <https://sws.geonames.org/2788313/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "13035" ;
+  skos:prefLabel "Ravels"@de,
+    "Ravels"@fr,
+    "Ravels"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/13036> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/13000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/13036>,
+    <http://www.wikidata.org/entity/Q912062>,
+    <https://sws.geonames.org/2788139/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "13036" ;
+  skos:prefLabel "Retie"@de,
+    "Retie"@fr,
+    "Retie"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/13037> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/13000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/13037>,
+    <http://www.wikidata.org/entity/Q929459>,
+    <https://sws.geonames.org/2788052/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "13037" ;
+  skos:prefLabel "Rijkevorsel"@de,
+    "Rijkevorsel"@fr,
+    "Rijkevorsel"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/13040> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/13000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/13040>,
+    <http://www.wikidata.org/entity/Q271783>,
+    <https://sws.geonames.org/2785142/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "13040" ;
+  skos:prefLabel "Turnhout"@de,
+    "Turnhout"@fr,
+    "Turnhout"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/13044> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/13000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/13044>,
+    <http://www.wikidata.org/entity/Q909914>,
+    <https://sws.geonames.org/2784371/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "13044" ;
+  skos:prefLabel "Vorselaar"@de,
+    "Vorselaar"@fr,
+    "Vorselaar"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/13046> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/13000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/13046>,
+    <http://www.wikidata.org/entity/Q929485>,
+    <https://sws.geonames.org/2784350/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "13046" ;
+  skos:prefLabel "Vosselaar"@de,
+    "Vosselaar"@fr,
+    "Vosselaar"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/13049> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/13000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/13049>,
+    <http://www.wikidata.org/entity/Q475931>,
+    <https://sws.geonames.org/2783802/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "13049" ;
+  skos:prefLabel "Westerlo"@de,
+    "Westerlo"@fr,
+    "Westerlo"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/13053> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/13000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/13053>,
+    <http://www.wikidata.org/entity/Q725122>,
+    <https://sws.geonames.org/2784365/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "13053" ;
+  skos:prefLabel "Laakdal"@de,
+    "Laakdal"@fr,
+    "Laakdal"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/21001> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/21000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/21001>,
+    <http://www.wikidata.org/entity/Q12886>,
+    <https://sws.geonames.org/2803202/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "21001" ;
+  skos:prefLabel "Anderlecht"@de,
+    "Anderlecht"@fr,
+    "Anderlecht"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/21002> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/21000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/21002>,
+    <http://www.wikidata.org/entity/Q272228>,
+    <https://sws.geonames.org/2802961/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "21002" ;
+  skos:prefLabel "Auderghem"@de,
+    "Auderghem"@fr,
+    "Oudergem"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/21003> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/21000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/21003>,
+    <http://www.wikidata.org/entity/Q272272>,
+    <https://sws.geonames.org/2802248/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "21003" ;
+  skos:prefLabel "Berchem-Sainte-Agathe"@de,
+    "Berchem-Sainte-Agathe"@fr,
+    "Sint-Agatha-Berchem"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/21004> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/21000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/21004>,
+    <http://www.wikidata.org/entity/Q239>,
+    <https://sws.geonames.org/3337389/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "21004" ;
+  skos:prefLabel "Brüssel"@de,
+    "Bruxelles"@fr,
+    "Brussel"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/21005> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/21000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/21005>,
+    <http://www.wikidata.org/entity/Q192859>,
+    <https://sws.geonames.org/2798579/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "21005" ;
+  skos:prefLabel "Etterbeek"@de,
+    "Etterbeek"@fr,
+    "Etterbeek"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/21006> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/21000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/21006>,
+    <http://www.wikidata.org/entity/Q321718>,
+    <https://sws.geonames.org/2798555/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "21006" ;
+  skos:prefLabel "Evere"@de,
+    "Evere"@fr,
+    "Evere"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/21007> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/21000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/21007>,
+    <http://www.wikidata.org/entity/Q72946>,
+    <https://sws.geonames.org/2798142/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "21007" ;
+  skos:prefLabel "Forest"@de,
+    "Forest"@fr,
+    "Vorst"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/21008> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/21000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/21008>,
+    <http://www.wikidata.org/entity/Q366552>,
+    <https://sws.geonames.org/2797845/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "21008" ;
+  skos:prefLabel "Ganshoren"@de,
+    "Ganshoren"@fr,
+    "Ganshoren"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/21009> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/21000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/21009>,
+    <http://www.wikidata.org/entity/Q208713>,
+    <https://sws.geonames.org/2795012/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "21009" ;
+  skos:prefLabel "Ixelles"@de,
+    "Ixelles"@fr,
+    "Elsene"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/21010> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/21000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/21010>,
+    <http://www.wikidata.org/entity/Q241918>,
+    <https://sws.geonames.org/2794915/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "21010" ;
+  skos:prefLabel "Jette"@de,
+    "Jette"@fr,
+    "Jette"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/21011> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/21000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/21011>,
+    <http://www.wikidata.org/entity/Q219244>,
+    <https://sws.geonames.org/2794192/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "21011" ;
+  skos:prefLabel "Koekelberg"@de,
+    "Koekelberg"@fr,
+    "Koekelberg"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/21012> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/21000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/21012>,
+    <http://www.wikidata.org/entity/Q180775>,
+    <https://sws.geonames.org/2791019/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "21012" ;
+  skos:prefLabel "Molenbeek-Saint-Jean"@de,
+    "Molenbeek-Saint-Jean"@fr,
+    "Sint-Jans-Molenbeek"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/21013> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/21000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/21013>,
+    <http://www.wikidata.org/entity/Q237674>,
+    <https://sws.geonames.org/2787415/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "21013" ;
+  skos:prefLabel "Saint-Gilles"@de,
+    "Saint-Gilles"@fr,
+    "Sint-Gillis"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/21014> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/21000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/21014>,
+    <http://www.wikidata.org/entity/Q272243>,
+    <https://sws.geonames.org/2787388/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "21014" ;
+  skos:prefLabel "Saint-Josse-ten-Noode"@de,
+    "Saint-Josse-ten-Noode"@fr,
+    "Sint-Joost-ten-Node"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/21015> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/21000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/21015>,
+    <http://www.wikidata.org/entity/Q12887>,
+    <https://sws.geonames.org/2787150/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "21015" ;
+  skos:prefLabel "Schaerbeek"@de,
+    "Schaerbeek"@fr,
+    "Schaarbeek"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/21016> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/21000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/21016>,
+    <http://www.wikidata.org/entity/Q203312>,
+    <https://sws.geonames.org/2785124/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "21016" ;
+  skos:prefLabel "Uccle"@de,
+    "Uccle"@fr,
+    "Ukkel"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/21017> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/21000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/21017>,
+    <http://www.wikidata.org/entity/Q272262>,
+    <https://sws.geonames.org/2783980/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "21017" ;
+  skos:prefLabel "Watermael-Boitsfort"@de,
+    "Watermael-Boitsfort"@fr,
+    "Watermaal-Bosvoorde"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/21018> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/21000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/21018>,
+    <http://www.wikidata.org/entity/Q211764>,
+    <https://sws.geonames.org/2783477/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "21018" ;
+  skos:prefLabel "Woluwe-Saint-Lambert"@de,
+    "Woluwe-Saint-Lambert"@fr,
+    "Sint-Lambrechts-Woluwe"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/21019> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/21000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/21019>,
+    <http://www.wikidata.org/entity/Q242393>,
+    <https://sws.geonames.org/2783475/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "21019" ;
+  skos:prefLabel "Woluwe-Saint-Pierre"@de,
+    "Woluwe-Saint-Pierre"@fr,
+    "Sint-Pieters-Woluwe"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/23002> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/23000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/23002>,
+    <http://www.wikidata.org/entity/Q515710>,
+    <https://sws.geonames.org/2803035/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "23002" ;
+  skos:prefLabel "Asse"@de,
+    "Asse"@fr,
+    "Asse"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/23003> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/23000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/23003>,
+    <http://www.wikidata.org/entity/Q692168>,
+    <https://sws.geonames.org/2802434/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "23003" ;
+  skos:prefLabel "Beersel"@de,
+    "Beersel"@fr,
+    "Beersel"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/23009> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/23000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/23009>,
+    <http://www.wikidata.org/entity/Q839017>,
+    <https://sws.geonames.org/2801951/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "23009" ;
+  skos:prefLabel "Bever"@de,
+    "Biévène"@fr,
+    "Bever"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/23016> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/23000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/23016>,
+    <http://www.wikidata.org/entity/Q641134>,
+    <https://sws.geonames.org/2799366/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "23016" ;
+  skos:prefLabel "Dilbeek"@de,
+    "Dilbeek"@fr,
+    "Dilbeek"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/23025> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/23000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/23025>,
+    <http://www.wikidata.org/entity/Q633063>,
+    <https://sws.geonames.org/2797115/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "23025" ;
+  skos:prefLabel "Grimbergen"@de,
+    "Grimbergen"@fr,
+    "Grimbergen"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/23027> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/23000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/23027>,
+    <http://www.wikidata.org/entity/Q210003>,
+    <https://sws.geonames.org/2796697/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "23027" ;
+  skos:prefLabel "Halle"@de,
+    "Hal"@fr,
+    "Halle"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/23033> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/23000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/23033>,
+    <http://www.wikidata.org/entity/Q641278>,
+    <https://sws.geonames.org/2795700/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "23033" ;
+  skos:prefLabel "Hoeilaart"@de,
+    "Hoeilaart"@fr,
+    "Hoeilaart"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/23038> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/23000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/23038>,
+    <http://www.wikidata.org/entity/Q492453>,
+    <https://sws.geonames.org/2794764/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "23038" ;
+  skos:prefLabel "Kampenhout"@de,
+    "Kampenhout"@fr,
+    "Kampenhout"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/23039> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/23000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/23039>,
+    <http://www.wikidata.org/entity/Q911995>,
+    <https://sws.geonames.org/2794725/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "23039" ;
+  skos:prefLabel "Kapelle-op-den-Bos"@de,
+    "Kapelle-op-den-Bos"@fr,
+    "Kapelle-op-den-Bos"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/23044> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/23000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/23044>,
+    <http://www.wikidata.org/entity/Q818621>,
+    <https://sws.geonames.org/2792424/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "23044" ;
+  skos:prefLabel "Liedekerke"@de,
+    "Liedekerke"@fr,
+    "Liedekerke"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/23045> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/23000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/23045>,
+    <http://www.wikidata.org/entity/Q587819>,
+    <https://sws.geonames.org/2792166/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "23045" ;
+  skos:prefLabel "Londerzeel"@de,
+    "Londerzeel"@fr,
+    "Londerzeel"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/23047> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/23000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/23047>,
+    <http://www.wikidata.org/entity/Q752115>,
+    <https://sws.geonames.org/2791953/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "23047" ;
+  skos:prefLabel "Machelen"@de,
+    "Machelen"@fr,
+    "Machelen"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/23050> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/23000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/23050>,
+    <http://www.wikidata.org/entity/Q922260>,
+    <https://sws.geonames.org/2791425/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "23050" ;
+  skos:prefLabel "Meise"@de,
+    "Meise"@fr,
+    "Meise"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/23052> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/23000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/23052>,
+    <http://www.wikidata.org/entity/Q912106>,
+    <https://sws.geonames.org/2791324/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "23052" ;
+  skos:prefLabel "Merchtem"@de,
+    "Merchtem"@fr,
+    "Merchtem"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/23060> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/23000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/23060>,
+    <http://www.wikidata.org/entity/Q930292>,
+    <https://sws.geonames.org/2789655/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "23060" ;
+  skos:prefLabel "Opwijk"@de,
+    "Opwijk"@fr,
+    "Opwijk"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/23062> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/23000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/23062>,
+    <http://www.wikidata.org/entity/Q599127>,
+    <https://sws.geonames.org/2789414/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "23062" ;
+  skos:prefLabel "Overijse"@de,
+    "Overijse"@fr,
+    "Overijse"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/23064> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/23000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/23064>,
+    <http://www.wikidata.org/entity/Q646037>,
+    <https://sws.geonames.org/2789193/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "23064" ;
+  skos:prefLabel "Pepingen"@de,
+    "Pepingen"@fr,
+    "Pepingen"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/23077> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/23000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/23077>,
+    <http://www.wikidata.org/entity/Q688790>,
+    <https://sws.geonames.org/2786560/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "23077" ;
+  skos:prefLabel "Sint-Pieters-Leeuw"@de,
+    "Sint-Pieters-Leeuw"@fr,
+    "Sint-Pieters-Leeuw"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/23081> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/23000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/23081>,
+    <http://www.wikidata.org/entity/Q984888>,
+    <https://sws.geonames.org/2786125/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "23081" ;
+  skos:prefLabel "Steenokkerzeel"@de,
+    "Steenokkerzeel"@fr,
+    "Steenokkerzeel"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/23086> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/23000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/23086>,
+    <http://www.wikidata.org/entity/Q930249>,
+    <https://sws.geonames.org/2785656/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "23086" ;
+  skos:prefLabel "Ternat"@de,
+    "Ternat"@fr,
+    "Ternat"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/23088> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/23000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/23088>,
+    <http://www.wikidata.org/entity/Q318418>,
+    <https://sws.geonames.org/2784605/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "23088" ;
+  skos:prefLabel "Vilvoorde"@de,
+    "Vilvorde"@fr,
+    "Vilvoorde"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/23094> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/23000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/23094>,
+    <http://www.wikidata.org/entity/Q28898>,
+    <https://sws.geonames.org/2783311/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "23094" ;
+  skos:prefLabel "Zaventem"@de,
+    "Zaventem"@fr,
+    "Zaventem"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/23096> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/23000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/23096>,
+    <http://www.wikidata.org/entity/Q179249>,
+    <https://sws.geonames.org/2783275/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "23096" ;
+  skos:prefLabel "Zemst"@de,
+    "Zemst"@fr,
+    "Zemst"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/23097> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/23000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/23097>,
+    <http://www.wikidata.org/entity/Q936660>,
+    <https://sws.geonames.org/2789347/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "23097" ;
+  skos:prefLabel "Roosdaal"@de,
+    "Roosdaal"@fr,
+    "Roosdaal"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/23098> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/23000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/23098>,
+    <http://www.wikidata.org/entity/Q688377>,
+    <https://sws.geonames.org/2799115/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "23098" ;
+  skos:prefLabel "Drogenbos"@de,
+    "Drogenbos"@fr,
+    "Drogenbos"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/23099> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/23000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/23099>,
+    <http://www.wikidata.org/entity/Q839023>,
+    <https://sws.geonames.org/2794017/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "23099" ;
+  skos:prefLabel "Kraainem"@de,
+    "Kraainem"@fr,
+    "Kraainem"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/23100> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/23000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/23100>,
+    <http://www.wikidata.org/entity/Q631639>,
+    <https://sws.geonames.org/2792302/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "23100" ;
+  skos:prefLabel "Linkebeek"@de,
+    "Linkebeek"@fr,
+    "Linkebeek"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/23101> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/23000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/23101>,
+    <http://www.wikidata.org/entity/Q841597>,
+    <https://sws.geonames.org/2786701/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "23101" ;
+  skos:prefLabel "Sint-Genesius-Rode"@de,
+    "Rhode-Saint-Genèse"@fr,
+    "Sint-Genesius-Rode"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/23102> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/23000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/23102>,
+    <http://www.wikidata.org/entity/Q913195>,
+    <https://sws.geonames.org/2783857/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "23102" ;
+  skos:prefLabel "Wemmel"@de,
+    "Wemmel"@fr,
+    "Wemmel"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/23103> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/23000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/23103>,
+    <http://www.wikidata.org/entity/Q912091>,
+    <https://sws.geonames.org/2783738/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "23103" ;
+  skos:prefLabel "Wezembeek-Oppem"@de,
+    "Wezembeek-Oppem"@fr,
+    "Wezembeek-Oppem"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/23104> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/23000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/23104>,
+    <http://www.wikidata.org/entity/Q912022>,
+    <https://sws.geonames.org/2786588/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "23104" ;
+  skos:prefLabel "Lennik"@de,
+    "Lennik"@fr,
+    "Lennik"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/23105> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/23000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/23105>,
+    <http://www.wikidata.org/entity/Q382860>,
+    <https://sws.geonames.org/2798612/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "23105" ;
+  skos:prefLabel "Affligem"@de,
+    "Affligem"@fr,
+    "Affligem"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/23106> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/23000> ;
+  skos:exactMatch <http://www.wikidata.org/entity/Q908554>,
+    <https://sws.geonames.org/2797852/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrowMatch <http://vocab.belgif.be/auth/refnis2019/23023>,
+    <http://vocab.belgif.be/auth/refnis2019/23024>,
+    <http://vocab.belgif.be/auth/refnis2019/23032> ;
+  skos:notation "23106" ;
+  skos:prefLabel "Pajottegem"@de,
+    "Pajottegem"@fr,
+    "Pajottegem"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2025-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/24001> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/24000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/24001>,
+    <http://www.wikidata.org/entity/Q273442>,
+    <https://sws.geonames.org/2803430/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "24001" ;
+  skos:prefLabel "Aarschot"@de,
+    "Aarschot"@fr,
+    "Aarschot"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/24007> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/24000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/24007>,
+    <http://www.wikidata.org/entity/Q432610>,
+    <https://sws.geonames.org/2802406/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "24007" ;
+  skos:prefLabel "Begijnendijk"@de,
+    "Begijnendijk"@fr,
+    "Begijnendijk"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/24008> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/24000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/24008>,
+    <http://www.wikidata.org/entity/Q815054>,
+    <https://sws.geonames.org/2802375/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "24008" ;
+  skos:prefLabel "Bekkevoort"@de,
+    "Bekkevoort"@fr,
+    "Bekkevoort"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/24009> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/24000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/24009>,
+    <http://www.wikidata.org/entity/Q827665>,
+    <https://sws.geonames.org/2802124/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "24009" ;
+  skos:prefLabel "Bertem"@de,
+    "Bertem"@fr,
+    "Bertem"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/24011> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/24000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/24011>,
+    <http://www.wikidata.org/entity/Q729929>,
+    <https://sws.geonames.org/2801999/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "24011" ;
+  skos:prefLabel "Bierbeek"@de,
+    "Bierbeek"@fr,
+    "Bierbeek"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/24014> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/24000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/24014>,
+    <http://www.wikidata.org/entity/Q746078>,
+    <https://sws.geonames.org/2801484/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "24014" ;
+  skos:prefLabel "Boortmeerbeek"@de,
+    "Boortmeerbeek"@fr,
+    "Boortmeerbeek"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/24016> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/24000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/24016>,
+    <http://www.wikidata.org/entity/Q895293>,
+    <https://sws.geonames.org/2801216/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "24016" ;
+  skos:prefLabel "Boutersem"@de,
+    "Boutersem"@fr,
+    "Boutersem"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/24020> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/24000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/24020>,
+    <http://www.wikidata.org/entity/Q743236>,
+    <https://sws.geonames.org/2799398/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "24020" ;
+  skos:prefLabel "Diest"@de,
+    "Diest"@fr,
+    "Diest"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/24028> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/24000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/24028>,
+    <http://www.wikidata.org/entity/Q984874>,
+    <https://sws.geonames.org/2797762/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "24028" ;
+  skos:prefLabel "Geetbets"@de,
+    "Geetbets"@fr,
+    "Geetbets"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/24033> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/24000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/24033>,
+    <http://www.wikidata.org/entity/Q950129>,
+    <https://sws.geonames.org/2796845/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "24033" ;
+  skos:prefLabel "Haacht"@de,
+    "Haacht"@fr,
+    "Haacht"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/24038> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/24000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/24038>,
+    <http://www.wikidata.org/entity/Q930269>,
+    <https://sws.geonames.org/2796013/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "24038" ;
+  skos:prefLabel "Herent"@de,
+    "Herent"@fr,
+    "Herent"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/24041> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/24000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/24041>,
+    <http://www.wikidata.org/entity/Q818787>,
+    <https://sws.geonames.org/2795704/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "24041" ;
+  skos:prefLabel "Hoegaarden"@de,
+    "Hoegaarden"@fr,
+    "Hoegaarden"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/24043> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/24000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/24043>,
+    <http://www.wikidata.org/entity/Q676893>,
+    <https://sws.geonames.org/2795512/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "24043" ;
+  skos:prefLabel "Holsbeek"@de,
+    "Holsbeek"@fr,
+    "Holsbeek"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/24045> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/24000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/24045>,
+    <http://www.wikidata.org/entity/Q943472>,
+    <https://sws.geonames.org/2795185/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "24045" ;
+  skos:prefLabel "Huldenberg"@de,
+    "Huldenberg"@fr,
+    "Huldenberg"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/24048> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/24000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/24048>,
+    <http://www.wikidata.org/entity/Q984894>,
+    <https://sws.geonames.org/2794620/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "24048" ;
+  skos:prefLabel "Keerbergen"@de,
+    "Keerbergen"@fr,
+    "Keerbergen"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/24054> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/24000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/24054>,
+    <http://www.wikidata.org/entity/Q984877>,
+    <https://sws.geonames.org/2794073/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "24054" ;
+  skos:prefLabel "Kortenaken"@de,
+    "Kortenaken"@fr,
+    "Kortenaken"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/24055> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/24000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/24055>,
+    <http://www.wikidata.org/entity/Q929474>,
+    <https://sws.geonames.org/2794071/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "24055" ;
+  skos:prefLabel "Kortenberg"@de,
+    "Kortenberg"@fr,
+    "Kortenberg"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/24059> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/24000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/24059>,
+    <http://www.wikidata.org/entity/Q943502>,
+    <https://sws.geonames.org/2793430/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "24059" ;
+  skos:prefLabel "Landen"@de,
+    "Landen"@fr,
+    "Landen"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/24062> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/24000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/24062>,
+    <http://www.wikidata.org/wiki/Q118958>,
+    <https://sws.geonames.org/2792483/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "24062" ;
+  skos:prefLabel "Löwen"@de,
+    "Louvain"@fr,
+    "Leuven"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/24066> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/24000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/24066>,
+    <http://www.wikidata.org/entity/Q929447>,
+    <https://sws.geonames.org/2792035/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "24066" ;
+  skos:prefLabel "Lubbeek"@de,
+    "Lubbeek"@fr,
+    "Lubbeek"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/24086> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/24000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/24086>,
+    <http://www.wikidata.org/entity/Q746641>,
+    <https://sws.geonames.org/2789493/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "24086" ;
+  skos:prefLabel "Oud-Heverlee"@de,
+    "Oud-Heverlee"@fr,
+    "Oud-Heverlee"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/24094> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/24000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/24094>,
+    <http://www.wikidata.org/entity/Q926139>,
+    <https://sws.geonames.org/2787663/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "24094" ;
+  skos:prefLabel "Rotselaar"@de,
+    "Rotselaar"@fr,
+    "Rotselaar"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/24104> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/24000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/24104>,
+    <http://www.wikidata.org/entity/Q456544>,
+    <https://sws.geonames.org/2785623/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "24104" ;
+  skos:prefLabel "Tervuren"@de,
+    "Tervuren"@fr,
+    "Tervuren"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/24107> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/24000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/24107>,
+    <http://www.wikidata.org/entity/Q456550>,
+    <https://sws.geonames.org/2785471/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "24107" ;
+  skos:prefLabel "Tienen"@de,
+    "Tirlemont"@fr,
+    "Tienen"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/24109> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/24000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/24109>,
+    <http://www.wikidata.org/entity/Q926110>,
+    <https://sws.geonames.org/2785294/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "24109" ;
+  skos:prefLabel "Tremelo"@de,
+    "Tremelo"@fr,
+    "Tremelo"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/24130> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/24000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/24130>,
+    <http://www.wikidata.org/entity/Q227070>,
+    <https://sws.geonames.org/2783171/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "24130" ;
+  skos:prefLabel "Zoutleeuw"@de,
+    "Léau"@fr,
+    "Zoutleeuw"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/24133> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/24000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/24133>,
+    <http://www.wikidata.org/entity/Q984881>,
+    <https://sws.geonames.org/2791389/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "24133" ;
+  skos:prefLabel "Linter"@de,
+    "Linter"@fr,
+    "Linter"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/24134> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/24000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/24134>,
+    <http://www.wikidata.org/entity/Q932020>,
+    <https://sws.geonames.org/2787061/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "24134" ;
+  skos:prefLabel "Scherpenheuvel-Zichem"@de,
+    "Montaigu-Zichem"@fr,
+    "Scherpenheuvel-Zichem"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/24135> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/24000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/24135>,
+    <http://www.wikidata.org/entity/Q984892>,
+    <https://sws.geonames.org/2785479/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "24135" ;
+  skos:prefLabel "Tielt-Winge"@de,
+    "Tielt-Winge"@fr,
+    "Tielt-Winge"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/24137> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/24000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/24137>,
+    <http://www.wikidata.org/entity/Q984868>,
+    <https://sws.geonames.org/2797501/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "24137" ;
+  skos:prefLabel "Glabbeek"@de,
+    "Glabbeek"@fr,
+    "Glabbeek"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/25005> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/25000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/25005>,
+    <http://www.wikidata.org/entity/Q276266>,
+    <https://sws.geonames.org/2802484/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "25005" ;
+  skos:prefLabel "Beauvechain"@de,
+    "Beauvechain"@fr,
+    "Bevekom"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/25014> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/25000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/25014>,
+    <http://www.wikidata.org/entity/Q497572>,
+    <https://sws.geonames.org/2801155/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "25014" ;
+  skos:prefLabel "Braine-l’Alleud"@de,
+    "Braine-l’Alleud"@fr,
+    "Eigenbrakel"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/25015> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/25000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/25015>,
+    <http://www.wikidata.org/entity/Q497558>,
+    <https://sws.geonames.org/2801153/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "25015" ;
+  skos:prefLabel "Braine-le-Château"@de,
+    "Braine-le-Château"@fr,
+    "Kasteelbrakel"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/25018> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/25000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/25018>,
+    <http://www.wikidata.org/entity/Q670141>,
+    <https://sws.geonames.org/2800431/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "25018" ;
+  skos:prefLabel "Chaumont-Gistoux"@de,
+    "Chaumont-Gistoux"@fr,
+    "Chaumont-Gistoux"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/25023> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/25000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/25023>,
+    <http://www.wikidata.org/entity/Q670210>,
+    <https://sws.geonames.org/2800043/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "25023" ;
+  skos:prefLabel "Court-Saint-Etienne"@de,
+    "Court-Saint-Etienne"@fr,
+    "Court-Saint-Etienne"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/25031> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/25000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/25031>,
+    <http://www.wikidata.org/entity/Q517899>,
+    <https://sws.geonames.org/2797695/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "25031" ;
+  skos:prefLabel "Genappe"@de,
+    "Genappe"@fr,
+    "Genepiën"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/25037> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/25000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/25037>,
+    <http://www.wikidata.org/entity/Q670310>,
+    <https://sws.geonames.org/2797129/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "25037" ;
+  skos:prefLabel "Grez-Doiceau"@de,
+    "Grez-Doiceau"@fr,
+    "Graven"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/25043> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/25000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/25043>,
+    <http://www.wikidata.org/entity/Q670455>,
+    <https://sws.geonames.org/2795064/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "25043" ;
+  skos:prefLabel "Incourt"@de,
+    "Incourt"@fr,
+    "Incourt"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/25044> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/25000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/25044>,
+    <http://www.wikidata.org/entity/Q281080>,
+    <https://sws.geonames.org/2795018/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "25044" ;
+  skos:prefLabel "Ittre"@de,
+    "Ittre"@fr,
+    "Itter"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/25048> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/25000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/25048>,
+    <http://www.wikidata.org/entity/Q670500>,
+    <https://sws.geonames.org/2794896/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "25048" ;
+  skos:prefLabel "Jodoigne"@de,
+    "Jodoigne"@fr,
+    "Geldenaken"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/25050> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/25000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/25050>,
+    <http://www.wikidata.org/entity/Q670407>,
+    <https://sws.geonames.org/2793549/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "25050" ;
+  skos:prefLabel "La Hulpe"@de,
+    "La Hulpe"@fr,
+    "Terhulpen"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/25068> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/25000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/25068>,
+    <http://www.wikidata.org/entity/Q650152>,
+    <https://sws.geonames.org/2790757/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "25068" ;
+  skos:prefLabel "Mont-Saint-Guibert"@de,
+    "Mont-Saint-Guibert"@fr,
+    "Mont-Saint-Guibert"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/25072> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/25000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/25072>,
+    <http://www.wikidata.org/entity/Q319463>,
+    <https://sws.geonames.org/2790102/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "25072" ;
+  skos:prefLabel "Nivelles"@de,
+    "Nivelles"@fr,
+    "Nijvel"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/25084> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/25000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/25084>,
+    <http://www.wikidata.org/entity/Q678458>,
+    <https://sws.geonames.org/2789158/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "25084" ;
+  skos:prefLabel "Perwez"@de,
+    "Perwez"@fr,
+    "Perwijs"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/25091> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/25000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/25091>,
+    <http://www.wikidata.org/entity/Q630478>,
+    <https://sws.geonames.org/2787990/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "25091" ;
+  skos:prefLabel "Rixensart"@de,
+    "Rixensart"@fr,
+    "Rixensart"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/25105> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/25000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/25105>,
+    <http://www.wikidata.org/entity/Q497549>,
+    <https://sws.geonames.org/2785170/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "25105" ;
+  skos:prefLabel "Tubize"@de,
+    "Tubize"@fr,
+    "Tubeke"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/25107> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/25000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/25107>,
+    <http://www.wikidata.org/entity/Q678612>,
+    <https://sws.geonames.org/2784642/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "25107" ;
+  skos:prefLabel "Villers-la-Ville"@de,
+    "Villers-la-Ville"@fr,
+    "Villers-la-Ville"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/25110> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/25000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/25110>,
+    <http://www.wikidata.org/entity/Q179034>,
+    <https://sws.geonames.org/2783986/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "25110" ;
+  skos:prefLabel "Waterloo"@de,
+    "Waterloo"@fr,
+    "Waterloo"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/25112> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/25000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/25112>,
+    <http://www.wikidata.org/entity/Q181314>,
+    <https://sws.geonames.org/2783942/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "25112" ;
+  skos:prefLabel "Wavre"@de,
+    "Wavre"@fr,
+    "Waver"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/25117> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/25000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/25117>,
+    <http://www.wikidata.org/entity/Q618054>,
+    <https://sws.geonames.org/2800458/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "25117" ;
+  skos:prefLabel "Chastre"@de,
+    "Chastre"@fr,
+    "Chastre"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/25118> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/25000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/25118>,
+    <http://www.wikidata.org/entity/Q670355>,
+    <https://sws.geonames.org/2792297/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "25118" ;
+  skos:prefLabel "Hélécine"@de,
+    "Hélécine"@fr,
+    "Hélécine"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/25119> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/25000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/25119>,
+    <http://www.wikidata.org/entity/Q678158>,
+    <https://sws.geonames.org/2793248/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "25119" ;
+  skos:prefLabel "Lasne"@de,
+    "Lasne"@fr,
+    "Lasne"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/25120> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/25000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/25120>,
+    <http://www.wikidata.org/entity/Q678218>,
+    <https://sws.geonames.org/2789622/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "25120" ;
+  skos:prefLabel "Orp-Jauche"@de,
+    "Orp-Jauche"@fr,
+    "Orp-Jauche"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/25121> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/25000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/25121>,
+    <http://www.wikidata.org/entity/Q329642>,
+    <https://sws.geonames.org/2789571/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "25121" ;
+  skos:prefLabel "Ottignies-Louvain-la-Neuve"@de,
+    "Ottignies-Louvain-la-Neuve"@fr,
+    "Ottignies-Louvain-la-Neuve"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/25122> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/25000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/25122>,
+    <http://www.wikidata.org/entity/Q531456>,
+    <https://sws.geonames.org/2788382/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "25122" ;
+  skos:prefLabel "Ramillies"@de,
+    "Ramillies"@fr,
+    "Ramillies"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/25123> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/25000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/25123>,
+    <http://www.wikidata.org/entity/Q374861>,
+    <https://sws.geonames.org/2788300/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "25123" ;
+  skos:prefLabel "Rebecq"@de,
+    "Rebecq"@fr,
+    "Rebecq"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/25124> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/25000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/25124>,
+    <http://www.wikidata.org/entity/Q650216>,
+    <https://sws.geonames.org/2784169/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "25124" ;
+  skos:prefLabel "Walhain"@de,
+    "Walhain"@fr,
+    "Walhain"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/31003> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/31000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/31003>,
+    <http://www.wikidata.org/entity/Q687921>,
+    <https://sws.geonames.org/2802438/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "31003" ;
+  skos:prefLabel "Beernem"@de,
+    "Beernem"@fr,
+    "Beernem"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/31004> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/31000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/31004>,
+    <http://www.wikidata.org/entity/Q328104>,
+    <https://sws.geonames.org/2801859/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "31004" ;
+  skos:prefLabel "Blankenberge"@de,
+    "Blankenberge"@fr,
+    "Blankenberge"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/31005> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/31000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/31005>,
+    <http://www.wikidata.org/entity/Q12994>,
+    <https://sws.geonames.org/2800935/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "31005" ;
+  skos:prefLabel "Brügge"@de,
+    "Bruges"@fr,
+    "Brugge"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/31006> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/31000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/31006>,
+    <http://www.wikidata.org/entity/Q323408>,
+    <https://sws.geonames.org/2799886/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "31006" ;
+  skos:prefLabel "Damme"@de,
+    "Damme"@fr,
+    "Damme"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/31012> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/31000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/31012>,
+    <http://www.wikidata.org/entity/Q465973>,
+    <https://sws.geonames.org/2795001/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "31012" ;
+  skos:prefLabel "Jabbeke"@de,
+    "Jabbeke"@fr,
+    "Jabbeke"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/31022> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/31000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/31022>,
+    <http://www.wikidata.org/entity/Q742892>,
+    <https://sws.geonames.org/2789752/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "31022" ;
+  skos:prefLabel "Oostkamp"@de,
+    "Oostkamp"@fr,
+    "Oostkamp"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/31033> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/31000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/31033>,
+    <http://www.wikidata.org/entity/Q270633>,
+    <https://sws.geonames.org/2785365/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "31033" ;
+  skos:prefLabel "Torhout"@de,
+    "Torhout"@fr,
+    "Torhout"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/31040> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/31000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/31040>,
+    <http://www.wikidata.org/entity/Q184287>,
+    <https://sws.geonames.org/2783309/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "31040" ;
+  skos:prefLabel "Zedelgem"@de,
+    "Zedelgem"@fr,
+    "Zedelgem"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/31042> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/31000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/31042>,
+    <http://www.wikidata.org/entity/Q228685>,
+    <https://sws.geonames.org/2783154/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "31042" ;
+  skos:prefLabel "Zuienkerke"@de,
+    "Zuienkerke"@fr,
+    "Zuienkerke"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/31043> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/31000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/31043>,
+    <http://www.wikidata.org/entity/Q12988>,
+    <https://sws.geonames.org/2794216/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "31043" ;
+  skos:prefLabel "Knokke-Heist"@de,
+    "Knokke-Heist"@fr,
+    "Knokke-Heist"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/32003> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/32000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/32003>,
+    <http://www.wikidata.org/entity/Q215244>,
+    <https://sws.geonames.org/2799370/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "32003" ;
+  skos:prefLabel "Diksmuide"@de,
+    "Dixmude"@fr,
+    "Diksmuide"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/32006> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/32000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/32006>,
+    <http://www.wikidata.org/entity/Q696942>,
+    <https://sws.geonames.org/2795256/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "32006" ;
+  skos:prefLabel "Houthulst"@de,
+    "Houthulst"@fr,
+    "Houthulst"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/32010> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/32000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/32010>,
+    <http://www.wikidata.org/entity/Q822795>,
+    <https://sws.geonames.org/2794195/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "32010" ;
+  skos:prefLabel "Koekelare"@de,
+    "Koekelare"@fr,
+    "Koekelare"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/32011> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/32000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/32011>,
+    <http://www.wikidata.org/entity/Q822763>,
+    <https://sws.geonames.org/2794075/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "32011" ;
+  skos:prefLabel "Kortemark"@de,
+    "Kortemark"@fr,
+    "Kortemark"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/32030> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/32000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/32030>,
+    <http://www.wikidata.org/entity/Q822790>,
+    <https://sws.geonames.org/2788179/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "32030" ;
+  skos:prefLabel "Lo-Reninge"@de,
+    "Lo-Reninge"@fr,
+    "Lo-Reninge"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/33011> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/33000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/33011>,
+    <http://www.wikidata.org/entity/Q102728>,
+    <https://sws.geonames.org/2795101/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "33011" ;
+  skos:prefLabel "Ypern"@de,
+    "Ypres"@fr,
+    "Ieper"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/33016> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/33000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/33016>,
+    <http://www.wikidata.org/entity/Q737077>,
+    <https://sws.geonames.org/2791285/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "33016" ;
+  skos:prefLabel "Mesen"@de,
+    "Messines"@fr,
+    "Mesen"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/33021> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/33000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/33021>,
+    <http://www.wikidata.org/entity/Q499588>,
+    <https://sws.geonames.org/2788727/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "33021" ;
+  skos:prefLabel "Poperinge"@de,
+    "Poperinge"@fr,
+    "Poperinge"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/33029> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/33000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/33029>,
+    <http://www.wikidata.org/entity/Q318532>,
+    <https://sws.geonames.org/2783821/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "33029" ;
+  skos:prefLabel "Wervik"@de,
+    "Wervik"@fr,
+    "Wervik"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/33037> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/33000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/33037>,
+    <http://www.wikidata.org/entity/Q214154>,
+    <https://sws.geonames.org/2783185/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "33037" ;
+  skos:prefLabel "Zonnebeke"@de,
+    "Zonnebeke"@fr,
+    "Zonnebeke"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/33039> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/33000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/33039>,
+    <http://www.wikidata.org/entity/Q822755>,
+    <https://sws.geonames.org/2794580/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "33039" ;
+  skos:prefLabel "Heuvelland"@de,
+    "Heuvelland"@fr,
+    "Heuvelland"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/33040> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/33000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/33040>,
+    <http://www.wikidata.org/entity/Q735865>,
+    <https://sws.geonames.org/2793393/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "33040" ;
+  skos:prefLabel "Langemark-Poelkapelle"@de,
+    "Langemark-Poelkapelle"@fr,
+    "Langemark-Poelkapelle"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/33041> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/33000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/33041>,
+    <http://www.wikidata.org/entity/Q735813>,
+    <https://sws.geonames.org/2783769/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "33041" ;
+  skos:prefLabel "Vleteren"@de,
+    "Vleteren"@fr,
+    "Vleteren"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/34002> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/34000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/34002>,
+    <http://www.wikidata.org/entity/Q614274>,
+    <https://sws.geonames.org/2803131/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "34002" ;
+  skos:prefLabel "Anzegem"@de,
+    "Anzegem"@fr,
+    "Anzegem"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/34003> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/34000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/34003>,
+    <http://www.wikidata.org/entity/Q177133>,
+    <https://sws.geonames.org/2802872/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "34003" ;
+  skos:prefLabel "Avelgem"@de,
+    "Avelgem"@fr,
+    "Avelgem"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/34009> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/34000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/34009>,
+    <http://www.wikidata.org/entity/Q822771>,
+    <https://sws.geonames.org/2799798/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "34009" ;
+  skos:prefLabel "Deerlijk"@de,
+    "Deerlijk"@fr,
+    "Deerlijk"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/34013> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/34000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/34013>,
+    <http://www.wikidata.org/entity/Q478797>,
+    <https://sws.geonames.org/2796543/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "34013" ;
+  skos:prefLabel "Harelbeke"@de,
+    "Harelbeke"@fr,
+    "Harelbeke"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/34022> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/34000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/34022>,
+    <http://www.wikidata.org/entity/Q12995>,
+    <https://sws.geonames.org/2794056/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "34022" ;
+  skos:prefLabel "Kortrijk"@de,
+    "Courtrai"@fr,
+    "Kortrijk"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/34023> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/34000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/34023>,
+    <http://www.wikidata.org/entity/Q731501>,
+    <https://sws.geonames.org/2793858/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "34023" ;
+  skos:prefLabel "Kuurne"@de,
+    "Kuurne"@fr,
+    "Kuurne"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/34025> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/34000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/34025>,
+    <http://www.wikidata.org/entity/Q696887>,
+    <https://sws.geonames.org/2792880/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "34025" ;
+  skos:prefLabel "Lendelede"@de,
+    "Lendelede"@fr,
+    "Lendelede"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/34027> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/34000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/34027>,
+    <http://www.wikidata.org/entity/Q213224>,
+    <https://sws.geonames.org/2791344/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "34027" ;
+  skos:prefLabel "Menen"@de,
+    "Menin"@fr,
+    "Menen"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/34040> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/34000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/34040>,
+    <http://www.wikidata.org/entity/Q204547>,
+    <https://sws.geonames.org/2784069/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "34040" ;
+  skos:prefLabel "Waregem"@de,
+    "Waregem"@fr,
+    "Waregem"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/34041> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/34000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/34041>,
+    <http://www.wikidata.org/entity/Q392343>,
+    <https://sws.geonames.org/2783760/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "34041" ;
+  skos:prefLabel "Wevelgem"@de,
+    "Wevelgem"@fr,
+    "Wevelgem"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/34042> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/34000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/34042>,
+    <http://www.wikidata.org/entity/Q244513>,
+    <https://sws.geonames.org/2783090/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "34042" ;
+  skos:prefLabel "Zwevegem"@de,
+    "Zwevegem"@fr,
+    "Zwevegem"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/34043> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/34000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/34043>,
+    <http://www.wikidata.org/entity/Q846212>,
+    <https://sws.geonames.org/2798628/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "34043" ;
+  skos:prefLabel "Spiere-Helkijn"@de,
+    "Espierres-Helchin"@fr,
+    "Spiere-Helkijn"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/35002> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/35000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/35002>,
+    <http://www.wikidata.org/entity/Q742920>,
+    <https://sws.geonames.org/2801104/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "35002" ;
+  skos:prefLabel "Bredene"@de,
+    "Bredene"@fr,
+    "Bredene"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/35005> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/35000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/35005>,
+    <http://www.wikidata.org/entity/Q815948>,
+    <https://sws.geonames.org/2797518/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "35005" ;
+  skos:prefLabel "Gistel"@de,
+    "Gistel"@fr,
+    "Gistel"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/35006> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/35000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/35006>,
+    <http://www.wikidata.org/entity/Q281181>,
+    <https://sws.geonames.org/2795107/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "35006" ;
+  skos:prefLabel "Ichtegem"@de,
+    "Ichtegem"@fr,
+    "Ichtegem"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/35011> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/35000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/35011>,
+    <http://www.wikidata.org/entity/Q492369>,
+    <https://sws.geonames.org/2791195/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "35011" ;
+  skos:prefLabel "Middelkerke"@de,
+    "Middelkerke"@fr,
+    "Middelkerke"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/35013> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/35000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/35013>,
+    <http://www.wikidata.org/entity/Q12996>,
+    <https://sws.geonames.org/2789788/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "35013" ;
+  skos:prefLabel "Ostende"@de,
+    "Ostende"@fr,
+    "Oostende"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/35014> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/35000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/35014>,
+    <http://www.wikidata.org/entity/Q835128>,
+    <https://sws.geonames.org/2789520/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "35014" ;
+  skos:prefLabel "Oudenburg"@de,
+    "Oudenburg"@fr,
+    "Oudenburg"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/35029> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/35000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/35029>,
+    <http://www.wikidata.org/entity/Q492351>,
+    <https://sws.geonames.org/2783855/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "35029" ;
+  skos:prefLabel "De Haan"@de,
+    "De Haan"@fr,
+    "De Haan"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/36006> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/36000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/36006>,
+    <http://www.wikidata.org/entity/Q696907>,
+    <https://sws.geonames.org/2795424/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "36006" ;
+  skos:prefLabel "Hooglede"@de,
+    "Hooglede"@fr,
+    "Hooglede"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/36007> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/36000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/36007>,
+    <http://www.wikidata.org/entity/Q822748>,
+    <https://sws.geonames.org/2795057/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "36007" ;
+  skos:prefLabel "Ingelmunster"@de,
+    "Ingelmunster"@fr,
+    "Ingelmunster"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/36008> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/36000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/36008>,
+    <http://www.wikidata.org/entity/Q392337>,
+    <https://sws.geonames.org/2795010/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "36008" ;
+  skos:prefLabel "Izegem"@de,
+    "Izegem"@fr,
+    "Izegem"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/36010> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/36000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/36010>,
+    <http://www.wikidata.org/entity/Q735842>,
+    <https://sws.geonames.org/2793068/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "36010" ;
+  skos:prefLabel "Ledegem"@de,
+    "Ledegem"@fr,
+    "Ledegem"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/36011> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/36000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/36011>,
+    <http://www.wikidata.org/entity/Q696871>,
+    <https://sws.geonames.org/2792430/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "36011" ;
+  skos:prefLabel "Lichtervelde"@de,
+    "Lichtervelde"@fr,
+    "Lichtervelde"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/36012> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/36000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/36012>,
+    <http://www.wikidata.org/entity/Q628733>,
+    <https://sws.geonames.org/2790730/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "36012" ;
+  skos:prefLabel "Moorslede"@de,
+    "Moorslede"@fr,
+    "Moorslede"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/36015> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/36000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/36015>,
+    <http://www.wikidata.org/entity/Q211037>,
+    <https://sws.geonames.org/2787891/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "36015" ;
+  skos:prefLabel "Roeselare"@de,
+    "Roulers"@fr,
+    "Roeselare"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/36019> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/36000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/36019>,
+    <http://www.wikidata.org/entity/Q742876>,
+    <https://sws.geonames.org/2786227/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "36019" ;
+  skos:prefLabel "Staden"@de,
+    "Staden"@fr,
+    "Staden"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/37002> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/37000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/37002>,
+    <http://www.wikidata.org/entity/Q742906>,
+    <https://sws.geonames.org/2799587/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "37002" ;
+  skos:prefLabel "Dentergem"@de,
+    "Dentergem"@fr,
+    "Dentergem"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/37010> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/37000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/37010>,
+    <http://www.wikidata.org/entity/Q822777>,
+    <https://sws.geonames.org/2789738/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "37010" ;
+  skos:prefLabel "Oostrozebeke"@de,
+    "Oostrozebeke"@fr,
+    "Oostrozebeke"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/37011> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/37000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/37011>,
+    <http://www.wikidata.org/entity/Q651724>,
+    <https://sws.geonames.org/2788926/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "37011" ;
+  skos:prefLabel "Pittem"@de,
+    "Pittem"@fr,
+    "Pittem"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/37017> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/37000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/37017>,
+    <http://www.wikidata.org/entity/Q339395>,
+    <https://sws.geonames.org/2783718/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "37017" ;
+  skos:prefLabel "Wielsbeke"@de,
+    "Wielsbeke"@fr,
+    "Wielsbeke"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/37020> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/37000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/37020>,
+    <http://www.wikidata.org/entity/Q639974>,
+    <https://sws.geonames.org/2803092/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "37020" ;
+  skos:prefLabel "Ardooie"@de,
+    "Ardooie"@fr,
+    "Ardooie"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/37021> a skos:Concept ;
+  skos:exactMatch <http://www.wikidata.org/entity/Q735797>,
+    <https://sws.geonames.org/2783587/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrowMatch <http://vocab.belgif.be/auth/refnis2019/37012>,
+    <http://vocab.belgif.be/auth/refnis2019/37018> ;
+  skos:notation "37021" ;
+  skos:prefLabel "Wingene"@de,
+    "Wingene"@fr,
+    "Wingene"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2025-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/37022> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/37000> ;
+  skos:exactMatch <http://www.wikidata.org/entity/Q651811>,
+    <https://sws.geonames.org/2785478/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrowMatch <http://vocab.belgif.be/auth/refnis2019/37007>,
+    <http://vocab.belgif.be/auth/refnis2019/37015> ;
+  skos:notation "37022" ;
+  skos:prefLabel "Tielt"@de,
+    "Tielt"@fr,
+    "Tielt"@nl ;
+  ns1:endDate "2025-01-01T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/38002> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/38000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/38002>,
+    <http://www.wikidata.org/entity/Q448840>,
+    <https://sws.geonames.org/2803253/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "38002" ;
+  skos:prefLabel "Alveringem"@de,
+    "Alveringem"@fr,
+    "Alveringem"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/38008> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/38000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/38008>,
+    <http://www.wikidata.org/entity/Q674954>,
+    <https://sws.geonames.org/2799578/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "38008" ;
+  skos:prefLabel "De Panne"@de,
+    "La Panne"@fr,
+    "De Panne"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/38014> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/38000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/38014>,
+    <http://www.wikidata.org/entity/Q465545>,
+    <https://sws.geonames.org/2794167/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "38014" ;
+  skos:prefLabel "Koksijde"@de,
+    "Koksijde"@fr,
+    "Koksijde"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/38016> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/38000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/38016>,
+    <http://www.wikidata.org/entity/Q623310>,
+    <https://sws.geonames.org/2790153/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "38016" ;
+  skos:prefLabel "Nieuwpoort"@de,
+    "Nieuport"@fr,
+    "Nieuwpoort"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/38025> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/38000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/38025>,
+    <http://www.wikidata.org/entity/Q506707>,
+    <https://sws.geonames.org/2784805/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "38025" ;
+  skos:prefLabel "Veurne"@de,
+    "Furnes"@fr,
+    "Veurne"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/41002> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/41000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/41002>,
+    <http://www.wikidata.org/entity/Q13121>,
+    <https://sws.geonames.org/2803451/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "41002" ;
+  skos:prefLabel "Aalst"@de,
+    "Alost"@fr,
+    "Aalst"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/41011> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/41000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/41011>,
+    <http://www.wikidata.org/entity/Q696825>,
+    <https://sws.geonames.org/2799648/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "41011" ;
+  skos:prefLabel "Denderleeuw"@de,
+    "Denderleeuw"@fr,
+    "Denderleeuw"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/41018> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/41000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/41018>,
+    <http://www.wikidata.org/entity/Q499532>,
+    <https://sws.geonames.org/2797639/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "41018" ;
+  skos:prefLabel "Geraardsbergen"@de,
+    "Grammont"@fr,
+    "Geraardsbergen"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/41024> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/41000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/41024>,
+    <http://www.wikidata.org/entity/Q911974>,
+    <https://sws.geonames.org/2796834/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "41024" ;
+  skos:prefLabel "Haaltert"@de,
+    "Haaltert"@fr,
+    "Haaltert"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/41027> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/41000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/41027>,
+    <http://www.wikidata.org/entity/Q587979>,
+    <https://sws.geonames.org/2795909/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "41027" ;
+  skos:prefLabel "Herzele"@de,
+    "Herzele"@fr,
+    "Herzele"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/41034> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/41000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/41034>,
+    <http://www.wikidata.org/entity/Q912113>,
+    <https://sws.geonames.org/2793079/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "41034" ;
+  skos:prefLabel "Lede"@de,
+    "Lede"@fr,
+    "Lede"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/41048> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/41000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/41048>,
+    <http://www.wikidata.org/entity/Q385026>,
+    <https://sws.geonames.org/2790115/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "41048" ;
+  skos:prefLabel "Ninove"@de,
+    "Ninove"@fr,
+    "Ninove"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/41063> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/41000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/41063>,
+    <http://www.wikidata.org/entity/Q817372>,
+    <https://sws.geonames.org/2786617/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "41063" ;
+  skos:prefLabel "Sint-Lievens-Houtem"@de,
+    "Sint-Lievens-Houtem"@fr,
+    "Sint-Lievens-Houtem"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/41081> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/41000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/41081>,
+    <http://www.wikidata.org/entity/Q226941>,
+    <https://sws.geonames.org/2783176/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "41081" ;
+  skos:prefLabel "Zottegem"@de,
+    "Zottegem"@fr,
+    "Zottegem"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/41082> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/41000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/41082>,
+    <http://www.wikidata.org/entity/Q817458>,
+    <https://sws.geonames.org/2798679/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "41082" ;
+  skos:prefLabel "Erpe-Mere"@de,
+    "Erpe-Mere"@fr,
+    "Erpe-Mere"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/42003> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/42000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/42003>,
+    <http://www.wikidata.org/entity/Q793584>,
+    <https://sws.geonames.org/2802155/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "42003" ;
+  skos:prefLabel "Berlare"@de,
+    "Berlare"@fr,
+    "Berlare"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/42004> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/42000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/42004>,
+    <http://www.wikidata.org/entity/Q202309>,
+    <https://sws.geonames.org/2800817/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "42004" ;
+  skos:prefLabel "Buggenhout"@de,
+    "Buggenhout"@fr,
+    "Buggenhout"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/42006> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/42000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/42006>,
+    <http://www.wikidata.org/entity/Q13122>,
+    <https://sws.geonames.org/2799646/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "42006" ;
+  skos:prefLabel "Dendermonde"@de,
+    "Termonde"@fr,
+    "Dendermonde"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/42008> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/42000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/42008>,
+    <http://www.wikidata.org/entity/Q391294>,
+    <https://sws.geonames.org/2796640/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "42008" ;
+  skos:prefLabel "Hamme"@de,
+    "Hamme"@fr,
+    "Hamme"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/42010> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/42000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/42010>,
+    <http://www.wikidata.org/entity/Q730696>,
+    <https://sws.geonames.org/2793798/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "42010" ;
+  skos:prefLabel "Laarne"@de,
+    "Laarne"@fr,
+    "Laarne"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/42011> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/42000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/42011>,
+    <http://www.wikidata.org/entity/Q504653>,
+    <https://sws.geonames.org/2793145/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "42011" ;
+  skos:prefLabel "Lebbeke"@de,
+    "Lebbeke"@fr,
+    "Lebbeke"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/42023> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/42000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/42023>,
+    <http://www.wikidata.org/entity/Q587906>,
+    <https://sws.geonames.org/2784232/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "42023" ;
+  skos:prefLabel "Waasmunster"@de,
+    "Waasmunster"@fr,
+    "Waasmunster"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/42025> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/42000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/42025>,
+    <http://www.wikidata.org/entity/Q643980>,
+    <https://sws.geonames.org/2783764/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "42025" ;
+  skos:prefLabel "Wetteren"@de,
+    "Wetteren"@fr,
+    "Wetteren"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/42026> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/42000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/42026>,
+    <http://www.wikidata.org/entity/Q730801>,
+    <https://sws.geonames.org/2783729/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "42026" ;
+  skos:prefLabel "Wichelen"@de,
+    "Wichelen"@fr,
+    "Wichelen"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/42028> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/42000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/42028>,
+    <http://www.wikidata.org/entity/Q388115>,
+    <https://sws.geonames.org/2783294/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "42028" ;
+  skos:prefLabel "Zele"@de,
+    "Zele"@fr,
+    "Zele"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/43002> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/43000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/43002>,
+    <http://www.wikidata.org/entity/Q12901>,
+    <https://sws.geonames.org/2803027/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "43002" ;
+  skos:prefLabel "Assenede"@de,
+    "Assenede"@fr,
+    "Assenede"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/43005> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/43000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/43005>,
+    <http://www.wikidata.org/entity/Q12440>,
+    <https://sws.geonames.org/2798988/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "43005" ;
+  skos:prefLabel "Eeklo"@de,
+    "Eeklo"@fr,
+    "Eeklo"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/43007> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/43000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/43007>,
+    <http://www.wikidata.org/entity/Q12437>,
+    <https://sws.geonames.org/2794708/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "43007" ;
+  skos:prefLabel "Kaprijke"@de,
+    "Kaprijke"@fr,
+    "Kaprijke"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/43010> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/43000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/43010>,
+    <http://www.wikidata.org/entity/Q12896>,
+    <https://sws.geonames.org/2791858/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "43010" ;
+  skos:prefLabel "Maldegem"@de,
+    "Maldegem"@fr,
+    "Maldegem"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/43014> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/43000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/43014>,
+    <http://www.wikidata.org/entity/Q13126>,
+    <https://sws.geonames.org/2786627/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "43014" ;
+  skos:prefLabel "Sint-Laureins"@de,
+    "Sint-Laureins"@fr,
+    "Sint-Laureins"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/43018> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/43000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/43018>,
+    <http://www.wikidata.org/entity/Q14062>,
+    <https://sws.geonames.org/2783279/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "43018" ;
+  skos:prefLabel "Zelzate"@de,
+    "Zelzate"@fr,
+    "Zelzate"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/44013> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/44000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/44013>,
+    <http://www.wikidata.org/entity/Q3177595>,
+    <https://sws.geonames.org/2799497/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "44013" ;
+  skos:prefLabel "Destelbergen"@de,
+    "Destelbergen"@fr,
+    "Destelbergen"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/44019> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/44000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/44019>,
+    <http://www.wikidata.org/entity/Q12997>,
+    <https://sws.geonames.org/2798553/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "44019" ;
+  skos:prefLabel "Evergem"@de,
+    "Evergem"@fr,
+    "Evergem"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/44020> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/44000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/44020>,
+    <http://www.wikidata.org/entity/Q690611>,
+    <https://sws.geonames.org/2797799/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "44020" ;
+  skos:prefLabel "Gavere"@de,
+    "Gavere"@fr,
+    "Gavere"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/44021> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/44000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/44021>,
+    <http://www.wikidata.org/entity/Q1296>,
+    <https://sws.geonames.org/2797657/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "44021" ;
+  skos:prefLabel "Gent"@de,
+    "Gand"@fr,
+    "Gent"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/44045> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/44000> ;
+  skos:exactMatch <http://www.wikidata.org/entity/Q397705>,
+    <https://sws.geonames.org/2791122/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "44045" ;
+  skos:prefLabel "Moerbeke"@de,
+    "Moerbeke"@fr,
+    "Moerbeke"@nl ;
+  ns1:endDate "2025-01-01T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/44052> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/44000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/44052>,
+    <http://www.wikidata.org/entity/Q842477>,
+    <https://sws.geonames.org/2789772/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "44052" ;
+  skos:prefLabel "Oosterzele"@de,
+    "Oosterzele"@fr,
+    "Oosterzele"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/44064> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/44000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/44064>,
+    <http://www.wikidata.org/entity/Q737538>,
+    <https://sws.geonames.org/2786592/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "44064" ;
+  skos:prefLabel "Sint-Martens-Latem"@de,
+    "Sint-Martens-Latem"@fr,
+    "Sint-Martens-Latem"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/44081> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/44000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/44081>,
+    <http://www.wikidata.org/entity/Q228863>,
+    <https://sws.geonames.org/2783152/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "44081" ;
+  skos:prefLabel "Zulte"@de,
+    "Zulte"@fr,
+    "Zulte"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/44083> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/44000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/44083>,
+    <http://www.wikidata.org/entity/Q499313>,
+    <https://sws.geonames.org/2799747/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrowMatch <http://www.wikidata.org/entity/Q822651>,
+    <https://sws.geonames.org/2790236/> ;
+  skos:notation "44083" ;
+  skos:prefLabel "Deinze"@de,
+    "Deinze"@fr,
+    "Deinze"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/44084> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/44000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/44084>,
+    <http://www.wikidata.org/entity/Q300970>,
+    <https://sws.geonames.org/2803444/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrowMatch <http://www.wikidata.org/entity/Q912069>,
+    <https://sws.geonames.org/2794224/> ;
+  skos:notation "44084" ;
+  skos:prefLabel "Aalter"@de,
+    "Aalter"@fr,
+    "Aalter"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/44085> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/44000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/44085>,
+    <https://sws.geonames.org/11994860/>,
+    <https://www.wikidata.org/entity/Q46865167> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrowMatch <http://www.wikidata.org/entity/Q219827>,
+    <http://www.wikidata.org/entity/Q840968>,
+    <http://www.wikidata.org/entity/Q911983>,
+    <https://sws.geonames.org/2783196/>,
+    <https://sws.geonames.org/2784238/>,
+    <https://sws.geonames.org/2792058/> ;
+  skos:notation "44085" ;
+  skos:prefLabel "Lievegem"@de,
+    "Lievegem"@fr,
+    "Lievegem"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/44086> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/44000> ;
+  skos:exactMatch <http://www.wikidata.org/entity/Q580315>,
+    <https://sws.geonames.org/2790435/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrowMatch <http://vocab.belgif.be/auth/refnis2019/44012>,
+    <http://vocab.belgif.be/auth/refnis2019/44048> ;
+  skos:notation "44086" ;
+  skos:prefLabel "Nazareth-De Pinte"@de,
+    "Nazareth-De Pinte"@fr,
+    "Nazareth-De Pinte"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2025-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/44087> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/44000> ;
+  skos:exactMatch <http://www.wikidata.org/entity/Q735827>,
+    <https://sws.geonames.org/2792236/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrowMatch <http://vocab.belgif.be/auth/refnis2019/44034>,
+    <http://vocab.belgif.be/auth/refnis2019/44073> ;
+  skos:notation "44087" ;
+  skos:prefLabel "Lochristi"@de,
+    "Lochristi"@fr,
+    "Lochristi"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2025-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/44088> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/44000> ;
+  skos:exactMatch <http://www.wikidata.org/entity/Q187755>,
+    <https://sws.geonames.org/2791316/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrowMatch <http://vocab.belgif.be/auth/refnis2019/44040>,
+    <http://vocab.belgif.be/auth/refnis2019/44043> ;
+  skos:notation "44088" ;
+  skos:prefLabel "Merelbeke-Melle"@de,
+    "Merelbeke-Melle"@fr,
+    "Merelbeke-Melle"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2025-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/45035> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/45000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/45035>,
+    <http://www.wikidata.org/entity/Q12992>,
+    <https://sws.geonames.org/2789530/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "45035" ;
+  skos:prefLabel "Oudenaarde"@de,
+    "Audenarde"@fr,
+    "Oudenaarde"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/45041> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/45000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/45041>,
+    <http://www.wikidata.org/entity/Q268219>,
+    <https://sws.geonames.org/2787770/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "45041" ;
+  skos:prefLabel "Ronse"@de,
+    "Renaix"@fr,
+    "Ronse"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/45059> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/45000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/45059>,
+    <http://www.wikidata.org/entity/Q845980>,
+    <https://sws.geonames.org/2790422/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "45059" ;
+  skos:prefLabel "Brakel"@de,
+    "Brakel"@fr,
+    "Brakel"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/45060> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/45000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/45060>,
+    <http://www.wikidata.org/entity/Q840517>,
+    <https://sws.geonames.org/2794234/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "45060" ;
+  skos:prefLabel "Kluisbergen"@de,
+    "Kluisbergen"@fr,
+    "Kluisbergen"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/45061> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/45000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/45061>,
+    <http://www.wikidata.org/entity/Q840935>,
+    <https://sws.geonames.org/2783450/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "45061" ;
+  skos:prefLabel "Wortegem-Petegem"@de,
+    "Wortegem-Petegem"@fr,
+    "Wortegem-Petegem"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/45062> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/45000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/45062>,
+    <http://www.wikidata.org/entity/Q912076>,
+    <https://sws.geonames.org/2786637/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "45062" ;
+  skos:prefLabel "Horebeke"@de,
+    "Horebeke"@fr,
+    "Horebeke"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/45063> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/45000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/45063>,
+    <http://www.wikidata.org/entity/Q648509>,
+    <https://sws.geonames.org/2786604/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "45063" ;
+  skos:prefLabel "Lierde"@de,
+    "Lierde"@fr,
+    "Lierde"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/45064> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/45000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/45064>,
+    <http://www.wikidata.org/entity/Q912099>,
+    <https://sws.geonames.org/2791971/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "45064" ;
+  skos:prefLabel "Maarkedal"@de,
+    "Maarkedal"@fr,
+    "Maarkedal"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/45065> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/45000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/45065>,
+    <http://www.wikidata.org/entity/Q231568>,
+    <https://sws.geonames.org/2790540/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "45065" ;
+  skos:prefLabel "Zwalm"@de,
+    "Zwalin"@fr,
+    "Zwalm"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/45068> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/45000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/45068>,
+    <http://www.wikidata.org/entity/Q46865464>,
+    <https://sws.geonames.org/11994886/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrowMatch <http://www.wikidata.org/entity/Q204477>,
+    <http://www.wikidata.org/entity/Q817375>,
+    <https://sws.geonames.org/2783216/>,
+    <https://sws.geonames.org/2793908/> ;
+  skos:notation "45068" ;
+  skos:prefLabel "Kruisem"@de,
+    "Kruisem"@fr,
+    "Kruisem"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/46020> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/46000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/46020>,
+    <http://www.wikidata.org/entity/Q430510>,
+    <https://sws.geonames.org/2786695/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "46020" ;
+  skos:prefLabel "Sint-Gillis-Waas"@de,
+    "Sint-Gillis-Waas"@fr,
+    "Sint-Gillis-Waas"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/46021> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/46000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/46021>,
+    <http://www.wikidata.org/wiki/Q13127>,
+    <https://sws.geonames.org/2786579/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "46021" ;
+  skos:prefLabel "Sint-Niklaas"@de,
+    "Saint-Nicolas"@fr,
+    "Sint-Niklaas"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/46024> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/46000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/46024>,
+    <http://www.wikidata.org/entity/Q735851>,
+    <https://sws.geonames.org/2786088/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "46024" ;
+  skos:prefLabel "Stekene"@de,
+    "Stekene"@fr,
+    "Stekene"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/46025> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/46000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/46025>,
+    <http://www.wikidata.org/entity/Q823623>,
+    <https://sws.geonames.org/2785779/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "46025" ;
+  skos:prefLabel "Temse"@de,
+    "Tamise"@fr,
+    "Temse"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/46029> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/46000> ;
+  skos:exactMatch <http://www.wikidata.org/entity/Q12910>,
+    <https://sws.geonames.org/2792197/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrowMatch <http://vocab.belgif.be/auth/refnis2019/44045>,
+    <http://vocab.belgif.be/auth/refnis2019/46014> ;
+  skos:notation "46029" ;
+  skos:prefLabel "Lokeren"@de,
+    "Lokeren"@fr,
+    "Lokeren"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2025-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/46030> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/46000> ;
+  skos:exactMatch <http://www.wikidata.org/entity/Q270644>,
+    <https://sws.geonames.org/2802035/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrowMatch <http://vocab.belgif.be/auth/refnis2019/11056>,
+    <http://vocab.belgif.be/auth/refnis2019/46003>,
+    <http://vocab.belgif.be/auth/refnis2019/46013> ;
+  skos:notation "46030" ;
+  skos:prefLabel "Beveren-Kruibeke-Zwijndrecht"@de,
+    "Beveren-Kruibeke-Zwijndrecht"@fr,
+    "Beveren-Kruibeke-Zwijndrecht"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2025-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/51004> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/51000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/51004>,
+    <http://www.wikidata.org/entity/Q95096>,
+    <https://sws.geonames.org/2803011/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "51004" ;
+  skos:prefLabel "Ath"@de,
+    "Ath"@fr,
+    "Aat"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/51008> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/51000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/51008>,
+    <http://www.wikidata.org/entity/Q95105>,
+    <https://sws.geonames.org/2802294/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "51008" ;
+  skos:prefLabel "Beloeil"@de,
+    "Beloeil"@fr,
+    "Beloeil"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/51009> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/51000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/51009>,
+    <http://www.wikidata.org/entity/Q95112>,
+    <https://sws.geonames.org/2802136/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "51009" ;
+  skos:prefLabel "Bernissart"@de,
+    "Bernissart"@fr,
+    "Bernissart"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/51012> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/51000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/51012>,
+    <http://www.wikidata.org/entity/Q95130>,
+    <https://sws.geonames.org/2800937/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "51012" ;
+  skos:prefLabel "Brugelette"@de,
+    "Brugelette"@fr,
+    "Brugelette"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/51014> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/51000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/51014>,
+    <http://www.wikidata.org/entity/Q95318>,
+    <https://sws.geonames.org/2800329/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "51014" ;
+  skos:prefLabel "Chièvres"@de,
+    "Chièvres"@fr,
+    "Chièvres"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/51017> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/51000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/51017>,
+    <http://www.wikidata.org/entity/Q665992>,
+    <https://sws.geonames.org/2798837/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "51017" ;
+  skos:prefLabel "Ellezelles"@de,
+    "Ellezelles"@fr,
+    "Elzele"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/51019> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/51000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/51019>,
+    <http://www.wikidata.org/entity/Q666559>,
+    <https://sws.geonames.org/2798291/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "51019" ;
+  skos:prefLabel "Flobecq"@de,
+    "Flobecq"@fr,
+    "Vloesberg"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/51065> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/51000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/51065>,
+    <http://www.wikidata.org/entity/Q666813>,
+    <https://sws.geonames.org/2797980/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "51065" ;
+  skos:prefLabel "Frasnes-lez-Anvaing"@de,
+    "Frasnes-lez-Anvaing"@fr,
+    "Frasnes-lez-Anvaing"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/51067> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/51000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/51067>,
+    <http://www.wikidata.org/entity/Q666238>,
+    <https://sws.geonames.org/2798748/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "51067" ;
+  skos:prefLabel "Enghien"@de,
+    "Enghien"@fr,
+    "Edingen"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/51068> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/51000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/51068>,
+    <http://www.wikidata.org/entity/Q669088>,
+    <https://sws.geonames.org/2786770/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "51068" ;
+  skos:prefLabel "Silly"@de,
+    "Silly"@fr,
+    "Opzullik"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/51069> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/51000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/51069>,
+    <http://www.wikidata.org/entity/Q667790>,
+    <https://sws.geonames.org/2792568/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "51069" ;
+  skos:prefLabel "Lessines"@de,
+    "Lessines"@fr,
+    "Lessen"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/52010> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/52000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/52010>,
+    <http://www.wikidata.org/entity/Q95140>,
+    <https://sws.geonames.org/2800501/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "52010" ;
+  skos:prefLabel "Chapelle-lez-Herlaimont"@de,
+    "Chapelle-lez-Herlaimont"@fr,
+    "Chapelle-lez-Herlaimont"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/52011> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/52000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/52011>,
+    <http://www.wikidata.org/entity/Q81046>,
+    <https://sws.geonames.org/2800482/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "52011" ;
+  skos:prefLabel "Charleroi"@de,
+    "Charleroi"@fr,
+    "Charleroi"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/52012> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/52000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/52012>,
+    <http://www.wikidata.org/entity/Q95144>,
+    <https://sws.geonames.org/2800449/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "52012" ;
+  skos:prefLabel "Châtelet"@de,
+    "Châtelet"@fr,
+    "Châtelet"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/52015> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/52000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/52015>,
+    <http://www.wikidata.org/entity/Q665860>,
+    <https://sws.geonames.org/2800064/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "52015" ;
+  skos:prefLabel "Courcelles"@de,
+    "Courcelles"@fr,
+    "Courcelles"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/52018> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/52000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/52018>,
+    <http://www.wikidata.org/entity/Q666503>,
+    <https://sws.geonames.org/2798471/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "52018" ;
+  skos:prefLabel "Farciennes"@de,
+    "Farciennes"@fr,
+    "Farciennes"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/52021> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/52000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/52021>,
+    <http://www.wikidata.org/entity/Q314922>,
+    <https://sws.geonames.org/2798298/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "52021" ;
+  skos:prefLabel "Fleurus"@de,
+    "Fleurus"@fr,
+    "Fleurus"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/52022> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/52000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/52022>,
+    <http://www.wikidata.org/entity/Q666696>,
+    <https://sws.geonames.org/2798185/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "52022" ;
+  skos:prefLabel "Fontaine-l’Evêque"@de,
+    "Fontaine-l’Evêque"@fr,
+    "Fontaine-l’Evêque"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/52025> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/52000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/52025>,
+    <http://www.wikidata.org/entity/Q666902>,
+    <https://sws.geonames.org/2797599/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "52025" ;
+  skos:prefLabel "Gerpinnes"@de,
+    "Gerpinnes"@fr,
+    "Gerpinnes"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/52048> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/52000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/52048>,
+    <http://www.wikidata.org/entity/Q668437>,
+    <https://sws.geonames.org/2790805/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "52048" ;
+  skos:prefLabel "Montigny-le-Tilleul"@de,
+    "Montigny-le-Tilleul"@fr,
+    "Montigny-le-Tilleul"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/52055> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/52000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/52055>,
+    <http://www.wikidata.org/entity/Q607182>,
+    <https://sws.geonames.org/2788766/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "52055" ;
+  skos:prefLabel "Pont-à-Celles"@de,
+    "Pont-à-Celles"@fr,
+    "Pont-à-Celles"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/52074> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/52000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/52074>,
+    <http://www.wikidata.org/entity/Q95004>,
+    <https://sws.geonames.org/2803324/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "52074" ;
+  skos:prefLabel "Aiseau-Presles"@de,
+    "Aiseau-Presles"@fr,
+    "Aiseau-Presles"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/52075> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/52000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/52075>,
+    <http://www.wikidata.org/entity/Q95123>,
+    <https://sws.geonames.org/2784626/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "52075" ;
+  skos:prefLabel "Les Bons Villers"@de,
+    "Les Bons Villers"@fr,
+    "Les Bons Villers"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/53014> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/53000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/53014>,
+    <http://www.wikidata.org/entity/Q95126>,
+    <https://sws.geonames.org/2801227/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "53014" ;
+  skos:prefLabel "Boussu"@de,
+    "Boussu"@fr,
+    "Boussu"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/53020> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/53000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/53020>,
+    <http://www.wikidata.org/entity/Q665938>,
+    <https://sws.geonames.org/2799227/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "53020" ;
+  skos:prefLabel "Dour"@de,
+    "Dour"@fr,
+    "Dour"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/53028> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/53000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/53028>,
+    <http://www.wikidata.org/entity/Q666751>,
+    <https://sws.geonames.org/2798024/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "53028" ;
+  skos:prefLabel "Frameries"@de,
+    "Frameries"@fr,
+    "Frameries"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/53039> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/53000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/53039>,
+    <http://www.wikidata.org/entity/Q666983>,
+    <https://sws.geonames.org/2796057/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "53039" ;
+  skos:prefLabel "Hensies"@de,
+    "Hensies"@fr,
+    "Hensies"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/53044> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/53000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/53044>,
+    <http://www.wikidata.org/entity/Q377152>,
+    <https://sws.geonames.org/2794853/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "53044" ;
+  skos:prefLabel "Jurbise"@de,
+    "Jurbise"@fr,
+    "Jurbeke"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/53046> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/53000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/53046>,
+    <http://www.wikidata.org/entity/Q667158>,
+    <https://sws.geonames.org/2792872/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "53046" ;
+  skos:prefLabel "Lens"@de,
+    "Lens"@fr,
+    "Lens"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/53053> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/53000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/53053>,
+    <http://www.wikidata.org/entity/Q83407>,
+    <https://sws.geonames.org/2790871/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "53053" ;
+  skos:prefLabel "Mons"@de,
+    "Mons"@fr,
+    "Bergen"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/53065> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/53000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/53065>,
+    <http://www.wikidata.org/entity/Q538735>,
+    <https://sws.geonames.org/2788500/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "53065" ;
+  skos:prefLabel "Quaregnon"@de,
+    "Quaregnon"@fr,
+    "Quaregnon"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/53068> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/53000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/53068>,
+    <http://www.wikidata.org/entity/Q668815>,
+    <https://sws.geonames.org/2788445/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "53068" ;
+  skos:prefLabel "Quiévrain"@de,
+    "Quiévrain"@fr,
+    "Quiévrain"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/53070> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/53000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/53070>,
+    <http://www.wikidata.org/entity/Q668950>,
+    <https://sws.geonames.org/2787417/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "53070" ;
+  skos:prefLabel "Saint-Ghislain"@de,
+    "Saint-Ghislain"@fr,
+    "Saint-Ghislain"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/53082> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/53000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/53082>,
+    <http://www.wikidata.org/entity/Q665573>,
+    <https://sws.geonames.org/2800221/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "53082" ;
+  skos:prefLabel "Colfontaine"@de,
+    "Colfontaine"@fr,
+    "Colfontaine"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/53083> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/53000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/53083>,
+    <http://www.wikidata.org/entity/Q667091>,
+    <https://sws.geonames.org/2802909/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "53083" ;
+  skos:prefLabel "Honnelles"@de,
+    "Honnelles"@fr,
+    "Honnelles"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/53084> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/53000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/53084>,
+    <http://www.wikidata.org/entity/Q668702>,
+    <https://sws.geonames.org/2788448/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "53084" ;
+  skos:prefLabel "Quévy"@de,
+    "Quévy"@fr,
+    "Quévy"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/55004> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/55000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/55004>,
+    <http://www.wikidata.org/entity/Q95129>,
+    <https://sws.geonames.org/2801151/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "55004" ;
+  skos:prefLabel "Braine-le-Comte"@de,
+    "Braine-le-Comte"@fr,
+    "’s Gravenbrakel"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/55035> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/55000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/55035>,
+    <http://www.wikidata.org/entity/Q668861>,
+    <https://sws.geonames.org/2787879/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "55035" ;
+  skos:prefLabel "Le Roeulx"@de,
+    "Le Roeulx"@fr,
+    "Le Roeulx"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/55040> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/55000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/55040>,
+    <http://www.wikidata.org/entity/Q462985>,
+    <https://sws.geonames.org/2786421/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "55040" ;
+  skos:prefLabel "Soignies"@de,
+    "Soignies"@fr,
+    "Zinnik"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/55050> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/55000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/55050>,
+    <http://www.wikidata.org/entity/Q273316>,
+    <https://sws.geonames.org/2791740/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "55050" ;
+  skos:prefLabel "Ecaussinnes"@de,
+    "Ecaussinnes"@fr,
+    "Ecaussinnes"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/55085> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/55000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/55085>,
+    <http://www.wikidata.org/entity/Q669051>,
+    <https://sws.geonames.org/2786853/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "55085" ;
+  skos:prefLabel "Seneffe"@de,
+    "Seneffe"@fr,
+    "Seneffe"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/55086> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/55000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/55086>,
+    <http://www.wikidata.org/entity/Q667987>,
+    <https://sws.geonames.org/2791815/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "55086" ;
+  skos:prefLabel "Manage"@de,
+    "Manage"@fr,
+    "Manage"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/56001> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/56000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/56001>,
+    <http://www.wikidata.org/entity/Q95005>,
+    <https://sws.geonames.org/2803200/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "56001" ;
+  skos:prefLabel "Anderlues"@de,
+    "Anderlues"@fr,
+    "Anderlues"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/56005> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/56000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/56005>,
+    <http://www.wikidata.org/entity/Q95100>,
+    <https://sws.geonames.org/2802511/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "56005" ;
+  skos:prefLabel "Beaumont"@de,
+    "Beaumont"@fr,
+    "Beaumont"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/56016> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/56000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/56016>,
+    <http://www.wikidata.org/entity/Q95380>,
+    <https://sws.geonames.org/2800326/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "56016" ;
+  skos:prefLabel "Chimay"@de,
+    "Chimay"@fr,
+    "Chimay"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/56022> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/56000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/56022>,
+    <http://www.wikidata.org/entity/Q666335>,
+    <https://sws.geonames.org/2798667/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "56022" ;
+  skos:prefLabel "Erquelinnes"@de,
+    "Erquelinnes"@fr,
+    "Erquelinnes"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/56029> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/56000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/56029>,
+    <http://www.wikidata.org/entity/Q666853>,
+    <https://sws.geonames.org/2797938/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "56029" ;
+  skos:prefLabel "Froidchapelle"@de,
+    "Froidchapelle"@fr,
+    "Froidchapelle"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/56044> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/56000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/56044>,
+    <http://www.wikidata.org/entity/Q667936>,
+    <https://sws.geonames.org/2792246/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "56044" ;
+  skos:prefLabel "Lobbes"@de,
+    "Lobbes"@fr,
+    "Lobbes"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/56049> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/56000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/56049>,
+    <http://www.wikidata.org/entity/Q668139>,
+    <https://sws.geonames.org/2791330/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "56049" ;
+  skos:prefLabel "Merbes-le-Château"@de,
+    "Merbes-le-Château"@fr,
+    "Merbes-le-Château"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/56051> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/56000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/56051>,
+    <http://www.wikidata.org/entity/Q668187>,
+    <https://sws.geonames.org/2790907/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "56051" ;
+  skos:prefLabel "Momignies"@de,
+    "Momignies"@fr,
+    "Momignies"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/56078> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/56000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/56078>,
+    <http://www.wikidata.org/entity/Q669186>,
+    <https://sws.geonames.org/2785518/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "56078" ;
+  skos:prefLabel "Thuin"@de,
+    "Thuin"@fr,
+    "Thuin"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/56086> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/56000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/56086>,
+    <http://www.wikidata.org/entity/Q666952>,
+    <https://sws.geonames.org/2796617/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "56086" ;
+  skos:prefLabel "Ham-sur-Heure-Nalinnes"@de,
+    "Ham-sur-Heure-Nalinnes"@fr,
+    "Ham-sur-Heure-Nalinnes"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/56088> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/56000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/56088>,
+    <http://www.wikidata.org/entity/Q669136>,
+    <https://sws.geonames.org/2786531/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "56088" ;
+  skos:prefLabel "Sivry-Rance"@de,
+    "Sivry-Rance"@fr,
+    "Sivry-Rance"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/57003> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/57000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/57003>,
+    <http://www.wikidata.org/entity/Q95011>,
+    <https://sws.geonames.org/2803145/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "57003" ;
+  skos:prefLabel "Antoing"@de,
+    "Antoing"@fr,
+    "Antoing"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/57018> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/57000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/57018>,
+    <http://www.wikidata.org/entity/Q95136>,
+    <https://sws.geonames.org/2800608/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "57018" ;
+  skos:prefLabel "Celles"@de,
+    "Celles"@fr,
+    "Celles"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/57027> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/57000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/57027>,
+    <http://www.wikidata.org/entity/Q666393>,
+    <https://sws.geonames.org/2798605/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "57027" ;
+  skos:prefLabel "Estaimpuis"@de,
+    "Estaimpuis"@fr,
+    "Estaimpuis"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/57062> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/57000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/57062>,
+    <http://www.wikidata.org/entity/Q668540>,
+    <https://sws.geonames.org/2789237/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "57062" ;
+  skos:prefLabel "Pecq"@de,
+    "Pecq"@fr,
+    "Pecq"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/57064> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/57000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/57064>,
+    <http://www.wikidata.org/entity/Q668630>,
+    <https://sws.geonames.org/2789163/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "57064" ;
+  skos:prefLabel "Péruwelz"@de,
+    "Péruwelz"@fr,
+    "Péruwelz"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/57072> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/57000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/57072>,
+    <http://www.wikidata.org/entity/Q668903>,
+    <https://sws.geonames.org/2787531/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "57072" ;
+  skos:prefLabel "Rumes"@de,
+    "Rumes"@fr,
+    "Rumes"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/57081> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/57000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/57081>,
+    <http://www.wikidata.org/entity/Q173219>,
+    <https://sws.geonames.org/2785342/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "57081" ;
+  skos:prefLabel "Tournai"@de,
+    "Tournai"@fr,
+    "Doornik"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/57093> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/57000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/57093>,
+    <http://www.wikidata.org/entity/Q95132>,
+    <https://sws.geonames.org/2801819/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "57093" ;
+  skos:prefLabel "Brunehaut"@de,
+    "Brunehaut"@fr,
+    "Brunehaut"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/57094> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/57000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/57094>,
+    <http://www.wikidata.org/entity/Q667862>,
+    <https://sws.geonames.org/2792477/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "57094" ;
+  skos:prefLabel "Leuze-en-Hainaut"@de,
+    "Leuze-en-Hainaut"@fr,
+    "Leuze-en-Hainaut"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/57095> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/57000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/57095>,
+    <http://www.wikidata.org/entity/Q668295>,
+    <https://sws.geonames.org/2803156/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "57095" ;
+  skos:prefLabel "Mont-de-l’Enclus"@de,
+    "Mont-de-l’Enclus"@fr,
+    "Mont-de-l’Enclus"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/57096> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/57000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/57096>,
+    <http://www.wikidata.org/entity/Q220145>,
+    <https://sws.geonames.org/2795937/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "57096" ;
+  skos:prefLabel "Mouscron"@de,
+    "Mouscron"@fr,
+    "Moeskroen"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/57097> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/57000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/57097>,
+    <http://www.wikidata.org/entity/Q665761>,
+    <https://sws.geonames.org/2800196/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "57097" ;
+  skos:prefLabel "Comines-Warneton"@de,
+    "Comines-Warneton"@fr,
+    "Komen-Waasten"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/58001> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/58000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/58001>,
+    <http://www.wikidata.org/entity/Q211572>,
+    <https://sws.geonames.org/2793509/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "55022" ;
+  skos:prefLabel "La Louvière"@de,
+    "La Louvière"@fr,
+    "La Louvière"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/58002> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/58000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/58002>,
+    <http://www.wikidata.org/entity/Q95121>,
+    <https://sws.geonames.org/2801923/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "58002" ;
+  skos:prefLabel "Binche"@de,
+    "Binche"@fr,
+    "Binche"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/58003> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/58000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/58003>,
+    <http://www.wikidata.org/entity/Q666446>,
+    <https://sws.geonames.org/2798598/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "58003" ;
+  skos:prefLabel "Estinnes"@de,
+    "Estinnes"@fr,
+    "Estinnes"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/58004> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/58000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/58004>,
+    <http://www.wikidata.org/entity/Q668493>,
+    <https://sws.geonames.org/2790698/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "58004" ;
+  skos:prefLabel "Morlanwelz"@de,
+    "Morlanwelz"@fr,
+    "Morlanwelz"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/61003> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/61000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/61003>,
+    <http://www.wikidata.org/entity/Q455969>,
+    <https://sws.geonames.org/2803247/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "61003" ;
+  skos:prefLabel "Amay"@de,
+    "Amay"@fr,
+    "Amay"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/61010> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/61000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/61010>,
+    <http://www.wikidata.org/entity/Q681368>,
+    <https://sws.geonames.org/2800762/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "61010" ;
+  skos:prefLabel "Burdinne"@de,
+    "Burdinne"@fr,
+    "Burdinne"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/61012> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/61000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/61012>,
+    <http://www.wikidata.org/entity/Q681854>,
+    <https://sws.geonames.org/2800270/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "61012" ;
+  skos:prefLabel "Clavier"@de,
+    "Clavier"@fr,
+    "Clavier"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/61019> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/61000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/61019>,
+    <http://www.wikidata.org/entity/Q682570>,
+    <https://sws.geonames.org/2798367/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "61019" ;
+  skos:prefLabel "Ferrières"@de,
+    "Ferrières"@fr,
+    "Ferrières"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/61024> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/61000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/61024>,
+    <http://www.wikidata.org/entity/Q683083>,
+    <https://sws.geonames.org/2796630/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "61024" ;
+  skos:prefLabel "Hamoir"@de,
+    "Hamoir"@fr,
+    "Hamoir"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/61028> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/61000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/61028>,
+    <http://www.wikidata.org/entity/Q683321>,
+    <https://sws.geonames.org/2795950/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "61028" ;
+  skos:prefLabel "Héron"@de,
+    "Héron"@fr,
+    "Héron"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/61031> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/61000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/61031>,
+    <http://www.wikidata.org/entity/Q207095>,
+    <https://sws.geonames.org/2795114/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "61031" ;
+  skos:prefLabel "Huy"@de,
+    "Huy"@fr,
+    "Hoei"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/61039> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/61000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/61039>,
+    <http://www.wikidata.org/entity/Q710190>,
+    <https://sws.geonames.org/2791734/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "61039" ;
+  skos:prefLabel "Marchin"@de,
+    "Marchin"@fr,
+    "Marchin"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/61041> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/61000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/61041>,
+    <http://www.wikidata.org/entity/Q710237>,
+    <https://sws.geonames.org/2791133/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "61041" ;
+  skos:prefLabel "Modave"@de,
+    "Modave"@fr,
+    "Modave"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/61043> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/61000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/61043>,
+    <http://www.wikidata.org/entity/Q710280>,
+    <https://sws.geonames.org/2790468/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "61043" ;
+  skos:prefLabel "Nandrin"@de,
+    "Nandrin"@fr,
+    "Nandrin"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/61048> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/61000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/61048>,
+    <http://www.wikidata.org/entity/Q222233>,
+    <https://sws.geonames.org/2789480/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "61048" ;
+  skos:prefLabel "Ouffet"@de,
+    "Ouffet"@fr,
+    "Ouffet"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/61063> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/61000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/61063>,
+    <http://www.wikidata.org/entity/Q711292>,
+    <https://sws.geonames.org/2784859/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "61063" ;
+  skos:prefLabel "Verlaine"@de,
+    "Verlaine"@fr,
+    "Verlaine"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/61068> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/61000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/61068>,
+    <http://www.wikidata.org/entity/Q711373>,
+    <https://sws.geonames.org/2784640/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "61068" ;
+  skos:prefLabel "Villers-Le-Bouillet"@de,
+    "Villers-Le-Bouillet"@fr,
+    "Villers-Le-Bouillet"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/61072> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/61000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/61072>,
+    <http://www.wikidata.org/entity/Q711443>,
+    <https://sws.geonames.org/2784093/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "61072" ;
+  skos:prefLabel "Wanze"@de,
+    "Wanze"@fr,
+    "Wanze"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/61079> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/61000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/61079>,
+    <http://www.wikidata.org/entity/Q572472>,
+    <https://sws.geonames.org/2803149/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "61079" ;
+  skos:prefLabel "Anthisnes"@de,
+    "Anthisnes"@fr,
+    "Anthisnes"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/61080> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/61000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/61080>,
+    <http://www.wikidata.org/entity/Q682223>,
+    <https://sws.geonames.org/2798744/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "61080" ;
+  skos:prefLabel "Engis"@de,
+    "Engis"@fr,
+    "Engis"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/61081> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/61000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/61081>,
+    <http://www.wikidata.org/entity/Q711152>,
+    <https://sws.geonames.org/2786426/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "61081" ;
+  skos:prefLabel "Tinlot"@de,
+    "Tinlot"@fr,
+    "Tinlot"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/62003> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/62000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/62003>,
+    <http://www.wikidata.org/entity/Q499594>,
+    <https://sws.geonames.org/2803161/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "62003" ;
+  skos:prefLabel "Ans"@de,
+    "Ans"@fr,
+    "Ans"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/62006> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/62000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/62006>,
+    <http://www.wikidata.org/entity/Q680564>,
+    <https://sws.geonames.org/2802851/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "62006" ;
+  skos:prefLabel "Awans"@de,
+    "Awans"@fr,
+    "Awans"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/62009> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/62000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/62009>,
+    <http://www.wikidata.org/entity/Q793396>,
+    <https://sws.geonames.org/2802838/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "62009" ;
+  skos:prefLabel "Aywaille"@de,
+    "Aywaille"@fr,
+    "Aywaille"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/62011> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/62000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/62011>,
+    <http://www.wikidata.org/entity/Q680918>,
+    <https://sws.geonames.org/2802607/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "62011" ;
+  skos:prefLabel "Bassenge"@de,
+    "Bassenge"@fr,
+    "Bitsingen"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/62015> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/62000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/62015>,
+    <http://www.wikidata.org/entity/Q681039>,
+    <https://sws.geonames.org/2802016/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "62015" ;
+  skos:prefLabel "Beyne-Heusay"@de,
+    "Beyne-Heusay"@fr,
+    "Beyne-Heusay"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/62022> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/62000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/62022>,
+    <http://www.wikidata.org/entity/Q503363>,
+    <https://sws.geonames.org/2800439/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "62022" ;
+  skos:prefLabel "Chaudfontaine"@de,
+    "Chaudfontaine"@fr,
+    "Chaudfontaine"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/62026> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/62000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/62026>,
+    <http://www.wikidata.org/entity/Q681909>,
+    <https://sws.geonames.org/2800205/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "62026" ;
+  skos:prefLabel "Comblain-au-Pont"@de,
+    "Comblain-au-Pont"@fr,
+    "Comblain-au-Pont"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/62027> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/62000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/62027>,
+    <http://www.wikidata.org/entity/Q846182>,
+    <https://sws.geonames.org/2799898/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "62027" ;
+  skos:prefLabel "Dalhem"@de,
+    "Dalhem"@fr,
+    "Dalhem"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/62032> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/62000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/62032>,
+    <http://www.wikidata.org/entity/Q682271>,
+    <https://sws.geonames.org/2798637/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "62032" ;
+  skos:prefLabel "Esneux"@de,
+    "Esneux"@fr,
+    "Esneux"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/62038> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/62000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/62038>,
+    <http://www.wikidata.org/entity/Q682811>,
+    <https://sws.geonames.org/2798302/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "62038" ;
+  skos:prefLabel "Fléron"@de,
+    "Fléron"@fr,
+    "Fléron"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/62051> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/62000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/62051>,
+    <http://www.wikidata.org/entity/Q211033>,
+    <https://sws.geonames.org/2795931/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "62051" ;
+  skos:prefLabel "Herstal"@de,
+    "Herstal"@fr,
+    "Herstal"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/62060> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/62000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/62060>,
+    <http://www.wikidata.org/entity/Q914102>,
+    <https://sws.geonames.org/2794855/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "62060" ;
+  skos:prefLabel "Juprelle"@de,
+    "Juprelle"@fr,
+    "Juprelle"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/62063> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/62000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/62063>,
+    <http://www.wikidata.org/entity/Q3992>,
+    <https://sws.geonames.org/2792414/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "62063" ;
+  skos:prefLabel "Lüttich"@de,
+    "Liège"@fr,
+    "Luik"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/62079> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/62000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/62079>,
+    <http://www.wikidata.org/entity/Q286215>,
+    <https://sws.geonames.org/2789472/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "62079" ;
+  skos:prefLabel "Oupeye"@de,
+    "Oupeye"@fr,
+    "Oupeye"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/62093> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/62000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/62093>,
+    <http://www.wikidata.org/entity/Q65062>,
+    <https://sws.geonames.org/2787357/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "62093" ;
+  skos:prefLabel "Saint-Nicolas"@de,
+    "Saint-Nicolas"@fr,
+    "Saint-Nicolas"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/62096> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/62000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/62096>,
+    <http://www.wikidata.org/entity/Q194037>,
+    <https://sws.geonames.org/2786825/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "62096" ;
+  skos:prefLabel "Seraing"@de,
+    "Seraing"@fr,
+    "Seraing"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/62099> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/62000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/62099>,
+    <http://www.wikidata.org/entity/Q696099>,
+    <https://sws.geonames.org/2786345/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "62099" ;
+  skos:prefLabel "Soumagne"@de,
+    "Soumagne"@fr,
+    "Soumagne"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/62100> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/62000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/62100>,
+    <http://www.wikidata.org/entity/Q696110>,
+    <https://sws.geonames.org/2786244/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "62100" ;
+  skos:prefLabel "Sprimont"@de,
+    "Sprimont"@fr,
+    "Sprimont"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/62108> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/62000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/62108>,
+    <http://www.wikidata.org/entity/Q49743>,
+    <https://sws.geonames.org/2784549/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "62108" ;
+  skos:prefLabel "Visé"@de,
+    "Visé"@fr,
+    "Wezet"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/62118> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/62000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/62118>,
+    <http://www.wikidata.org/entity/Q683034>,
+    <https://sws.geonames.org/2797337/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "62118" ;
+  skos:prefLabel "Grâce-Hollogne"@de,
+    "Grâce-Hollogne"@fr,
+    "Grâce-Hollogne"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/62119> a skos:Concept ;
+  skos:altLabel "Blégny"@de,
+    "Blégny"@fr,
+    "Blégny"@nl ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/62000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/62119>,
+    <http://www.wikidata.org/entity/Q681109>,
+    <https://sws.geonames.org/2802681/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "62119" ;
+  skos:prefLabel "Blegny"@de,
+    "Blegny"@fr,
+    "Blegny"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/62120> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/62000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/62120>,
+    <http://www.wikidata.org/entity/Q175322>,
+    <https://sws.geonames.org/2798310/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "62120" ;
+  skos:prefLabel "Flémalle"@de,
+    "Flémalle"@fr,
+    "Flémalle"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/62121> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/62000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/62121>,
+    <http://www.wikidata.org/entity/Q710316>,
+    <https://sws.geonames.org/2790241/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "62121" ;
+  skos:prefLabel "Neupré"@de,
+    "Neupré"@fr,
+    "Neupré"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/62122> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/62000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/62122>,
+    <http://www.wikidata.org/entity/Q711205>,
+    <https://sws.geonames.org/2798035/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "62122" ;
+  skos:prefLabel "Trooz"@de,
+    "Trooz"@fr,
+    "Trooz"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/63001> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/63000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/63001>,
+    <http://www.wikidata.org/entity/Q159868>,
+    <https://sws.geonames.org/2803243/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "63001" ;
+  skos:prefLabel "Amel"@de,
+    "Amblève"@fr,
+    "Amel"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/63003> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/63000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/63003>,
+    <http://www.wikidata.org/entity/Q678920>,
+    <https://sws.geonames.org/2802986/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "63003" ;
+  skos:prefLabel "Aubel"@de,
+    "Aubel"@fr,
+    "Aubel"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/63004> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/63000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/63004>,
+    <http://www.wikidata.org/entity/Q680845>,
+    <https://sws.geonames.org/2802788/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "63004" ;
+  skos:prefLabel "Baelen"@de,
+    "Baelen"@fr,
+    "Baelen"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/63012> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/63000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/63012>,
+    <http://www.wikidata.org/entity/Q152737>,
+    <https://sws.geonames.org/2800783/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "63012" ;
+  skos:prefLabel "Büllingen"@de,
+    "Bullange"@fr,
+    "Büllingen"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/63013> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/63000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/63013>,
+    <http://www.wikidata.org/entity/Q160005>,
+    <https://sws.geonames.org/2800712/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "63013" ;
+  skos:prefLabel "Bütgenbach"@de,
+    "Butgenbach"@fr,
+    "Bütgenbach"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/63020> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/63000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/63020>,
+    <http://www.wikidata.org/entity/Q682105>,
+    <https://sws.geonames.org/2799348/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "63020" ;
+  skos:prefLabel "Dison"@de,
+    "Dison"@fr,
+    "Dison"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/63023> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/63000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/63023>,
+    <http://www.wikidata.org/entity/Q151831>,
+    <https://sws.geonames.org/2798574/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "63023" ;
+  skos:prefLabel "Eupen"@de,
+    "Eupen"@fr,
+    "Eupen"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/63035> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/63000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/63035>,
+    <http://www.wikidata.org/entity/Q683465>,
+    <https://sws.geonames.org/2795913/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "63035" ;
+  skos:prefLabel "Herve"@de,
+    "Herve"@fr,
+    "Herve"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/63038> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/63000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/63038>,
+    <http://www.wikidata.org/entity/Q683634>,
+    <https://sws.geonames.org/2794990/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "63038" ;
+  skos:prefLabel "Jalhay"@de,
+    "Jalhay"@fr,
+    "Jalhay"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/63040> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/63000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/63040>,
+    <http://www.wikidata.org/entity/Q159864>,
+    <https://sws.geonames.org/2793723/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "63040" ;
+  skos:prefLabel "Kelmis"@de,
+    "La Calamine"@fr,
+    "Kelmis"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/63045> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/63000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/63045>,
+    <http://www.wikidata.org/entity/Q710022>,
+    <https://sws.geonames.org/2792401/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "63045" ;
+  skos:prefLabel "Lierneux"@de,
+    "Lierneux"@fr,
+    "Lierneux"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/63046> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/63000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/63046>,
+    <http://www.wikidata.org/entity/Q506739>,
+    <https://sws.geonames.org/2792349/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "63046" ;
+  skos:prefLabel "Limbourg"@de,
+    "Limbourg"@fr,
+    "Limburg"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/63048> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/63000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/63048>,
+    <http://www.wikidata.org/entity/Q159958>,
+    <https://sws.geonames.org/2792120/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "63048" ;
+  skos:prefLabel "Lontzen"@de,
+    "Lontzen"@fr,
+    "Lontzen"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/63049> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/63000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/63049>,
+    <http://www.wikidata.org/entity/Q159838>,
+    <https://sws.geonames.org/2791835/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "63049" ;
+  skos:prefLabel "Malmedy"@de,
+    "Malmedy"@fr,
+    "Malmedy"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/63057> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/63000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/63057>,
+    <http://www.wikidata.org/entity/Q710358>,
+    <https://sws.geonames.org/2789870/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "63057" ;
+  skos:prefLabel "Olne"@de,
+    "Olne"@fr,
+    "Olne"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/63058> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/63000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/63058>,
+    <http://www.wikidata.org/entity/Q710522>,
+    <https://sws.geonames.org/2789191/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "63058" ;
+  skos:prefLabel "Pepinster"@de,
+    "Pepinster"@fr,
+    "Pepinster"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/63061> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/63000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/63061>,
+    <http://www.wikidata.org/entity/Q152734>,
+    <https://sws.geonames.org/2788411/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "63061" ;
+  skos:prefLabel "Raeren"@de,
+    "Raeren"@fr,
+    "Raeren"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/63067> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/63000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/63067>,
+    <http://www.wikidata.org/entity/Q152748>,
+    <https://sws.geonames.org/2787316/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "63067" ;
+  skos:prefLabel "Sankt Vith"@de,
+    "Saint-Vith"@fr,
+    "Sankt Vith"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/63072> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/63000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/63072>,
+    <http://www.wikidata.org/entity/Q39865>,
+    <https://sws.geonames.org/2786319/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "63072" ;
+  skos:prefLabel "Spa"@de,
+    "Spa"@fr,
+    "Spa"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/63073> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/63000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/63073>,
+    <http://www.wikidata.org/entity/Q468920>,
+    <https://sws.geonames.org/2786186/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "63073" ;
+  skos:prefLabel "Stavelot"@de,
+    "Stavelot"@fr,
+    "Stavelot"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/63075> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/63000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/63075>,
+    <http://www.wikidata.org/entity/Q711046>,
+    <https://sws.geonames.org/2785990/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "63075" ;
+  skos:prefLabel "Stoumont"@de,
+    "Stoumont"@fr,
+    "Stoumont"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/63076> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/63000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/63076>,
+    <http://www.wikidata.org/entity/Q711079>,
+    <https://sws.geonames.org/2785594/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "63076" ;
+  skos:prefLabel "Theux"@de,
+    "Theux"@fr,
+    "Theux"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/63079> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/63000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/63079>,
+    <http://www.wikidata.org/entity/Q202954>,
+    <https://sws.geonames.org/2784822/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "63079" ;
+  skos:prefLabel "Verviers"@de,
+    "Verviers"@fr,
+    "Verviers"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/63080> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/63000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/63080>,
+    <http://www.wikidata.org/entity/Q159961>,
+    <https://sws.geonames.org/2784200/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "63080" ;
+  skos:prefLabel "Weismes"@de,
+    "Waimes"@fr,
+    "Weismes"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/63084> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/63000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/63084>,
+    <http://www.wikidata.org/entity/Q152743>,
+    <https://sws.geonames.org/2783871/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "63084" ;
+  skos:prefLabel "Welkenraedt"@de,
+    "Welkenraedt"@fr,
+    "Welkenraedt"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/63086> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/63000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/63086>,
+    <http://www.wikidata.org/entity/Q711183>,
+    <https://sws.geonames.org/2784103/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "63086" ;
+  skos:prefLabel "Trois-Ponts"@de,
+    "Trois-Ponts"@fr,
+    "Trois-Ponts"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/63087> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/63000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/63087>,
+    <http://www.wikidata.org/entity/Q159981>,
+    <https://sws.geonames.org/2788132/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "63087" ;
+  skos:prefLabel "Burg-Reuland"@de,
+    "Burg-Reuland"@fr,
+    "Burg-Reuland"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/63088> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/63000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/63088>,
+    <http://www.wikidata.org/entity/Q710606>,
+    <https://sws.geonames.org/2797697/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "63088" ;
+  skos:prefLabel "Plombières"@de,
+    "Plombières"@fr,
+    "Plombières"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/63089> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/63000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/63089>,
+    <http://www.wikidata.org/entity/Q711115>,
+    <https://sws.geonames.org/2785563/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "63089" ;
+  skos:prefLabel "Thimister-Clermont"@de,
+    "Thimister-Clermont"@fr,
+    "Thimister-Clermont"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/64008> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/64000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/64008>,
+    <http://www.wikidata.org/entity/Q680978>,
+    <https://sws.geonames.org/2802144/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "64008" ;
+  skos:prefLabel "Berloz"@de,
+    "Berloz"@fr,
+    "Berloz"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/64015> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/64000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/64015>,
+    <http://www.wikidata.org/entity/Q681153>,
+    <https://sws.geonames.org/2801148/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "64015" ;
+  skos:prefLabel "Braives"@de,
+    "Braives"@fr,
+    "Braives"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/64021> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/64000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/64021>,
+    <http://www.wikidata.org/entity/Q929415>,
+    <https://sws.geonames.org/2799998/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "64021" ;
+  skos:prefLabel "Crisnée"@de,
+    "Crisnée"@fr,
+    "Crisnée"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/64023> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/64000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/64023>,
+    <http://www.wikidata.org/entity/Q682163>,
+    <https://sws.geonames.org/2799318/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "64023" ;
+  skos:prefLabel "Donceel"@de,
+    "Donceel"@fr,
+    "Donceel"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/64025> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/64000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/64025>,
+    <http://www.wikidata.org/entity/Q379113>,
+    <https://sws.geonames.org/2798358/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "64025" ;
+  skos:prefLabel "Fexhe-le-Haut-Clocher"@de,
+    "Fexhe-le-Haut-Clocher"@fr,
+    "Fexhe-le-Haut-Clocher"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/64029> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/64000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/64029>,
+    <http://www.wikidata.org/entity/Q682982>,
+    <https://sws.geonames.org/2797771/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "64029" ;
+  skos:prefLabel "Geer"@de,
+    "Geer"@fr,
+    "Geer"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/64034> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/64000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/64034>,
+    <http://www.wikidata.org/entity/Q683141>,
+    <https://sws.geonames.org/2796584/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "64034" ;
+  skos:prefLabel "Hannut"@de,
+    "Hannut"@fr,
+    "Hannuit"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/64047> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/64000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/64047>,
+    <http://www.wikidata.org/entity/Q509457>,
+    <https://sws.geonames.org/2792333/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "64047" ;
+  skos:prefLabel "Lincent"@de,
+    "Lincent"@fr,
+    "Lijsem"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/64056> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/64000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/64056>,
+    <http://www.wikidata.org/entity/Q710409>,
+    <https://sws.geonames.org/2789636/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "64056" ;
+  skos:prefLabel "Oreye"@de,
+    "Oreye"@fr,
+    "Oerle"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/64063> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/64000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/64063>,
+    <http://www.wikidata.org/entity/Q710690>,
+    <https://sws.geonames.org/2788212/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "64063" ;
+  skos:prefLabel "Remicourt"@de,
+    "Remicourt"@fr,
+    "Remicourt"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/64065> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/64000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/64065>,
+    <http://www.wikidata.org/entity/Q710718>,
+    <https://sws.geonames.org/2787426/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "64065" ;
+  skos:prefLabel "Saint-Georges-sur-Meuse"@de,
+    "Saint-Georges-sur-Meuse"@fr,
+    "Saint-Georges-sur-Meuse"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/64074> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/64000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/64074>,
+    <http://www.wikidata.org/entity/Q711474>,
+    <https://sws.geonames.org/2797322/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "64074" ;
+  skos:prefLabel "Waremme"@de,
+    "Waremme"@fr,
+    "Borgworm"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/64075> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/64000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/64075>,
+    <http://www.wikidata.org/entity/Q711502>,
+    <https://sws.geonames.org/2784011/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "64075" ;
+  skos:prefLabel "Wasseiges"@de,
+    "Wasseiges"@fr,
+    "Wasseiges"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/64076> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/64000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/64076>,
+    <http://www.wikidata.org/entity/Q682441>,
+    <https://sws.geonames.org/2800609/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "64076" ;
+  skos:prefLabel "Faimes"@de,
+    "Faimes"@fr,
+    "Faimes"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/71002> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/71000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/71002>,
+    <http://www.wikidata.org/entity/Q696591>,
+    <https://sws.geonames.org/2803054/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "71002" ;
+  skos:prefLabel "As"@de,
+    "As"@fr,
+    "As"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/71004> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/71000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/71004>,
+    <http://www.wikidata.org/entity/Q242407>,
+    <https://sws.geonames.org/2802172/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "71004" ;
+  skos:prefLabel "Beringen"@de,
+    "Beringen"@fr,
+    "Beringen"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/71011> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/71000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/71011>,
+    <http://www.wikidata.org/entity/Q651826>,
+    <https://sws.geonames.org/2799413/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "71011" ;
+  skos:prefLabel "Diepenbeek"@de,
+    "Diepenbeek"@fr,
+    "Diepenbeek"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/71016> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/71000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/71016>,
+    <http://www.wikidata.org/entity/Q189692>,
+    <https://sws.geonames.org/2797671/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "71016" ;
+  skos:prefLabel "Genk"@de,
+    "Genk"@fr,
+    "Genk"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/71017> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/71000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/71017>,
+    <http://www.wikidata.org/entity/Q651837>,
+    <https://sws.geonames.org/2797524/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "71017" ;
+  skos:prefLabel "Gingelom"@de,
+    "Gingelom"@fr,
+    "Gingelom"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/71020> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/71000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/71020>,
+    <http://www.wikidata.org/entity/Q461436>,
+    <https://sws.geonames.org/2796716/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "71020" ;
+  skos:prefLabel "Halen"@de,
+    "Halen"@fr,
+    "Halen"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/71024> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/71000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/71024>,
+    <http://www.wikidata.org/entity/Q696585>,
+    <https://sws.geonames.org/2795986/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "71024" ;
+  skos:prefLabel "Herk-de-Stad"@de,
+    "Herck-la-Ville"@fr,
+    "Herk-de-Stad"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/71034> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/71000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/71034>,
+    <http://www.wikidata.org/entity/Q736120>,
+    <https://sws.geonames.org/2792857/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "71034" ;
+  skos:prefLabel "Leopoldsburg"@de,
+    "Bourg-Léopold"@fr,
+    "Leopoldsburg"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/71037> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/71000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/71037>,
+    <http://www.wikidata.org/entity/Q329628>,
+    <https://sws.geonames.org/2792008/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "71037" ;
+  skos:prefLabel "Lummen"@de,
+    "Lummen"@fr,
+    "Lummen"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/71045> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/71000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/71045>,
+    <http://www.wikidata.org/entity/Q696740>,
+    <https://sws.geonames.org/2790181/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "71045" ;
+  skos:prefLabel "Nieuwerkerken"@de,
+    "Nieuwerkerken"@fr,
+    "Nieuwerkerken"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/71053> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/71000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/71053>,
+    <http://www.wikidata.org/entity/Q37792>,
+    <https://sws.geonames.org/2786546/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "71053" ;
+  skos:prefLabel "Sint-Truiden"@de,
+    "Saint-Trond"@fr,
+    "Sint-Truiden"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/71066> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/71000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/71066>,
+    <http://www.wikidata.org/entity/Q133769>,
+    <https://sws.geonames.org/2783189/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "71066" ;
+  skos:prefLabel "Zonhoven"@de,
+    "Zonhoven"@fr,
+    "Zonhoven"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/71067> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/71000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/71067>,
+    <http://www.wikidata.org/entity/Q231090>,
+    <https://sws.geonames.org/2783144/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "71067" ;
+  skos:prefLabel "Zutendaal"@de,
+    "Zutendaal"@fr,
+    "Zutendaal"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/71070> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/71000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/71070>,
+    <http://www.wikidata.org/entity/Q319792>,
+    <https://sws.geonames.org/2795802/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "71070" ;
+  skos:prefLabel "Heusden-Zolder"@de,
+    "Heusden-Zolder"@fr,
+    "Heusden-Zolder"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/71071> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/71000> ;
+  skos:exactMatch <http://www.wikidata.org/entity/Q695354>,
+    <https://sws.geonames.org/2789770/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrowMatch <http://vocab.belgif.be/auth/refnis2019/71057>,
+    <http://vocab.belgif.be/auth/refnis2019/71069> ;
+  skos:notation "71071" ;
+  skos:prefLabel "Tessenderlo-Ham"@de,
+    "Tessenderlo-Ham"@fr,
+    "Tessenderlo-Ham"@nl ;
+  ns1:endDate "2025-01-01T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/71072> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/71000> ;
+  skos:exactMatch <http://www.wikidata.org/entity/Q58780>,
+    <https://sws.geonames.org/2796492/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrowMatch <http://vocab.belgif.be/auth/refnis2019/71022>,
+    <http://vocab.belgif.be/auth/refnis2019/73040> ;
+  skos:notation "71072" ;
+  skos:prefLabel "Hasselt"@de,
+    "Hasselt"@fr,
+    "Hasselt"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2025-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/72003> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/72000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/72003>,
+    <http://www.wikidata.org/entity/Q889044>,
+    <https://sws.geonames.org/2801755/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "72003" ;
+  skos:prefLabel "Bocholt"@de,
+    "Bocholt"@fr,
+    "Bocholt"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/72004> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/72000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/72004>,
+    <http://www.wikidata.org/entity/Q275863>,
+    <https://sws.geonames.org/2801094/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "72004" ;
+  skos:prefLabel "Bree"@de,
+    "Bree"@fr,
+    "Bree"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/72018> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/72000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/72018>,
+    <http://www.wikidata.org/entity/Q819133>,
+    <https://sws.geonames.org/2794446/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "72018" ;
+  skos:prefLabel "Kinrooi"@de,
+    "Kinrooi"@fr,
+    "Kinrooi"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/72020> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/72000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/72020>,
+    <http://www.wikidata.org/entity/Q194366>,
+    <https://sws.geonames.org/2792180/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "72020" ;
+  skos:prefLabel "Lommel"@de,
+    "Lommel"@fr,
+    "Lommel"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/72021> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/72000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/72021>,
+    <http://www.wikidata.org/entity/Q110989>,
+    <https://sws.geonames.org/2791965/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "72021" ;
+  skos:prefLabel "Maaseik"@de,
+    "Maaseik"@fr,
+    "Maaseik"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/72030> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/72000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/72030>,
+    <http://www.wikidata.org/entity/Q736085>,
+    <https://sws.geonames.org/2789233/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "72030" ;
+  skos:prefLabel "Peer"@de,
+    "Peer"@fr,
+    "Peer"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/72037> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/72000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/72037>,
+    <http://www.wikidata.org/entity/Q499599>,
+    <https://sws.geonames.org/2796626/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "72037" ;
+  skos:prefLabel "Hamont-Achel"@de,
+    "Hamont-Achel"@fr,
+    "Hamont-Achel"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/72038> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/72000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/72038>,
+    <http://www.wikidata.org/entity/Q819164>,
+    <https://sws.geonames.org/2796320/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "72038" ;
+  skos:prefLabel "Hechtel-Eksel"@de,
+    "Hechtel-Eksel"@fr,
+    "Hechtel-Eksel"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/72039> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/72000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/72039>,
+    <http://www.wikidata.org/entity/Q478795>,
+    <https://sws.geonames.org/2795262/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "72039" ;
+  skos:prefLabel "Houthalen-Helchteren"@de,
+    "Houthalen-Helchteren"@fr,
+    "Houthalen-Helchteren"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/72041> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/72000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/72041>,
+    <http://www.wikidata.org/entity/Q581246>,
+    <https://sws.geonames.org/2799363/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "72041" ;
+  skos:prefLabel "Dilsen-Stokkem"@de,
+    "Dilsen-Stokkem"@fr,
+    "Dilsen-Stokkem"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/72042> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/72000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/72042>,
+    <https://sws.geonames.org/11995083/>,
+    <https://www.wikidata.org/entity/Q41795471> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrowMatch <http://www.wikidata.org/entity/Q125979>,
+    <http://www.wikidata.org/entity/Q651801>,
+    <https://sws.geonames.org/2789715/>,
+    <https://sws.geonames.org/2791461/> ;
+  skos:notation "72042" ;
+  skos:prefLabel "Oudsbergen"@de,
+    "Oudsbergen"@fr,
+    "Oudsbergen"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/72043> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/72000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/72043>,
+    <http://www.wikidata.org/entity/Q42878311>,
+    <http://www.wikidata.org/entity/Q651736>,
+    <https://sws.geonames.org/11995106/>,
+    <https://sws.geonames.org/2789404/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrowMatch <http://www.wikidata.org/entity/Q651751>,
+    <https://sws.geonames.org/2790358/> ;
+  skos:notation "72043" ;
+  skos:prefLabel "Pelt"@de,
+    "Pelt"@fr,
+    "Pelt"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/73001> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/73000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/73001>,
+    <http://www.wikidata.org/entity/Q499604>,
+    <https://sws.geonames.org/2803286/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "73001" ;
+  skos:prefLabel "Alken"@de,
+    "Alken"@fr,
+    "Alken"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/73022> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/73000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/73022>,
+    <http://www.wikidata.org/entity/Q819162>,
+    <https://sws.geonames.org/2796298/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "73022" ;
+  skos:prefLabel "Heers"@de,
+    "Heers"@fr,
+    "Heers"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/73028> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/73000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/73028>,
+    <http://www.wikidata.org/entity/Q499584>,
+    <https://sws.geonames.org/2795929/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "73028" ;
+  skos:prefLabel "Herstappe"@de,
+    "Herstappe"@fr,
+    "Herstappe"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/73042> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/73000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/73042>,
+    <http://www.wikidata.org/entity/Q695315>,
+    <https://sws.geonames.org/2793447/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "73042" ;
+  skos:prefLabel "Lanaken"@de,
+    "Lanaken"@fr,
+    "Lanaken"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/73066> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/73000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/73066>,
+    <http://www.wikidata.org/entity/Q736097>,
+    <https://sws.geonames.org/2788089/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "73066" ;
+  skos:prefLabel "Riemst"@de,
+    "Riemst"@fr,
+    "Riemst"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/73098> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/73000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/73098>,
+    <http://www.wikidata.org/entity/Q119331>,
+    <https://sws.geonames.org/2783865/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "73098" ;
+  skos:prefLabel "Wellen"@de,
+    "Wellen"@fr,
+    "Wellen"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/73107> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/73000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/73107>,
+    <http://www.wikidata.org/entity/Q329633>,
+    <https://sws.geonames.org/2791535/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "73107" ;
+  skos:prefLabel "Maasmechelen"@de,
+    "Maasmechelen"@fr,
+    "Maasmechelen"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/73109> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/73000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/73109>,
+    <http://www.wikidata.org/entity/Q460479>,
+    <https://sws.geonames.org/2786584/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "73109" ;
+  skos:prefLabel "Voeren"@de,
+    "Fourons"@fr,
+    "Voeren"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/73110> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/73000> ;
+  skos:exactMatch <http://www.wikidata.org/entity/Q241898>,
+    <https://sws.geonames.org/2801925/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrowMatch <http://vocab.belgif.be/auth/refnis2019/73006>,
+    <http://vocab.belgif.be/auth/refnis2019/73032> ;
+  skos:notation "73110" ;
+  skos:prefLabel "Bilzen-Hoeselt"@de,
+    "Bilzen-Hoeselt"@fr,
+    "Bilzen-Hoeselt"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2025-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/73111> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/73000> ;
+  skos:exactMatch <http://www.wikidata.org/entity/Q499609>,
+    <https://sws.geonames.org/2801468/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrowMatch <http://vocab.belgif.be/auth/refnis2019/73009>,
+    <http://vocab.belgif.be/auth/refnis2019/73083> ;
+  skos:notation "73111" ;
+  skos:prefLabel "Tongeren-Borgloon"@de,
+    "Tongres-Looz"@fr,
+    "Tongeren-Borgloon"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2025-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/81001> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/81000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/81001>,
+    <http://www.wikidata.org/entity/Q675960>,
+    <https://sws.geonames.org/2803074/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "81001" ;
+  skos:prefLabel "Arlon"@de,
+    "Arlon"@fr,
+    "Aarlen"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/81003> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/81000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/81003>,
+    <http://www.wikidata.org/entity/Q690926>,
+    <https://sws.geonames.org/2802997/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "81003" ;
+  skos:prefLabel "Attert"@de,
+    "Attert"@fr,
+    "Attert"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/81004> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/81000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/81004>,
+    <http://www.wikidata.org/entity/Q713088>,
+    <https://sws.geonames.org/2802991/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "81004" ;
+  skos:prefLabel "Aubange"@de,
+    "Aubange"@fr,
+    "Aubange"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/81013> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/81000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/81013>,
+    <http://www.wikidata.org/entity/Q713498>,
+    <https://sws.geonames.org/2791643/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "81013" ;
+  skos:prefLabel "Martelange"@de,
+    "Martelange"@fr,
+    "Martelange"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/81015> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/81000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/81015>,
+    <http://www.wikidata.org/entity/Q692243>,
+    <https://sws.geonames.org/2791273/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "81015" ;
+  skos:prefLabel "Messancy"@de,
+    "Messancy"@fr,
+    "Messancy"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/82009> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/82000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/82009>,
+    <http://www.wikidata.org/entity/Q713282>,
+    <https://sws.geonames.org/2798439/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "82009" ;
+  skos:prefLabel "Fauvillers"@de,
+    "Fauvillers"@fr,
+    "Fauvillers"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/82014> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/82000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/82014>,
+    <http://www.wikidata.org/entity/Q650274>,
+    <https://sws.geonames.org/2795323/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "82014" ;
+  skos:prefLabel "Houffalize"@de,
+    "Houffalize"@fr,
+    "Houffalize"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/82032> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/82000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/82032>,
+    <http://www.wikidata.org/entity/Q650172>,
+    <https://sws.geonames.org/2784776/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "82032" ;
+  skos:prefLabel "Vielsalm"@de,
+    "Vielsalm"@fr,
+    "Vielsalm"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/82036> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/82000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/82036>,
+    <http://www.wikidata.org/entity/Q713864>,
+    <https://sws.geonames.org/2784999/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "82036" ;
+  skos:prefLabel "Vaux-sur-Sûre"@de,
+    "Vaux-sur-Sûre"@fr,
+    "Vaux-sur-Sûre"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/82037> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/82000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/82037>,
+    <http://www.wikidata.org/entity/Q713319>,
+    <https://sws.geonames.org/2792344/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "82037" ;
+  skos:prefLabel "Gouvy"@de,
+    "Gouvy"@fr,
+    "Gouvy"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/82038> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/82000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/82038>,
+    <http://www.wikidata.org/entity/Q713708>,
+    <https://sws.geonames.org/2803245/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "82038" ;
+  skos:prefLabel "Sainte-Ode"@de,
+    "Sainte-Ode"@fr,
+    "Sainte-Ode"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/82039> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/82000> ;
+  skos:exactMatch <http://www.wikidata.org/entity/Q34021>,
+    <https://sws.geonames.org/2802584/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrowMatch <http://vocab.belgif.be/auth/refnis2019/82003>,
+    <http://vocab.belgif.be/auth/refnis2019/82005> ;
+  skos:notation "82039" ;
+  skos:prefLabel "Bastnach"@de,
+    "Bastogne"@fr,
+    "Bastenaken"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2024-12-02T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/83012> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/83000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/83012>,
+    <http://www.wikidata.org/entity/Q497697>,
+    <https://sws.geonames.org/2799048/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "83012" ;
+  skos:prefLabel "Durbuy"@de,
+    "Durbuy"@fr,
+    "Durbuy"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/83013> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/83000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/83013>,
+    <http://www.wikidata.org/entity/Q287813>,
+    <https://sws.geonames.org/2798699/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "83013" ;
+  skos:prefLabel "Erezée"@de,
+    "Erezée"@fr,
+    "Erezée"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/83028> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/83000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/83028>,
+    <http://www.wikidata.org/entity/Q160709>,
+    <https://sws.geonames.org/2795338/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "83028" ;
+  skos:prefLabel "Hotton"@de,
+    "Hotton"@fr,
+    "Hotton"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/83031> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/83000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/83031>,
+    <http://www.wikidata.org/entity/Q159974>,
+    <https://sws.geonames.org/2793280/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "83031" ;
+  skos:prefLabel "La Roche-en-Ardenne"@de,
+    "La Roche-en-Ardenne"@fr,
+    "La Roche-en-Ardenne"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/83034> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/83000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/83034>,
+    <http://www.wikidata.org/entity/Q269908>,
+    <https://sws.geonames.org/2791745/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "83034" ;
+  skos:prefLabel "Marche-en-Famenne"@de,
+    "Marche-en-Famenne"@fr,
+    "Marche-en-Famenne"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/83040> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/83000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/83040>,
+    <http://www.wikidata.org/entity/Q429794>,
+    <https://sws.geonames.org/2790452/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "83040" ;
+  skos:prefLabel "Nassogne"@de,
+    "Nassogne"@fr,
+    "Nassogne"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/83044> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/83000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/83044>,
+    <http://www.wikidata.org/entity/Q713615>,
+    <https://sws.geonames.org/2788187/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "83044" ;
+  skos:prefLabel "Rendeux"@de,
+    "Rendeux"@fr,
+    "Rendeux"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/83049> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/83000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/83049>,
+    <http://www.wikidata.org/entity/Q511239>,
+    <https://sws.geonames.org/2785746/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "83049" ;
+  skos:prefLabel "Tenneville"@de,
+    "Tenneville"@fr,
+    "Tenneville"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/83055> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/83000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/83055>,
+    <http://www.wikidata.org/entity/Q713458>,
+    <https://sws.geonames.org/2797227/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "83055" ;
+  skos:prefLabel "Manhay"@de,
+    "Manhay"@fr,
+    "Manhay"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/84009> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/84000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/84009>,
+    <http://www.wikidata.org/entity/Q713135>,
+    <https://sws.geonames.org/2802107/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "84009" ;
+  skos:prefLabel "Bertrix"@de,
+    "Bertrix"@fr,
+    "Bertrix"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/84010> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/84000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/84010>,
+    <http://www.wikidata.org/entity/Q217216>,
+    <https://sws.geonames.org/2801284/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "84010" ;
+  skos:prefLabel "Bouillon"@de,
+    "Bouillon"@fr,
+    "Bouillon"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/84016> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/84000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/84016>,
+    <http://www.wikidata.org/entity/Q713189>,
+    <https://sws.geonames.org/2799852/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "84016" ;
+  skos:prefLabel "Daverdisse"@de,
+    "Daverdisse"@fr,
+    "Daverdisse"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/84029> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/84000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/84029>,
+    <http://www.wikidata.org/entity/Q713353>,
+    <https://sws.geonames.org/2796038/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "84029" ;
+  skos:prefLabel "Herbeumont"@de,
+    "Herbeumont"@fr,
+    "Herbeumont"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/84033> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/84000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/84033>,
+    <http://www.wikidata.org/entity/Q713404>,
+    <https://sws.geonames.org/2792986/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "84033" ;
+  skos:prefLabel "Léglise"@de,
+    "Léglise"@fr,
+    "Léglise"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/84035> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/84000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/84035>,
+    <http://www.wikidata.org/entity/Q713433>,
+    <https://sws.geonames.org/2792443/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "84035" ;
+  skos:prefLabel "Libin"@de,
+    "Libin"@fr,
+    "Libin"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/84043> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/84000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/84043>,
+    <http://www.wikidata.org/entity/Q650135>,
+    <https://sws.geonames.org/2790288/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "84043" ;
+  skos:prefLabel "Neufchâteau"@de,
+    "Neufchâteau"@fr,
+    "Neufchâteau"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/84050> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/84000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/84050>,
+    <http://www.wikidata.org/entity/Q696127>,
+    <https://sws.geonames.org/2789355/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "84050" ;
+  skos:prefLabel "Paliseul"@de,
+    "Paliseul"@fr,
+    "Paliseul"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/84059> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/84000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/84059>,
+    <http://www.wikidata.org/entity/Q713740>,
+    <https://sws.geonames.org/2787409/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "84059" ;
+  skos:prefLabel "Saint-Hubert"@de,
+    "Saint-Hubert"@fr,
+    "Saint-Hubert"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/84068> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/84000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/84068>,
+    <http://www.wikidata.org/entity/Q713812>,
+    <https://sws.geonames.org/2785794/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "84068" ;
+  skos:prefLabel "Tellin"@de,
+    "Tellin"@fr,
+    "Tellin"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/84075> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/84000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/84075>,
+    <http://www.wikidata.org/entity/Q713911>,
+    <https://sws.geonames.org/2783863/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "84075" ;
+  skos:prefLabel "Wellin"@de,
+    "Wellin"@fr,
+    "Wellin"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/84077> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/84000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/84077>,
+    <http://www.wikidata.org/entity/Q612267>,
+    <https://sws.geonames.org/2792438/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "84077" ;
+  skos:prefLabel "Libramont-Chevigny"@de,
+    "Libramont-Chevigny"@fr,
+    "Libramont-Chevigny"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/85007> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/85000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/85007>,
+    <http://www.wikidata.org/entity/Q713170>,
+    <https://sws.geonames.org/2800321/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "85007" ;
+  skos:prefLabel "Chiny"@de,
+    "Chiny"@fr,
+    "Chiny"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/85009> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/85000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/85009>,
+    <http://www.wikidata.org/entity/Q288872>,
+    <https://sws.geonames.org/2798594/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "85009" ;
+  skos:prefLabel "Etalle"@de,
+    "Etalle"@fr,
+    "Etalle"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/85011> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/85000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/85011>,
+    <http://www.wikidata.org/entity/Q713300>,
+    <https://sws.geonames.org/2798273/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "85011" ;
+  skos:prefLabel "Florenville"@de,
+    "Florenville"@fr,
+    "Florenville"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/85024> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/85000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/85024>,
+    <http://www.wikidata.org/entity/Q669134>,
+    <https://sws.geonames.org/2791420/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "85024" ;
+  skos:prefLabel "Meix-devant-Virton"@de,
+    "Meix-devant-Virton"@fr,
+    "Meix-devant-Virton"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/85026> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/85000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/85026>,
+    <http://www.wikidata.org/entity/Q713538>,
+    <https://sws.geonames.org/2790516/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "85026" ;
+  skos:prefLabel "Musson"@de,
+    "Musson"@fr,
+    "Musson"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/85034> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/85000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/85034>,
+    <http://www.wikidata.org/entity/Q713786>,
+    <https://sws.geonames.org/2787380/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "85034" ;
+  skos:prefLabel "Saint-Léger"@de,
+    "Saint-Léger"@fr,
+    "Saint-Léger"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/85039> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/85000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/85039>,
+    <http://www.wikidata.org/entity/Q713845>,
+    <https://sws.geonames.org/2785423/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "85039" ;
+  skos:prefLabel "Tintigny"@de,
+    "Tintigny"@fr,
+    "Tintigny"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/85045> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/85000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/85045>,
+    <http://www.wikidata.org/entity/Q456495>,
+    <https://sws.geonames.org/2784556/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "85045" ;
+  skos:prefLabel "Virton"@de,
+    "Virton"@fr,
+    "Virton"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/85046> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/85000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/85046>,
+    <http://www.wikidata.org/entity/Q713334>,
+    <https://sws.geonames.org/2796810/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "85046" ;
+  skos:prefLabel "Habay"@de,
+    "Habay"@fr,
+    "Habay"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/85047> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/85000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/85047>,
+    <http://www.wikidata.org/entity/Q713677>,
+    <https://sws.geonames.org/2793464/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "85047" ;
+  skos:prefLabel "Rouvroy"@de,
+    "Rouvroy"@fr,
+    "Rouvroy"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/91005> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/91000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/91005>,
+    <http://www.wikidata.org/entity/Q545889>,
+    <https://sws.geonames.org/2803175/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "91005" ;
+  skos:prefLabel "Anhée"@de,
+    "Anhée"@fr,
+    "Anhée"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/91013> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/91000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/91013>,
+    <http://www.wikidata.org/entity/Q329621>,
+    <https://sws.geonames.org/2802502/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "91013" ;
+  skos:prefLabel "Beauraing"@de,
+    "Beauraing"@fr,
+    "Beauraing"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/91015> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/91000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/91015>,
+    <http://www.wikidata.org/entity/Q715371>,
+    <https://sws.geonames.org/2801950/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "91015" ;
+  skos:prefLabel "Bièvre"@de,
+    "Bièvre"@fr,
+    "Bièvre"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/91030> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/91000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/91030>,
+    <http://www.wikidata.org/entity/Q456490>,
+    <https://sws.geonames.org/2800299/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "91030" ;
+  skos:prefLabel "Ciney"@de,
+    "Ciney"@fr,
+    "Ciney"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/91034> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/91000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/91034>,
+    <http://www.wikidata.org/entity/Q108247>,
+    <https://sws.geonames.org/2799359/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "91034" ;
+  skos:prefLabel "Dinant"@de,
+    "Dinant"@fr,
+    "Dinant"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/91054> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/91000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/91054>,
+    <http://www.wikidata.org/entity/Q241069>,
+    <https://sws.geonames.org/2797782/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "91054" ;
+  skos:prefLabel "Gedinne"@de,
+    "Gedinne"@fr,
+    "Gedinne"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/91059> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/91000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/91059>,
+    <http://www.wikidata.org/entity/Q696133>,
+    <https://sws.geonames.org/2796628/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "91059" ;
+  skos:prefLabel "Hamois"@de,
+    "Hamois"@fr,
+    "Hamois"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/91064> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/91000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/91064>,
+    <http://www.wikidata.org/entity/Q720709>,
+    <https://sws.geonames.org/2796370/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "91064" ;
+  skos:prefLabel "Havelange"@de,
+    "Havelange"@fr,
+    "Havelange"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/91072> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/91000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/91072>,
+    <http://www.wikidata.org/entity/Q695390>,
+    <https://sws.geonames.org/2795239/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "91072" ;
+  skos:prefLabel "Houyet"@de,
+    "Houyet"@fr,
+    "Houyet"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/91103> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/91000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/91103>,
+    <http://www.wikidata.org/entity/Q695349>,
+    <https://sws.geonames.org/2789835/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "91103" ;
+  skos:prefLabel "Onhaye"@de,
+    "Onhaye"@fr,
+    "Onhaye"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/91114> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/91000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/91114>,
+    <http://www.wikidata.org/entity/Q497764>,
+    <https://sws.geonames.org/2787949/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "91114" ;
+  skos:prefLabel "Rochefort"@de,
+    "Rochefort"@fr,
+    "Rochefort"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/91120> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/91000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/91120>,
+    <http://www.wikidata.org/entity/Q721342>,
+    <https://sws.geonames.org/2786388/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "91120" ;
+  skos:prefLabel "Somme-Leuze"@de,
+    "Somme-Leuze"@fr,
+    "Somme-Leuze"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/91141> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/91000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/91141>,
+    <http://www.wikidata.org/entity/Q650163>,
+    <https://sws.geonames.org/2783386/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "91141" ;
+  skos:prefLabel "Yvoir"@de,
+    "Yvoir"@fr,
+    "Yvoir"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/91142> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/91000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/91142>,
+    <http://www.wikidata.org/entity/Q514641>,
+    <https://sws.geonames.org/2796483/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "91142" ;
+  skos:prefLabel "Hastière"@de,
+    "Hastière"@fr,
+    "Hastière"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/91143> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/91000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/91143>,
+    <http://www.wikidata.org/entity/Q650206>,
+    <https://sws.geonames.org/2784312/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "91143" ;
+  skos:prefLabel "Vresse-sur-Semois"@de,
+    "Vresse-sur-Semois"@fr,
+    "Vresse-sur-Semois"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/92003> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/92000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/92003>,
+    <http://www.wikidata.org/entity/Q333466>,
+    <https://sws.geonames.org/2803205/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "92003" ;
+  skos:prefLabel "Andenne"@de,
+    "Andenne"@fr,
+    "Andenne"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/92006> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/92000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/92006>,
+    <http://www.wikidata.org/entity/Q715246>,
+    <https://sws.geonames.org/2803019/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "92006" ;
+  skos:prefLabel "Assesse"@de,
+    "Assesse"@fr,
+    "Assesse"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/92035> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/92000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/92035>,
+    <http://www.wikidata.org/entity/Q274522>,
+    <https://sws.geonames.org/2798950/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "92035" ;
+  skos:prefLabel "Eghezée"@de,
+    "Eghezée"@fr,
+    "Eghezée"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/92045> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/92000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/92045>,
+    <http://www.wikidata.org/entity/Q578583>,
+    <https://sws.geonames.org/2798280/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "92045" ;
+  skos:prefLabel "Floreffe"@de,
+    "Floreffe"@fr,
+    "Floreffe"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/92048> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/92000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/92048>,
+    <http://www.wikidata.org/entity/Q720478>,
+    <https://sws.geonames.org/2798101/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "92048" ;
+  skos:prefLabel "Fosses-la-Ville"@de,
+    "Fosses-la-Ville"@fr,
+    "Fosses-la-Ville"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/92054> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/92000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/92054>,
+    <http://www.wikidata.org/entity/Q388879>,
+    <https://sws.geonames.org/2797582/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "92054" ;
+  skos:prefLabel "Gesves"@de,
+    "Gesves"@fr,
+    "Gesves"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/92087> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/92000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/92087>,
+    <http://www.wikidata.org/entity/Q118769>,
+    <https://sws.geonames.org/2791262/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "92087" ;
+  skos:prefLabel "Mettet"@de,
+    "Mettet"@fr,
+    "Mettet"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/92094> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/92000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/92094>,
+    <http://www.wikidata.org/entity/Q134121>,
+    <https://sws.geonames.org/2790472/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "92094" ;
+  skos:prefLabel "Namur"@de,
+    "Namur"@fr,
+    "Namen"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/92097> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/92000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/92097>,
+    <http://www.wikidata.org/entity/Q721090>,
+    <https://sws.geonames.org/2789909/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "92097" ;
+  skos:prefLabel "Ohey"@de,
+    "Ohey"@fr,
+    "Ohey"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/92101> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/92000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/92101>,
+    <http://www.wikidata.org/entity/Q696940>,
+    <https://sws.geonames.org/2788578/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "92101" ;
+  skos:prefLabel "Profondeville"@de,
+    "Profondeville"@fr,
+    "Profondeville"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/92114> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/92000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/92114>,
+    <http://www.wikidata.org/entity/Q650226>,
+    <https://sws.geonames.org/2786391/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "92114" ;
+  skos:prefLabel "Sombreffe"@de,
+    "Sombreffe"@fr,
+    "Sombreffe"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/92137> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/92000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/92137>,
+    <http://www.wikidata.org/entity/Q650185>,
+    <https://sws.geonames.org/2802903/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "92137" ;
+  skos:prefLabel "Sambreville"@de,
+    "Sambreville"@fr,
+    "Sambreville"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/92138> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/92000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/92138>,
+    <http://www.wikidata.org/entity/Q696104>,
+    <https://sws.geonames.org/2788742/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "92138" ;
+  skos:prefLabel "Fernelmont"@de,
+    "Fernelmont"@fr,
+    "Fernelmont"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/92140> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/92000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/92140>,
+    <http://www.wikidata.org/entity/Q720791>,
+    <https://sws.geonames.org/2794933/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "92140" ;
+  skos:prefLabel "Jemeppe-sur-Sambre"@de,
+    "Jemeppe-sur-Sambre"@fr,
+    "Jemeppe-sur-Sambre"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/92141> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/92000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/92141>,
+    <http://www.wikidata.org/entity/Q715422>,
+    <https://sws.geonames.org/2788112/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "92141" ;
+  skos:prefLabel "La Bruyère"@de,
+    "La Bruyère"@fr,
+    "La Bruyère"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/92142> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/92000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/92142>,
+    <http://www.wikidata.org/entity/Q223927>,
+    <https://sws.geonames.org/2797714/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "92142" ;
+  skos:prefLabel "Gembloux"@de,
+    "Gembloux"@fr,
+    "Gembloux"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/93010> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/93000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/93010>,
+    <http://www.wikidata.org/entity/Q715474>,
+    <https://sws.geonames.org/2800592/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "93010" ;
+  skos:prefLabel "Cerfontaine"@de,
+    "Cerfontaine"@fr,
+    "Cerfontaine"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/93014> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/93000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/93014>,
+    <http://www.wikidata.org/entity/Q326771>,
+    <https://sws.geonames.org/2800026/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "93014" ;
+  skos:prefLabel "Couvin"@de,
+    "Couvin"@fr,
+    "Couvin"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/93018> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/93000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/93018>,
+    <http://www.wikidata.org/entity/Q720275>,
+    <https://sws.geonames.org/2799329/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "93018" ;
+  skos:prefLabel "Doische"@de,
+    "Doische"@fr,
+    "Doische"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/93022> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/93000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/93022>,
+    <http://www.wikidata.org/entity/Q720429>,
+    <https://sws.geonames.org/2798277/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "93022" ;
+  skos:prefLabel "Florennes"@de,
+    "Florennes"@fr,
+    "Florennes"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/93056> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/93000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/93056>,
+    <http://www.wikidata.org/entity/Q650239>,
+    <https://sws.geonames.org/2789017/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "93056" ;
+  skos:prefLabel "Philippeville"@de,
+    "Philippeville"@fr,
+    "Philippeville"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/93088> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/93000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/93088>,
+    <http://www.wikidata.org/entity/Q497565>,
+    <https://sws.geonames.org/2784190/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "93088" ;
+  skos:prefLabel "Walcourt"@de,
+    "Walcourt"@fr,
+    "Walcourt"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/93090> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/93000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/93090>,
+    <http://www.wikidata.org/entity/Q650261>,
+    <https://sws.geonames.org/2799225/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:notation "93090" ;
+  skos:prefLabel "Viroinval"@de,
+    "Viroinval"@fr,
+    "Viroinval"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/20002> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/3000> ;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE31>,
+    <http://vocab.belgif.be/auth/refnis2019/20002>,
+    <https://sws.geonames.org/3333251/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/25000> ;
+  skos:notation "20002" ;
+  skos:prefLabel "Provinz Wallonisch-Brabant"@de,
+    "Province du Brabant wallon"@fr,
+    "Provincie Waals-Brabant"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/4000> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/1000> ;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE1>,
+    <http://vocab.belgif.be/auth/refnis2019/4000>,
+    <https://sws.geonames.org/2800867/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/21000> ;
+  skos:notation "4000" ;
+  skos:prefLabel "Region Brüssel-Hauptstadt"@de,
+    "Région de Bruxelles-Capitale"@fr,
+    "Brussels Hoofdstedelijk Gewest"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<https://org.belgif.be/id/CbeRegisteredEntity/0314595348/statbel> regorg:legalName "Statbel"@de,
+    "Statbel"@en,
+    "Statbel"@fr,
+    "Statbel"@nl .
+
+<http://vocab.belgif.be/auth/refnis2025/20001> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/2000> ;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE24>,
+    <http://vocab.belgif.be/auth/refnis2019/20001>,
+    <https://sws.geonames.org/3333250/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/23000>,
+    <http://vocab.belgif.be/auth/refnis2025/24000> ;
+  skos:notation "20001" ;
+  skos:prefLabel "Provinz Flämisch-Brabant"@de,
+    "Province du Brabant flamand"@fr,
+    "Provincie Vlaams-Brabant"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/1000> a skos:Concept ;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE>,
+    <http://vocab.belgif.be/auth/refnis2019/1000>,
+    <http://vocab.belgif.be/auth/territory/150>,
+    <https://sws.geonames.org/2802361/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/2000>,
+    <http://vocab.belgif.be/auth/refnis2025/3000>,
+    <http://vocab.belgif.be/auth/refnis2025/4000> ;
+  skos:notation "1000" ;
+  skos:prefLabel "Belgien"@de,
+    "Belgique"@fr,
+    "België"@nl ;
+  skos:topConceptOf <http://vocab.belgif.be/auth/refnis2025> ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/10000> a skos:Concept ;
+  skos:broadMatch <http://vocab.belgif.be/auth/refnis2019/10000> ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/2000> ;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE21>,
+    <https://sws.geonames.org/2803136/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/11000>,
+    <http://vocab.belgif.be/auth/refnis2025/12000>,
+    <http://vocab.belgif.be/auth/refnis2025/13000> ;
+  skos:notation "10000" ;
+  skos:prefLabel "Provinz Antwerpen"@de,
+    "Province d’Anvers"@fr,
+    "Provincie Antwerpen"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2025-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/70000> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/2000> ;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE22>,
+    <http://vocab.belgif.be/auth/refnis2019/70000>,
+    <https://sws.geonames.org/2792347/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/71000>,
+    <http://vocab.belgif.be/auth/refnis2025/72000>,
+    <http://vocab.belgif.be/auth/refnis2025/73000> ;
+  skos:notation "70000" ;
+  skos:prefLabel "Provinz Limburg"@de,
+    "Province du Limbourg"@fr,
+    "Provincie Limburg"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/90000> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/3000> ;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE35>,
+    <http://vocab.belgif.be/auth/refnis2019/90000>,
+    <https://sws.geonames.org/2790469/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/91000>,
+    <http://vocab.belgif.be/auth/refnis2025/92000>,
+    <http://vocab.belgif.be/auth/refnis2025/93000> ;
+  skos:notation "90000" ;
+  skos:prefLabel "Provinz Namur"@de,
+    "Province de Namur"@fr,
+    "Provincie Namen"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/58000> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/50000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/58000> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/58001>,
+    <http://vocab.belgif.be/auth/refnis2025/58002>,
+    <http://vocab.belgif.be/auth/refnis2025/58003>,
+    <http://vocab.belgif.be/auth/refnis2025/58004> ;
+  skos:notation "58000" ;
+  skos:prefLabel "Bezirk La Louvière"@de,
+    "Arrondissement de La Louvière"@fr,
+    "Arrondissement La Louvière"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/60000> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/3000> ;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE33>,
+    <http://vocab.belgif.be/auth/refnis2019/60000>,
+    <https://sws.geonames.org/2792411/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/61000>,
+    <http://vocab.belgif.be/auth/refnis2025/62000>,
+    <http://vocab.belgif.be/auth/refnis2025/63000>,
+    <http://vocab.belgif.be/auth/refnis2025/64000> ;
+  skos:notation "60000" ;
+  skos:prefLabel "Provinz Lüttich"@de,
+    "Province de Liège"@fr,
+    "Provincie Luik"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/2000> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/1000> ;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE2>,
+    <http://vocab.belgif.be/auth/refnis2019/2000>,
+    <https://sws.geonames.org/3337388/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/10000>,
+    <http://vocab.belgif.be/auth/refnis2025/20001>,
+    <http://vocab.belgif.be/auth/refnis2025/30000>,
+    <http://vocab.belgif.be/auth/refnis2025/40000>,
+    <http://vocab.belgif.be/auth/refnis2025/70000> ;
+  skos:notation "2000" ;
+  skos:prefLabel "Flämische Region"@de,
+    "Région flamande"@fr,
+    "Vlaams Gewest"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/3000> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/1000> ;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE3>,
+    <http://vocab.belgif.be/auth/refnis2019/3000>,
+    <https://sws.geonames.org/3337387/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/20002>,
+    <http://vocab.belgif.be/auth/refnis2025/50000>,
+    <http://vocab.belgif.be/auth/refnis2025/60000>,
+    <http://vocab.belgif.be/auth/refnis2025/80000>,
+    <http://vocab.belgif.be/auth/refnis2025/90000> ;
+  skos:notation "3000" ;
+  skos:prefLabel "Wallonische Region"@de,
+    "Région wallonne"@fr,
+    "Waals Gewest"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/32000> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/30000> ;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE252>,
+    <http://vocab.belgif.be/auth/refnis2019/32000> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/32003>,
+    <http://vocab.belgif.be/auth/refnis2025/32006>,
+    <http://vocab.belgif.be/auth/refnis2025/32010>,
+    <http://vocab.belgif.be/auth/refnis2025/32011>,
+    <http://vocab.belgif.be/auth/refnis2025/32030> ;
+  skos:notation "32000" ;
+  skos:prefLabel "Bezirk Diksmuide"@de,
+    "Arrondissement de Dixmude"@fr,
+    "Arrondissement Diksmuide"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/38000> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/30000> ;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE258>,
+    <http://vocab.belgif.be/auth/refnis2019/38000> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/38002>,
+    <http://vocab.belgif.be/auth/refnis2025/38008>,
+    <http://vocab.belgif.be/auth/refnis2025/38014>,
+    <http://vocab.belgif.be/auth/refnis2025/38016>,
+    <http://vocab.belgif.be/auth/refnis2025/38025> ;
+  skos:notation "38000" ;
+  skos:prefLabel "Bezirk Veurne"@de,
+    "Arrondissement de Furnes"@fr,
+    "Arrondissement Veurne"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/80000> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/3000> ;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE34>,
+    <http://vocab.belgif.be/auth/refnis2019/80000>,
+    <https://sws.geonames.org/2791993/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/81000>,
+    <http://vocab.belgif.be/auth/refnis2025/82000>,
+    <http://vocab.belgif.be/auth/refnis2025/83000>,
+    <http://vocab.belgif.be/auth/refnis2025/84000>,
+    <http://vocab.belgif.be/auth/refnis2025/85000> ;
+  skos:notation "80000" ;
+  skos:prefLabel "Provinz Luxemburg"@de,
+    "Province du Luxembourg"@fr,
+    "Provincie Luxemburg"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/81000> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/80000> ;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE341>,
+    <http://vocab.belgif.be/auth/refnis2019/81000> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/81001>,
+    <http://vocab.belgif.be/auth/refnis2025/81003>,
+    <http://vocab.belgif.be/auth/refnis2025/81004>,
+    <http://vocab.belgif.be/auth/refnis2025/81013>,
+    <http://vocab.belgif.be/auth/refnis2025/81015> ;
+  skos:notation "81000" ;
+  skos:prefLabel "Bezirk Arlon"@de,
+    "Arrondissement d’Arlon"@fr,
+    "Arrondissement Aarlen"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/37000> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/30000> ;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE257>,
+    <http://vocab.belgif.be/auth/refnis2019/37000> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/37002>,
+    <http://vocab.belgif.be/auth/refnis2025/37010>,
+    <http://vocab.belgif.be/auth/refnis2025/37011>,
+    <http://vocab.belgif.be/auth/refnis2025/37017>,
+    <http://vocab.belgif.be/auth/refnis2025/37020>,
+    <http://vocab.belgif.be/auth/refnis2025/37021>,
+    <http://vocab.belgif.be/auth/refnis2025/37022> ;
+  skos:notation "37000" ;
+  skos:prefLabel "Bezirk Tielt"@de,
+    "Arrondissement de Tielt"@fr,
+    "Arrondissement Tielt"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/40000> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/2000> ;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE23>,
+    <https://sws.geonames.org/2789733/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrowMatch <http://vocab.belgif.be/auth/refnis2019/40000> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/41000>,
+    <http://vocab.belgif.be/auth/refnis2025/42000>,
+    <http://vocab.belgif.be/auth/refnis2025/43000>,
+    <http://vocab.belgif.be/auth/refnis2025/44000>,
+    <http://vocab.belgif.be/auth/refnis2025/45000>,
+    <http://vocab.belgif.be/auth/refnis2025/46000> ;
+  skos:notation "40000" ;
+  skos:prefLabel "Provinz Ostflandern"@de,
+    "Province de Flandre orientale"@fr,
+    "Provincie Oost-Vlaanderen"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2025-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/43000> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/40000> ;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE233>,
+    <http://vocab.belgif.be/auth/refnis2019/43000> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/43002>,
+    <http://vocab.belgif.be/auth/refnis2025/43005>,
+    <http://vocab.belgif.be/auth/refnis2025/43007>,
+    <http://vocab.belgif.be/auth/refnis2025/43010>,
+    <http://vocab.belgif.be/auth/refnis2025/43014>,
+    <http://vocab.belgif.be/auth/refnis2025/43018> ;
+  skos:notation "43000" ;
+  skos:prefLabel "Bezirk Eeklo"@de,
+    "Arrondissement d’Eeklo"@fr,
+    "Arrondissement Eeklo"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/46000> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/40000> ;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE236> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrowMatch <http://vocab.belgif.be/auth/refnis2019/46000> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/46020>,
+    <http://vocab.belgif.be/auth/refnis2025/46021>,
+    <http://vocab.belgif.be/auth/refnis2025/46024>,
+    <http://vocab.belgif.be/auth/refnis2025/46025>,
+    <http://vocab.belgif.be/auth/refnis2025/46029>,
+    <http://vocab.belgif.be/auth/refnis2025/46030> ;
+  skos:notation "46000" ;
+  skos:prefLabel "Bezirk Sint-Niklaas"@de,
+    "Arrondissement de Saint-Nicolas"@fr,
+    "Arrondissement Sint-Niklaas"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2025-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/55000> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/50000> ;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE325>,
+    <http://vocab.belgif.be/auth/refnis2019/55000> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/55004>,
+    <http://vocab.belgif.be/auth/refnis2025/55035>,
+    <http://vocab.belgif.be/auth/refnis2025/55040>,
+    <http://vocab.belgif.be/auth/refnis2025/55050>,
+    <http://vocab.belgif.be/auth/refnis2025/55085>,
+    <http://vocab.belgif.be/auth/refnis2025/55086> ;
+  skos:notation "55000" ;
+  skos:prefLabel "Bezirk Soignies"@de,
+    "Arrondissement de Soignies"@fr,
+    "Arrondissement Zinnik"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/35000> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/30000> ;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE255>,
+    <http://vocab.belgif.be/auth/refnis2019/35000> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/35002>,
+    <http://vocab.belgif.be/auth/refnis2025/35005>,
+    <http://vocab.belgif.be/auth/refnis2025/35006>,
+    <http://vocab.belgif.be/auth/refnis2025/35011>,
+    <http://vocab.belgif.be/auth/refnis2025/35013>,
+    <http://vocab.belgif.be/auth/refnis2025/35014>,
+    <http://vocab.belgif.be/auth/refnis2025/35029> ;
+  skos:notation "35000" ;
+  skos:prefLabel "Bezirk Ostende"@de,
+    "Arrondissement d’Ostende"@fr,
+    "Arrondissement Oostende"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/50000> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/3000> ;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE32>,
+    <http://vocab.belgif.be/auth/refnis2019/50000>,
+    <https://sws.geonames.org/2796741/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/51000>,
+    <http://vocab.belgif.be/auth/refnis2025/52000>,
+    <http://vocab.belgif.be/auth/refnis2025/53000>,
+    <http://vocab.belgif.be/auth/refnis2025/55000>,
+    <http://vocab.belgif.be/auth/refnis2025/56000>,
+    <http://vocab.belgif.be/auth/refnis2025/57000>,
+    <http://vocab.belgif.be/auth/refnis2025/58000> ;
+  skos:notation "50000" ;
+  skos:prefLabel "Provinz Hennegau"@de,
+    "Province du Hainaut"@fr,
+    "Provincie Henegouwen"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/82000> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/80000> ;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE342>,
+    <http://vocab.belgif.be/auth/refnis2019/82000> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/82009>,
+    <http://vocab.belgif.be/auth/refnis2025/82014>,
+    <http://vocab.belgif.be/auth/refnis2025/82032>,
+    <http://vocab.belgif.be/auth/refnis2025/82036>,
+    <http://vocab.belgif.be/auth/refnis2025/82037>,
+    <http://vocab.belgif.be/auth/refnis2025/82038>,
+    <http://vocab.belgif.be/auth/refnis2025/82039> ;
+  skos:notation "82000" ;
+  skos:prefLabel "Bezirk Bastogne"@de,
+    "Arrondissement de Bastogne"@fr,
+    "Arrondissement Bastenaken"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/93000> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/90000> ;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE353>,
+    <http://vocab.belgif.be/auth/refnis2019/93000> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/93010>,
+    <http://vocab.belgif.be/auth/refnis2025/93014>,
+    <http://vocab.belgif.be/auth/refnis2025/93018>,
+    <http://vocab.belgif.be/auth/refnis2025/93022>,
+    <http://vocab.belgif.be/auth/refnis2025/93056>,
+    <http://vocab.belgif.be/auth/refnis2025/93088>,
+    <http://vocab.belgif.be/auth/refnis2025/93090> ;
+  skos:notation "93000" ;
+  skos:prefLabel "Bezirk Philippeville"@de,
+    "Arrondissement de Philippeville"@fr,
+    "Arrondissement Philippeville"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/30000> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/2000> ;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE25>,
+    <http://vocab.belgif.be/auth/refnis2019/30000>,
+    <https://sws.geonames.org/2783770/> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/31000>,
+    <http://vocab.belgif.be/auth/refnis2025/32000>,
+    <http://vocab.belgif.be/auth/refnis2025/33000>,
+    <http://vocab.belgif.be/auth/refnis2025/34000>,
+    <http://vocab.belgif.be/auth/refnis2025/35000>,
+    <http://vocab.belgif.be/auth/refnis2025/36000>,
+    <http://vocab.belgif.be/auth/refnis2025/37000>,
+    <http://vocab.belgif.be/auth/refnis2025/38000> ;
+  skos:notation "30000" ;
+  skos:prefLabel "Provinz Westflandern"@de,
+    "Province de Flandre occidentale"@fr,
+    "Provincie West-Vlaanderen"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/33000> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/30000> ;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE253>,
+    <http://vocab.belgif.be/auth/refnis2019/33000> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/33011>,
+    <http://vocab.belgif.be/auth/refnis2025/33016>,
+    <http://vocab.belgif.be/auth/refnis2025/33021>,
+    <http://vocab.belgif.be/auth/refnis2025/33029>,
+    <http://vocab.belgif.be/auth/refnis2025/33037>,
+    <http://vocab.belgif.be/auth/refnis2025/33039>,
+    <http://vocab.belgif.be/auth/refnis2025/33040>,
+    <http://vocab.belgif.be/auth/refnis2025/33041> ;
+  skos:notation "33000" ;
+  skos:prefLabel "Bezirk Ypern"@de,
+    "Arrondissement d’Ypres"@fr,
+    "Arrondissement Ieper"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/36000> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/30000> ;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE256>,
+    <http://vocab.belgif.be/auth/refnis2019/36000> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/36006>,
+    <http://vocab.belgif.be/auth/refnis2025/36007>,
+    <http://vocab.belgif.be/auth/refnis2025/36008>,
+    <http://vocab.belgif.be/auth/refnis2025/36010>,
+    <http://vocab.belgif.be/auth/refnis2025/36011>,
+    <http://vocab.belgif.be/auth/refnis2025/36012>,
+    <http://vocab.belgif.be/auth/refnis2025/36015>,
+    <http://vocab.belgif.be/auth/refnis2025/36019> ;
+  skos:notation "36000" ;
+  skos:prefLabel "Bezirk Roeselare"@de,
+    "Arrondissement de Roulers"@fr,
+    "Arrondissement Roeselare"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/83000> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/80000> ;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE343>,
+    <http://vocab.belgif.be/auth/refnis2019/83000> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/83012>,
+    <http://vocab.belgif.be/auth/refnis2025/83013>,
+    <http://vocab.belgif.be/auth/refnis2025/83028>,
+    <http://vocab.belgif.be/auth/refnis2025/83031>,
+    <http://vocab.belgif.be/auth/refnis2025/83034>,
+    <http://vocab.belgif.be/auth/refnis2025/83040>,
+    <http://vocab.belgif.be/auth/refnis2025/83044>,
+    <http://vocab.belgif.be/auth/refnis2025/83049>,
+    <http://vocab.belgif.be/auth/refnis2025/83055> ;
+  skos:notation "83000" ;
+  skos:prefLabel "Bezirk Marche-en-Famenne"@de,
+    "Arrondissement de Marche-en-Famenne"@fr,
+    "Arrondissement Marche-en-Famenne"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/31000> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/30000> ;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE251>,
+    <http://vocab.belgif.be/auth/refnis2019/31000> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/31003>,
+    <http://vocab.belgif.be/auth/refnis2025/31004>,
+    <http://vocab.belgif.be/auth/refnis2025/31005>,
+    <http://vocab.belgif.be/auth/refnis2025/31006>,
+    <http://vocab.belgif.be/auth/refnis2025/31012>,
+    <http://vocab.belgif.be/auth/refnis2025/31022>,
+    <http://vocab.belgif.be/auth/refnis2025/31033>,
+    <http://vocab.belgif.be/auth/refnis2025/31040>,
+    <http://vocab.belgif.be/auth/refnis2025/31042>,
+    <http://vocab.belgif.be/auth/refnis2025/31043> ;
+  skos:notation "31000" ;
+  skos:prefLabel "Bezirk Brügge"@de,
+    "Arrondissement de Bruges"@fr,
+    "Arrondissement Brugge"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/41000> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/40000> ;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE231>,
+    <http://vocab.belgif.be/auth/refnis2019/41000> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/41002>,
+    <http://vocab.belgif.be/auth/refnis2025/41011>,
+    <http://vocab.belgif.be/auth/refnis2025/41018>,
+    <http://vocab.belgif.be/auth/refnis2025/41024>,
+    <http://vocab.belgif.be/auth/refnis2025/41027>,
+    <http://vocab.belgif.be/auth/refnis2025/41034>,
+    <http://vocab.belgif.be/auth/refnis2025/41048>,
+    <http://vocab.belgif.be/auth/refnis2025/41063>,
+    <http://vocab.belgif.be/auth/refnis2025/41081>,
+    <http://vocab.belgif.be/auth/refnis2025/41082> ;
+  skos:notation "41000" ;
+  skos:prefLabel "Bezirk Aalst"@de,
+    "Arrondissement d’Alost"@fr,
+    "Arrondissement Aalst"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/42000> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/40000> ;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE232>,
+    <http://vocab.belgif.be/auth/refnis2019/42000> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/42003>,
+    <http://vocab.belgif.be/auth/refnis2025/42004>,
+    <http://vocab.belgif.be/auth/refnis2025/42006>,
+    <http://vocab.belgif.be/auth/refnis2025/42008>,
+    <http://vocab.belgif.be/auth/refnis2025/42010>,
+    <http://vocab.belgif.be/auth/refnis2025/42011>,
+    <http://vocab.belgif.be/auth/refnis2025/42023>,
+    <http://vocab.belgif.be/auth/refnis2025/42025>,
+    <http://vocab.belgif.be/auth/refnis2025/42026>,
+    <http://vocab.belgif.be/auth/refnis2025/42028> ;
+  skos:notation "42000" ;
+  skos:prefLabel "Bezirk Dendermonde"@de,
+    "Arrondissement de Termonde"@fr,
+    "Arrondissement Dendermonde"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/45000> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/40000> ;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE235>,
+    <http://vocab.belgif.be/auth/refnis2019/45000> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/45035>,
+    <http://vocab.belgif.be/auth/refnis2025/45041>,
+    <http://vocab.belgif.be/auth/refnis2025/45059>,
+    <http://vocab.belgif.be/auth/refnis2025/45060>,
+    <http://vocab.belgif.be/auth/refnis2025/45061>,
+    <http://vocab.belgif.be/auth/refnis2025/45062>,
+    <http://vocab.belgif.be/auth/refnis2025/45063>,
+    <http://vocab.belgif.be/auth/refnis2025/45064>,
+    <http://vocab.belgif.be/auth/refnis2025/45065>,
+    <http://vocab.belgif.be/auth/refnis2025/45068> ;
+  skos:notation "45000" ;
+  skos:prefLabel "Bezirk Oudenaarde"@de,
+    "Arrondissement d’Audenarde"@fr,
+    "Arrondissement Oudenaarde"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/73000> a skos:Concept ;
+  skos:broadMatch <http://vocab.belgif.be/auth/refnis2019/73000> ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/70000> ;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE223> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/73001>,
+    <http://vocab.belgif.be/auth/refnis2025/73022>,
+    <http://vocab.belgif.be/auth/refnis2025/73028>,
+    <http://vocab.belgif.be/auth/refnis2025/73042>,
+    <http://vocab.belgif.be/auth/refnis2025/73066>,
+    <http://vocab.belgif.be/auth/refnis2025/73098>,
+    <http://vocab.belgif.be/auth/refnis2025/73107>,
+    <http://vocab.belgif.be/auth/refnis2025/73109>,
+    <http://vocab.belgif.be/auth/refnis2025/73110>,
+    <http://vocab.belgif.be/auth/refnis2025/73111> ;
+  skos:notation "73000" ;
+  skos:prefLabel "Bezirk Tongeren"@de,
+    "Arrondissement de Tongres"@fr,
+    "Arrondissement Tongeren"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2025-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/85000> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/80000> ;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE345>,
+    <http://vocab.belgif.be/auth/refnis2019/85000> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/85007>,
+    <http://vocab.belgif.be/auth/refnis2025/85009>,
+    <http://vocab.belgif.be/auth/refnis2025/85011>,
+    <http://vocab.belgif.be/auth/refnis2025/85024>,
+    <http://vocab.belgif.be/auth/refnis2025/85026>,
+    <http://vocab.belgif.be/auth/refnis2025/85034>,
+    <http://vocab.belgif.be/auth/refnis2025/85039>,
+    <http://vocab.belgif.be/auth/refnis2025/85045>,
+    <http://vocab.belgif.be/auth/refnis2025/85046>,
+    <http://vocab.belgif.be/auth/refnis2025/85047> ;
+  skos:notation "85000" ;
+  skos:prefLabel "Bezirk Virton"@de,
+    "Arrondissement de Virton"@fr,
+    "Arrondissement Virton"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/51000> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/50000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/51000> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrowMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE321> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/51004>,
+    <http://vocab.belgif.be/auth/refnis2025/51008>,
+    <http://vocab.belgif.be/auth/refnis2025/51009>,
+    <http://vocab.belgif.be/auth/refnis2025/51012>,
+    <http://vocab.belgif.be/auth/refnis2025/51014>,
+    <http://vocab.belgif.be/auth/refnis2025/51017>,
+    <http://vocab.belgif.be/auth/refnis2025/51019>,
+    <http://vocab.belgif.be/auth/refnis2025/51065>,
+    <http://vocab.belgif.be/auth/refnis2025/51067>,
+    <http://vocab.belgif.be/auth/refnis2025/51068>,
+    <http://vocab.belgif.be/auth/refnis2025/51069> ;
+  skos:notation "51000" ;
+  skos:prefLabel "Bezirk Ath"@de,
+    "Arrondissement d’Ath"@fr,
+    "Arrondissement Aat"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/56000> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/50000> ;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE326>,
+    <http://vocab.belgif.be/auth/refnis2019/56000> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/56001>,
+    <http://vocab.belgif.be/auth/refnis2025/56005>,
+    <http://vocab.belgif.be/auth/refnis2025/56016>,
+    <http://vocab.belgif.be/auth/refnis2025/56022>,
+    <http://vocab.belgif.be/auth/refnis2025/56029>,
+    <http://vocab.belgif.be/auth/refnis2025/56044>,
+    <http://vocab.belgif.be/auth/refnis2025/56049>,
+    <http://vocab.belgif.be/auth/refnis2025/56051>,
+    <http://vocab.belgif.be/auth/refnis2025/56078>,
+    <http://vocab.belgif.be/auth/refnis2025/56086>,
+    <http://vocab.belgif.be/auth/refnis2025/56088> ;
+  skos:notation "56000" ;
+  skos:prefLabel "Bezirk Thuin"@de,
+    "Arrondissement de Thuin"@fr,
+    "Arrondissement Thuin"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/34000> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/30000> ;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE254>,
+    <http://vocab.belgif.be/auth/refnis2019/34000> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/34002>,
+    <http://vocab.belgif.be/auth/refnis2025/34003>,
+    <http://vocab.belgif.be/auth/refnis2025/34009>,
+    <http://vocab.belgif.be/auth/refnis2025/34013>,
+    <http://vocab.belgif.be/auth/refnis2025/34022>,
+    <http://vocab.belgif.be/auth/refnis2025/34023>,
+    <http://vocab.belgif.be/auth/refnis2025/34025>,
+    <http://vocab.belgif.be/auth/refnis2025/34027>,
+    <http://vocab.belgif.be/auth/refnis2025/34040>,
+    <http://vocab.belgif.be/auth/refnis2025/34041>,
+    <http://vocab.belgif.be/auth/refnis2025/34042>,
+    <http://vocab.belgif.be/auth/refnis2025/34043> ;
+  skos:notation "34000" ;
+  skos:prefLabel "Bezirk Kortrijk"@de,
+    "Arrondissement de Courtrai"@fr,
+    "Arrondissement Kortrijk"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/52000> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/50000> ;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE322>,
+    <http://vocab.belgif.be/auth/refnis2019/52000> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/52010>,
+    <http://vocab.belgif.be/auth/refnis2025/52011>,
+    <http://vocab.belgif.be/auth/refnis2025/52012>,
+    <http://vocab.belgif.be/auth/refnis2025/52015>,
+    <http://vocab.belgif.be/auth/refnis2025/52018>,
+    <http://vocab.belgif.be/auth/refnis2025/52021>,
+    <http://vocab.belgif.be/auth/refnis2025/52022>,
+    <http://vocab.belgif.be/auth/refnis2025/52025>,
+    <http://vocab.belgif.be/auth/refnis2025/52048>,
+    <http://vocab.belgif.be/auth/refnis2025/52055>,
+    <http://vocab.belgif.be/auth/refnis2025/52074>,
+    <http://vocab.belgif.be/auth/refnis2025/52075> ;
+  skos:notation "52000" ;
+  skos:prefLabel "Bezirk Charleroi"@de,
+    "Arrondissement de Charleroi"@fr,
+    "Arrondissement Charleroi"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/57000> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/50000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/57000> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrowMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE327> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/57003>,
+    <http://vocab.belgif.be/auth/refnis2025/57018>,
+    <http://vocab.belgif.be/auth/refnis2025/57027>,
+    <http://vocab.belgif.be/auth/refnis2025/57062>,
+    <http://vocab.belgif.be/auth/refnis2025/57064>,
+    <http://vocab.belgif.be/auth/refnis2025/57072>,
+    <http://vocab.belgif.be/auth/refnis2025/57081>,
+    <http://vocab.belgif.be/auth/refnis2025/57093>,
+    <http://vocab.belgif.be/auth/refnis2025/57094>,
+    <http://vocab.belgif.be/auth/refnis2025/57095>,
+    <http://vocab.belgif.be/auth/refnis2025/57096>,
+    <http://vocab.belgif.be/auth/refnis2025/57097> ;
+  skos:notation "57000" ;
+  skos:prefLabel "Bezirk Tournai-Mouscron"@de,
+    "Arrondissement de Tournai-Mouscron"@fr,
+    "Arrondissement Doornik-Moeskroen"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/72000> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/70000> ;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE222>,
+    <http://vocab.belgif.be/auth/refnis2019/72000> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/72003>,
+    <http://vocab.belgif.be/auth/refnis2025/72004>,
+    <http://vocab.belgif.be/auth/refnis2025/72018>,
+    <http://vocab.belgif.be/auth/refnis2025/72020>,
+    <http://vocab.belgif.be/auth/refnis2025/72021>,
+    <http://vocab.belgif.be/auth/refnis2025/72030>,
+    <http://vocab.belgif.be/auth/refnis2025/72037>,
+    <http://vocab.belgif.be/auth/refnis2025/72038>,
+    <http://vocab.belgif.be/auth/refnis2025/72039>,
+    <http://vocab.belgif.be/auth/refnis2025/72041>,
+    <http://vocab.belgif.be/auth/refnis2025/72042>,
+    <http://vocab.belgif.be/auth/refnis2025/72043> ;
+  skos:notation "72000" ;
+  skos:prefLabel "Bezirk Maaseik"@de,
+    "Arrondissement de Maaseik"@fr,
+    "Arrondissement Maaseik"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/84000> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/80000> ;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE344>,
+    <http://vocab.belgif.be/auth/refnis2019/84000> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/84009>,
+    <http://vocab.belgif.be/auth/refnis2025/84010>,
+    <http://vocab.belgif.be/auth/refnis2025/84016>,
+    <http://vocab.belgif.be/auth/refnis2025/84029>,
+    <http://vocab.belgif.be/auth/refnis2025/84033>,
+    <http://vocab.belgif.be/auth/refnis2025/84035>,
+    <http://vocab.belgif.be/auth/refnis2025/84043>,
+    <http://vocab.belgif.be/auth/refnis2025/84050>,
+    <http://vocab.belgif.be/auth/refnis2025/84059>,
+    <http://vocab.belgif.be/auth/refnis2025/84068>,
+    <http://vocab.belgif.be/auth/refnis2025/84075>,
+    <http://vocab.belgif.be/auth/refnis2025/84077> ;
+  skos:notation "84000" ;
+  skos:prefLabel "Bezirk Neufchâteau"@de,
+    "Arrondissement de Neufchâteau"@fr,
+    "Arrondissement Neufchâteau"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/12000> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/10000> ;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE212>,
+    <http://vocab.belgif.be/auth/refnis2019/12000> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/12002>,
+    <http://vocab.belgif.be/auth/refnis2025/12005>,
+    <http://vocab.belgif.be/auth/refnis2025/12007>,
+    <http://vocab.belgif.be/auth/refnis2025/12009>,
+    <http://vocab.belgif.be/auth/refnis2025/12014>,
+    <http://vocab.belgif.be/auth/refnis2025/12021>,
+    <http://vocab.belgif.be/auth/refnis2025/12025>,
+    <http://vocab.belgif.be/auth/refnis2025/12026>,
+    <http://vocab.belgif.be/auth/refnis2025/12029>,
+    <http://vocab.belgif.be/auth/refnis2025/12034>,
+    <http://vocab.belgif.be/auth/refnis2025/12035>,
+    <http://vocab.belgif.be/auth/refnis2025/12040>,
+    <http://vocab.belgif.be/auth/refnis2025/12041> ;
+  skos:notation "12000" ;
+  skos:prefLabel "Bezirk Mechelen"@de,
+    "Arrondissement de Malines"@fr,
+    "Arrondissement Mechelen"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/53000> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/50000> ;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE323>,
+    <http://vocab.belgif.be/auth/refnis2019/53000> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/53014>,
+    <http://vocab.belgif.be/auth/refnis2025/53020>,
+    <http://vocab.belgif.be/auth/refnis2025/53028>,
+    <http://vocab.belgif.be/auth/refnis2025/53039>,
+    <http://vocab.belgif.be/auth/refnis2025/53044>,
+    <http://vocab.belgif.be/auth/refnis2025/53046>,
+    <http://vocab.belgif.be/auth/refnis2025/53053>,
+    <http://vocab.belgif.be/auth/refnis2025/53065>,
+    <http://vocab.belgif.be/auth/refnis2025/53068>,
+    <http://vocab.belgif.be/auth/refnis2025/53070>,
+    <http://vocab.belgif.be/auth/refnis2025/53082>,
+    <http://vocab.belgif.be/auth/refnis2025/53083>,
+    <http://vocab.belgif.be/auth/refnis2025/53084> ;
+  skos:notation "53000" ;
+  skos:prefLabel "Bezirk Mons"@de,
+    "Arrondissement de Mons"@fr,
+    "Arrondissement Bergen"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/44000> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/40000> ;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE234>,
+    <http://vocab.belgif.be/auth/refnis2019/44000> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/44013>,
+    <http://vocab.belgif.be/auth/refnis2025/44019>,
+    <http://vocab.belgif.be/auth/refnis2025/44020>,
+    <http://vocab.belgif.be/auth/refnis2025/44021>,
+    <http://vocab.belgif.be/auth/refnis2025/44045>,
+    <http://vocab.belgif.be/auth/refnis2025/44052>,
+    <http://vocab.belgif.be/auth/refnis2025/44064>,
+    <http://vocab.belgif.be/auth/refnis2025/44081>,
+    <http://vocab.belgif.be/auth/refnis2025/44083>,
+    <http://vocab.belgif.be/auth/refnis2025/44084>,
+    <http://vocab.belgif.be/auth/refnis2025/44085>,
+    <http://vocab.belgif.be/auth/refnis2025/44086>,
+    <http://vocab.belgif.be/auth/refnis2025/44087>,
+    <http://vocab.belgif.be/auth/refnis2025/44088> ;
+  skos:notation "44000" ;
+  skos:prefLabel "Bezirk Gent"@de,
+    "Arrondissement de Gand"@fr,
+    "Arrondissement Gent"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/64000> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/60000> ;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE334>,
+    <http://vocab.belgif.be/auth/refnis2019/64000> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/64008>,
+    <http://vocab.belgif.be/auth/refnis2025/64015>,
+    <http://vocab.belgif.be/auth/refnis2025/64021>,
+    <http://vocab.belgif.be/auth/refnis2025/64023>,
+    <http://vocab.belgif.be/auth/refnis2025/64025>,
+    <http://vocab.belgif.be/auth/refnis2025/64029>,
+    <http://vocab.belgif.be/auth/refnis2025/64034>,
+    <http://vocab.belgif.be/auth/refnis2025/64047>,
+    <http://vocab.belgif.be/auth/refnis2025/64056>,
+    <http://vocab.belgif.be/auth/refnis2025/64063>,
+    <http://vocab.belgif.be/auth/refnis2025/64065>,
+    <http://vocab.belgif.be/auth/refnis2025/64074>,
+    <http://vocab.belgif.be/auth/refnis2025/64075>,
+    <http://vocab.belgif.be/auth/refnis2025/64076> ;
+  skos:notation "64000" ;
+  skos:prefLabel "Bezirk Waremme"@de,
+    "Arrondissement de Waremme"@fr,
+    "Arrondissement Borgworm"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/91000> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/90000> ;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE351>,
+    <http://vocab.belgif.be/auth/refnis2019/91000> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/91005>,
+    <http://vocab.belgif.be/auth/refnis2025/91013>,
+    <http://vocab.belgif.be/auth/refnis2025/91015>,
+    <http://vocab.belgif.be/auth/refnis2025/91030>,
+    <http://vocab.belgif.be/auth/refnis2025/91034>,
+    <http://vocab.belgif.be/auth/refnis2025/91054>,
+    <http://vocab.belgif.be/auth/refnis2025/91059>,
+    <http://vocab.belgif.be/auth/refnis2025/91064>,
+    <http://vocab.belgif.be/auth/refnis2025/91072>,
+    <http://vocab.belgif.be/auth/refnis2025/91103>,
+    <http://vocab.belgif.be/auth/refnis2025/91114>,
+    <http://vocab.belgif.be/auth/refnis2025/91120>,
+    <http://vocab.belgif.be/auth/refnis2025/91141>,
+    <http://vocab.belgif.be/auth/refnis2025/91142>,
+    <http://vocab.belgif.be/auth/refnis2025/91143> ;
+  skos:notation "91000" ;
+  skos:prefLabel "Bezirk Dinant"@de,
+    "Arrondissement de Dinant"@fr,
+    "Arrondissement Dinant"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/71000> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/70000> ;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE221> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrowMatch <http://vocab.belgif.be/auth/refnis2019/71000> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/71002>,
+    <http://vocab.belgif.be/auth/refnis2025/71004>,
+    <http://vocab.belgif.be/auth/refnis2025/71011>,
+    <http://vocab.belgif.be/auth/refnis2025/71016>,
+    <http://vocab.belgif.be/auth/refnis2025/71017>,
+    <http://vocab.belgif.be/auth/refnis2025/71020>,
+    <http://vocab.belgif.be/auth/refnis2025/71024>,
+    <http://vocab.belgif.be/auth/refnis2025/71034>,
+    <http://vocab.belgif.be/auth/refnis2025/71037>,
+    <http://vocab.belgif.be/auth/refnis2025/71045>,
+    <http://vocab.belgif.be/auth/refnis2025/71053>,
+    <http://vocab.belgif.be/auth/refnis2025/71066>,
+    <http://vocab.belgif.be/auth/refnis2025/71067>,
+    <http://vocab.belgif.be/auth/refnis2025/71070>,
+    <http://vocab.belgif.be/auth/refnis2025/71071>,
+    <http://vocab.belgif.be/auth/refnis2025/71072> ;
+  skos:notation "71000" ;
+  skos:prefLabel "Bezirk Hasselt"@de,
+    "Arrondissement de Hasselt"@fr,
+    "Arrondissement Hasselt"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2025-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/92000> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/90000> ;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE352>,
+    <http://vocab.belgif.be/auth/refnis2019/92000> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/92003>,
+    <http://vocab.belgif.be/auth/refnis2025/92006>,
+    <http://vocab.belgif.be/auth/refnis2025/92035>,
+    <http://vocab.belgif.be/auth/refnis2025/92045>,
+    <http://vocab.belgif.be/auth/refnis2025/92048>,
+    <http://vocab.belgif.be/auth/refnis2025/92054>,
+    <http://vocab.belgif.be/auth/refnis2025/92087>,
+    <http://vocab.belgif.be/auth/refnis2025/92094>,
+    <http://vocab.belgif.be/auth/refnis2025/92097>,
+    <http://vocab.belgif.be/auth/refnis2025/92101>,
+    <http://vocab.belgif.be/auth/refnis2025/92114>,
+    <http://vocab.belgif.be/auth/refnis2025/92137>,
+    <http://vocab.belgif.be/auth/refnis2025/92138>,
+    <http://vocab.belgif.be/auth/refnis2025/92140>,
+    <http://vocab.belgif.be/auth/refnis2025/92141>,
+    <http://vocab.belgif.be/auth/refnis2025/92142> ;
+  skos:notation "92000" ;
+  skos:prefLabel "Bezirk Namur"@de,
+    "Arrondissement de Namur"@fr,
+    "Arrondissement Namen"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/61000> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/60000> ;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE331>,
+    <http://vocab.belgif.be/auth/refnis2019/61000> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/61003>,
+    <http://vocab.belgif.be/auth/refnis2025/61010>,
+    <http://vocab.belgif.be/auth/refnis2025/61012>,
+    <http://vocab.belgif.be/auth/refnis2025/61019>,
+    <http://vocab.belgif.be/auth/refnis2025/61024>,
+    <http://vocab.belgif.be/auth/refnis2025/61028>,
+    <http://vocab.belgif.be/auth/refnis2025/61031>,
+    <http://vocab.belgif.be/auth/refnis2025/61039>,
+    <http://vocab.belgif.be/auth/refnis2025/61041>,
+    <http://vocab.belgif.be/auth/refnis2025/61043>,
+    <http://vocab.belgif.be/auth/refnis2025/61048>,
+    <http://vocab.belgif.be/auth/refnis2025/61063>,
+    <http://vocab.belgif.be/auth/refnis2025/61068>,
+    <http://vocab.belgif.be/auth/refnis2025/61072>,
+    <http://vocab.belgif.be/auth/refnis2025/61079>,
+    <http://vocab.belgif.be/auth/refnis2025/61080>,
+    <http://vocab.belgif.be/auth/refnis2025/61081> ;
+  skos:notation "61000" ;
+  skos:prefLabel "Bezirk Huy"@de,
+    "Arrondissement de Huy"@fr,
+    "Arrondissement Hoei"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/21000> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/4000> ;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE100>,
+    <http://vocab.belgif.be/auth/refnis2019/21000> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/21001>,
+    <http://vocab.belgif.be/auth/refnis2025/21002>,
+    <http://vocab.belgif.be/auth/refnis2025/21003>,
+    <http://vocab.belgif.be/auth/refnis2025/21004>,
+    <http://vocab.belgif.be/auth/refnis2025/21005>,
+    <http://vocab.belgif.be/auth/refnis2025/21006>,
+    <http://vocab.belgif.be/auth/refnis2025/21007>,
+    <http://vocab.belgif.be/auth/refnis2025/21008>,
+    <http://vocab.belgif.be/auth/refnis2025/21009>,
+    <http://vocab.belgif.be/auth/refnis2025/21010>,
+    <http://vocab.belgif.be/auth/refnis2025/21011>,
+    <http://vocab.belgif.be/auth/refnis2025/21012>,
+    <http://vocab.belgif.be/auth/refnis2025/21013>,
+    <http://vocab.belgif.be/auth/refnis2025/21014>,
+    <http://vocab.belgif.be/auth/refnis2025/21015>,
+    <http://vocab.belgif.be/auth/refnis2025/21016>,
+    <http://vocab.belgif.be/auth/refnis2025/21017>,
+    <http://vocab.belgif.be/auth/refnis2025/21018>,
+    <http://vocab.belgif.be/auth/refnis2025/21019> ;
+  skos:notation "21000" ;
+  skos:prefLabel "Bezirk Brüssel-Hauptstadt"@de,
+    "Arrondissement de Bruxelles-Capitale"@fr,
+    "Arrondissement Brussel-Hoofdstad"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/62000> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/60000> ;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE332>,
+    <http://vocab.belgif.be/auth/refnis2019/62000> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/62003>,
+    <http://vocab.belgif.be/auth/refnis2025/62006>,
+    <http://vocab.belgif.be/auth/refnis2025/62009>,
+    <http://vocab.belgif.be/auth/refnis2025/62011>,
+    <http://vocab.belgif.be/auth/refnis2025/62015>,
+    <http://vocab.belgif.be/auth/refnis2025/62022>,
+    <http://vocab.belgif.be/auth/refnis2025/62026>,
+    <http://vocab.belgif.be/auth/refnis2025/62027>,
+    <http://vocab.belgif.be/auth/refnis2025/62032>,
+    <http://vocab.belgif.be/auth/refnis2025/62038>,
+    <http://vocab.belgif.be/auth/refnis2025/62051>,
+    <http://vocab.belgif.be/auth/refnis2025/62060>,
+    <http://vocab.belgif.be/auth/refnis2025/62063>,
+    <http://vocab.belgif.be/auth/refnis2025/62079>,
+    <http://vocab.belgif.be/auth/refnis2025/62093>,
+    <http://vocab.belgif.be/auth/refnis2025/62096>,
+    <http://vocab.belgif.be/auth/refnis2025/62099>,
+    <http://vocab.belgif.be/auth/refnis2025/62100>,
+    <http://vocab.belgif.be/auth/refnis2025/62108>,
+    <http://vocab.belgif.be/auth/refnis2025/62118>,
+    <http://vocab.belgif.be/auth/refnis2025/62119>,
+    <http://vocab.belgif.be/auth/refnis2025/62120>,
+    <http://vocab.belgif.be/auth/refnis2025/62121>,
+    <http://vocab.belgif.be/auth/refnis2025/62122> ;
+  skos:notation "62000" ;
+  skos:prefLabel "Bezirk Lüttich"@de,
+    "Arrondissement de Liège"@fr,
+    "Arrondissement Luik"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/13000> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/10000> ;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE213>,
+    <http://vocab.belgif.be/auth/refnis2019/13000> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/13001>,
+    <http://vocab.belgif.be/auth/refnis2025/13002>,
+    <http://vocab.belgif.be/auth/refnis2025/13003>,
+    <http://vocab.belgif.be/auth/refnis2025/13004>,
+    <http://vocab.belgif.be/auth/refnis2025/13006>,
+    <http://vocab.belgif.be/auth/refnis2025/13008>,
+    <http://vocab.belgif.be/auth/refnis2025/13010>,
+    <http://vocab.belgif.be/auth/refnis2025/13011>,
+    <http://vocab.belgif.be/auth/refnis2025/13012>,
+    <http://vocab.belgif.be/auth/refnis2025/13013>,
+    <http://vocab.belgif.be/auth/refnis2025/13014>,
+    <http://vocab.belgif.be/auth/refnis2025/13016>,
+    <http://vocab.belgif.be/auth/refnis2025/13017>,
+    <http://vocab.belgif.be/auth/refnis2025/13019>,
+    <http://vocab.belgif.be/auth/refnis2025/13021>,
+    <http://vocab.belgif.be/auth/refnis2025/13023>,
+    <http://vocab.belgif.be/auth/refnis2025/13025>,
+    <http://vocab.belgif.be/auth/refnis2025/13029>,
+    <http://vocab.belgif.be/auth/refnis2025/13031>,
+    <http://vocab.belgif.be/auth/refnis2025/13035>,
+    <http://vocab.belgif.be/auth/refnis2025/13036>,
+    <http://vocab.belgif.be/auth/refnis2025/13037>,
+    <http://vocab.belgif.be/auth/refnis2025/13040>,
+    <http://vocab.belgif.be/auth/refnis2025/13044>,
+    <http://vocab.belgif.be/auth/refnis2025/13046>,
+    <http://vocab.belgif.be/auth/refnis2025/13049>,
+    <http://vocab.belgif.be/auth/refnis2025/13053> ;
+  skos:notation "13000" ;
+  skos:prefLabel "Bezirk Turnhout"@de,
+    "Arrondissement de Turnhout"@fr,
+    "Arrondissement Turnhout"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/25000> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/20002> ;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE310>,
+    <http://vocab.belgif.be/auth/refnis2019/25000> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/25005>,
+    <http://vocab.belgif.be/auth/refnis2025/25014>,
+    <http://vocab.belgif.be/auth/refnis2025/25015>,
+    <http://vocab.belgif.be/auth/refnis2025/25018>,
+    <http://vocab.belgif.be/auth/refnis2025/25023>,
+    <http://vocab.belgif.be/auth/refnis2025/25031>,
+    <http://vocab.belgif.be/auth/refnis2025/25037>,
+    <http://vocab.belgif.be/auth/refnis2025/25043>,
+    <http://vocab.belgif.be/auth/refnis2025/25044>,
+    <http://vocab.belgif.be/auth/refnis2025/25048>,
+    <http://vocab.belgif.be/auth/refnis2025/25050>,
+    <http://vocab.belgif.be/auth/refnis2025/25068>,
+    <http://vocab.belgif.be/auth/refnis2025/25072>,
+    <http://vocab.belgif.be/auth/refnis2025/25084>,
+    <http://vocab.belgif.be/auth/refnis2025/25091>,
+    <http://vocab.belgif.be/auth/refnis2025/25105>,
+    <http://vocab.belgif.be/auth/refnis2025/25107>,
+    <http://vocab.belgif.be/auth/refnis2025/25110>,
+    <http://vocab.belgif.be/auth/refnis2025/25112>,
+    <http://vocab.belgif.be/auth/refnis2025/25117>,
+    <http://vocab.belgif.be/auth/refnis2025/25118>,
+    <http://vocab.belgif.be/auth/refnis2025/25119>,
+    <http://vocab.belgif.be/auth/refnis2025/25120>,
+    <http://vocab.belgif.be/auth/refnis2025/25121>,
+    <http://vocab.belgif.be/auth/refnis2025/25122>,
+    <http://vocab.belgif.be/auth/refnis2025/25123>,
+    <http://vocab.belgif.be/auth/refnis2025/25124> ;
+  skos:notation "25000" ;
+  skos:prefLabel "Bezirk Nivelles"@de,
+    "Arrondissement de Nivelles"@fr,
+    "Arrondissement Nijvel"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/11000> a skos:Concept ;
+  skos:broadMatch <http://vocab.belgif.be/auth/refnis2019/11000> ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/10000> ;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE211> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/11001>,
+    <http://vocab.belgif.be/auth/refnis2025/11002>,
+    <http://vocab.belgif.be/auth/refnis2025/11004>,
+    <http://vocab.belgif.be/auth/refnis2025/11005>,
+    <http://vocab.belgif.be/auth/refnis2025/11008>,
+    <http://vocab.belgif.be/auth/refnis2025/11009>,
+    <http://vocab.belgif.be/auth/refnis2025/11013>,
+    <http://vocab.belgif.be/auth/refnis2025/11016>,
+    <http://vocab.belgif.be/auth/refnis2025/11018>,
+    <http://vocab.belgif.be/auth/refnis2025/11021>,
+    <http://vocab.belgif.be/auth/refnis2025/11022>,
+    <http://vocab.belgif.be/auth/refnis2025/11023>,
+    <http://vocab.belgif.be/auth/refnis2025/11024>,
+    <http://vocab.belgif.be/auth/refnis2025/11025>,
+    <http://vocab.belgif.be/auth/refnis2025/11029>,
+    <http://vocab.belgif.be/auth/refnis2025/11030>,
+    <http://vocab.belgif.be/auth/refnis2025/11035>,
+    <http://vocab.belgif.be/auth/refnis2025/11037>,
+    <http://vocab.belgif.be/auth/refnis2025/11038>,
+    <http://vocab.belgif.be/auth/refnis2025/11039>,
+    <http://vocab.belgif.be/auth/refnis2025/11040>,
+    <http://vocab.belgif.be/auth/refnis2025/11044>,
+    <http://vocab.belgif.be/auth/refnis2025/11050>,
+    <http://vocab.belgif.be/auth/refnis2025/11052>,
+    <http://vocab.belgif.be/auth/refnis2025/11053>,
+    <http://vocab.belgif.be/auth/refnis2025/11054>,
+    <http://vocab.belgif.be/auth/refnis2025/11055>,
+    <http://vocab.belgif.be/auth/refnis2025/11057> ;
+  skos:notation "11000" ;
+  skos:prefLabel "Bezirk Antwerpen"@de,
+    "Arrondissement d’Anvers"@fr,
+    "Arrondissement Antwerpen"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2025-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/63000> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/60000> ;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2019/63000> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrowMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE335> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/63001>,
+    <http://vocab.belgif.be/auth/refnis2025/63003>,
+    <http://vocab.belgif.be/auth/refnis2025/63004>,
+    <http://vocab.belgif.be/auth/refnis2025/63012>,
+    <http://vocab.belgif.be/auth/refnis2025/63013>,
+    <http://vocab.belgif.be/auth/refnis2025/63020>,
+    <http://vocab.belgif.be/auth/refnis2025/63023>,
+    <http://vocab.belgif.be/auth/refnis2025/63035>,
+    <http://vocab.belgif.be/auth/refnis2025/63038>,
+    <http://vocab.belgif.be/auth/refnis2025/63040>,
+    <http://vocab.belgif.be/auth/refnis2025/63045>,
+    <http://vocab.belgif.be/auth/refnis2025/63046>,
+    <http://vocab.belgif.be/auth/refnis2025/63048>,
+    <http://vocab.belgif.be/auth/refnis2025/63049>,
+    <http://vocab.belgif.be/auth/refnis2025/63057>,
+    <http://vocab.belgif.be/auth/refnis2025/63058>,
+    <http://vocab.belgif.be/auth/refnis2025/63061>,
+    <http://vocab.belgif.be/auth/refnis2025/63067>,
+    <http://vocab.belgif.be/auth/refnis2025/63072>,
+    <http://vocab.belgif.be/auth/refnis2025/63073>,
+    <http://vocab.belgif.be/auth/refnis2025/63075>,
+    <http://vocab.belgif.be/auth/refnis2025/63076>,
+    <http://vocab.belgif.be/auth/refnis2025/63079>,
+    <http://vocab.belgif.be/auth/refnis2025/63080>,
+    <http://vocab.belgif.be/auth/refnis2025/63084>,
+    <http://vocab.belgif.be/auth/refnis2025/63086>,
+    <http://vocab.belgif.be/auth/refnis2025/63087>,
+    <http://vocab.belgif.be/auth/refnis2025/63088>,
+    <http://vocab.belgif.be/auth/refnis2025/63089> ;
+  skos:notation "63000" ;
+  skos:prefLabel "Bezirk Verviers"@de,
+    "Arrondissement de Verviers"@fr,
+    "Arrondissement Verviers"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/24000> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/20001> ;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE242>,
+    <http://vocab.belgif.be/auth/refnis2019/24000> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/24001>,
+    <http://vocab.belgif.be/auth/refnis2025/24007>,
+    <http://vocab.belgif.be/auth/refnis2025/24008>,
+    <http://vocab.belgif.be/auth/refnis2025/24009>,
+    <http://vocab.belgif.be/auth/refnis2025/24011>,
+    <http://vocab.belgif.be/auth/refnis2025/24014>,
+    <http://vocab.belgif.be/auth/refnis2025/24016>,
+    <http://vocab.belgif.be/auth/refnis2025/24020>,
+    <http://vocab.belgif.be/auth/refnis2025/24028>,
+    <http://vocab.belgif.be/auth/refnis2025/24033>,
+    <http://vocab.belgif.be/auth/refnis2025/24038>,
+    <http://vocab.belgif.be/auth/refnis2025/24041>,
+    <http://vocab.belgif.be/auth/refnis2025/24043>,
+    <http://vocab.belgif.be/auth/refnis2025/24045>,
+    <http://vocab.belgif.be/auth/refnis2025/24048>,
+    <http://vocab.belgif.be/auth/refnis2025/24054>,
+    <http://vocab.belgif.be/auth/refnis2025/24055>,
+    <http://vocab.belgif.be/auth/refnis2025/24059>,
+    <http://vocab.belgif.be/auth/refnis2025/24062>,
+    <http://vocab.belgif.be/auth/refnis2025/24066>,
+    <http://vocab.belgif.be/auth/refnis2025/24086>,
+    <http://vocab.belgif.be/auth/refnis2025/24094>,
+    <http://vocab.belgif.be/auth/refnis2025/24104>,
+    <http://vocab.belgif.be/auth/refnis2025/24107>,
+    <http://vocab.belgif.be/auth/refnis2025/24109>,
+    <http://vocab.belgif.be/auth/refnis2025/24130>,
+    <http://vocab.belgif.be/auth/refnis2025/24133>,
+    <http://vocab.belgif.be/auth/refnis2025/24134>,
+    <http://vocab.belgif.be/auth/refnis2025/24135>,
+    <http://vocab.belgif.be/auth/refnis2025/24137> ;
+  skos:notation "24000" ;
+  skos:prefLabel "Bezirk Löwen"@de,
+    "Arrondissement de Louvain"@fr,
+    "Arrondissement Leuven"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025/23000> a skos:Concept ;
+  skos:broader <http://vocab.belgif.be/auth/refnis2025/20001> ;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE241>,
+    <http://vocab.belgif.be/auth/refnis2019/23000> ;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2025/23002>,
+    <http://vocab.belgif.be/auth/refnis2025/23003>,
+    <http://vocab.belgif.be/auth/refnis2025/23009>,
+    <http://vocab.belgif.be/auth/refnis2025/23016>,
+    <http://vocab.belgif.be/auth/refnis2025/23025>,
+    <http://vocab.belgif.be/auth/refnis2025/23027>,
+    <http://vocab.belgif.be/auth/refnis2025/23033>,
+    <http://vocab.belgif.be/auth/refnis2025/23038>,
+    <http://vocab.belgif.be/auth/refnis2025/23039>,
+    <http://vocab.belgif.be/auth/refnis2025/23044>,
+    <http://vocab.belgif.be/auth/refnis2025/23045>,
+    <http://vocab.belgif.be/auth/refnis2025/23047>,
+    <http://vocab.belgif.be/auth/refnis2025/23050>,
+    <http://vocab.belgif.be/auth/refnis2025/23052>,
+    <http://vocab.belgif.be/auth/refnis2025/23060>,
+    <http://vocab.belgif.be/auth/refnis2025/23062>,
+    <http://vocab.belgif.be/auth/refnis2025/23064>,
+    <http://vocab.belgif.be/auth/refnis2025/23077>,
+    <http://vocab.belgif.be/auth/refnis2025/23081>,
+    <http://vocab.belgif.be/auth/refnis2025/23086>,
+    <http://vocab.belgif.be/auth/refnis2025/23088>,
+    <http://vocab.belgif.be/auth/refnis2025/23094>,
+    <http://vocab.belgif.be/auth/refnis2025/23096>,
+    <http://vocab.belgif.be/auth/refnis2025/23097>,
+    <http://vocab.belgif.be/auth/refnis2025/23098>,
+    <http://vocab.belgif.be/auth/refnis2025/23099>,
+    <http://vocab.belgif.be/auth/refnis2025/23100>,
+    <http://vocab.belgif.be/auth/refnis2025/23101>,
+    <http://vocab.belgif.be/auth/refnis2025/23102>,
+    <http://vocab.belgif.be/auth/refnis2025/23103>,
+    <http://vocab.belgif.be/auth/refnis2025/23104>,
+    <http://vocab.belgif.be/auth/refnis2025/23105>,
+    <http://vocab.belgif.be/auth/refnis2025/23106> ;
+  skos:notation "23000" ;
+  skos:prefLabel "Bezirk Halle-Vilvoorde"@de,
+    "Arrondissement de Hal-Vilvorde"@fr,
+    "Arrondissement Halle-Vilvoorde"@nl ;
+  ns1:endDate "9999-12-31T00:00:00+01:00"^^xsd:dateTime ;
+  ns1:startDate "2019-01-01T00:00:00+01:00"^^xsd:dateTime .
+
+<http://vocab.belgif.be/auth/refnis2025> a skos:ConceptScheme ;
+  ns2:creator <https://org.belgif.be/id/CbeRegisteredEntity/0314595348/statbel> ;
+  ns2:description "REFNIS (ab 12/2024)"@de,
+    "REFNIS (starting in 12/2024)"@en,
+    "REFNIS (à partir de 12/2024): la division administrative repose sur quatre unités territoriales : les régions, les provinces, les arrondissements administratifs et les communes."@fr,
+    "REFNIS (vanaf 12/2024): de administratieve indeling gebeurt aan de hand van vier territoriale eenheden: gewesten, provincies, bestuurlijke arrondissementen en gemeenten."@nl ;
+  ns2:license <http://statbel.fgov.be/en/statistics/opendata/licence/> ;
+  ns2:modified "2024-12-11T18:13:00"^^xsd:dateTime ;
+  ns2:rightsHolder <https://org.belgif.be/id/CbeRegisteredEntity/0314595348/statbel> ;
+  ns2:source <https://economie.fgov.be/en/themes/enterprises/crossroads-bank-enterprises/services-administrations/tables-codes>,
+    <https://statbel.fgov.be/fr/propos-de-statbel/methodologie/classifications/geographie> ;
+  ns2:title "REFNIS-2025"@de,
+    "REFNIS-2025"@en,
+    "REFNIS-2025"@fr,
+    "REFNIS-2025"@nl ;
+  owl:versionInfo "Draft version 2024-12-01" ;
+  skos:hasTopConcept <http://vocab.belgif.be/auth/refnis2025/1000> .
+

--- a/config/migrations/2025/20250107100000-nis-codes-2025/20250107102500-add-uuids-to-nis-codes-2025.sparql
+++ b/config/migrations/2025/20250107100000-nis-codes-2025/20250107102500-add-uuids-to-nis-codes-2025.sparql
@@ -1,0 +1,12 @@
+INSERT {
+  GRAPH ?g {
+    ?nisCode <http://mu.semte.ch/vocabularies/core/uuid> ?uuid .
+  }
+} WHERE {
+  GRAPH ?g {
+    ?nisCode a skos:Concept ;
+      skos:inScheme <http://vocab.belgif.be/auth/refnis2025> .
+
+    BIND(SHA256(CONCAT("NIS codes 2025", STR(?nisCode))) AS ?uuid) .
+  }
+}

--- a/config/migrations/2025/20250107100000-nis-codes-2025/20250107103200-update-nis-codes-to-2025-update.sparql
+++ b/config/migrations/2025/20250107100000-nis-codes-2025/20250107103200-update-nis-codes-to-2025-update.sparql
@@ -1,0 +1,18 @@
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/shared> {
+    ?werkingsgebied <http://www.w3.org/2004/02/skos/core#exactMatch> ?nis2019 .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/shared> {
+    ?werkingsgebied <http://www.w3.org/2004/02/skos/core#exactMatch> ?nis2025 .
+  }
+} WHERE {
+  ?werkingsgebied a <http://www.w3.org/ns/prov#Location> ;
+    <http://www.w3.org/2004/02/skos/core#exactMatch> ?nis2019 .
+    
+  ?nis2019 skos:inScheme <http://vocab.belgif.be/auth/refnis2019> .
+
+  ?nis2025 a skos:Concept ;
+    skos:inScheme <http://vocab.belgif.be/auth/refnis2025> ;
+    skos:exactMatch ?nis2019 .
+}

--- a/config/migrations/2025/20250107100000-nis-codes-2025/20250107104100-link-new-fusie-gemeenten-to-their-nis-codes.sparql
+++ b/config/migrations/2025/20250107100000-nis-codes-2025/20250107104100-link-new-fusie-gemeenten-to-their-nis-codes.sparql
@@ -1,0 +1,30 @@
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/shared> {
+    ?werkingsgebied <http://www.w3.org/2004/02/skos/core#exactMatch> ?preMergerNIS .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/shared> {
+    ?werkingsgebied <http://www.w3.org/2004/02/skos/core#exactMatch> ?postMergerNIS .
+  }
+} WHERE {
+  VALUES (?werkingsgebied ?postMergerNIS) {
+    (<http://data.lblod.info/id/werkingsgebieden/92398c49-30d5-46b2-af90-37f135c89e47> <http://vocab.belgif.be/auth/refnis2025/23106>) # Pajottegem
+    (<http://data.lblod.info/id/werkingsgebieden/21034a361da5b5c45424cbbef38a89029ca025e32aa1b132fcceca1d13149ee6> <http://vocab.belgif.be/auth/refnis2025/37021>) # Wingene
+    (<http://data.lblod.info/id/werkingsgebieden/1fb92312354f3d900670e2b9cfbd80148910f1227e321f2c377f92957b071cb1> <http://vocab.belgif.be/auth/refnis2025/37022>) # Tielt
+    (<http://data.lblod.info/id/werkingsgebieden/41362ab2-5130-4160-b76b-4bfa5d9a1f59> <http://vocab.belgif.be/auth/refnis2025/44086>) # Nazareth-De Pinte
+    (<http://data.lblod.info/id/werkingsgebieden/f1552be4471af0742d8ea03cd8596900c634a66f67e1fbc130d79f655de0240e> <http://vocab.belgif.be/auth/refnis2025/44087>) # Lochristi
+    (<http://data.lblod.info/id/werkingsgebieden/4afbdfef4de7314c2637a9f950b13bb9b0b4eaaf3413c0bd5d0600852a9d7cb3> <http://vocab.belgif.be/auth/refnis2025/46029>) # Lokeren
+    (<http://data.lblod.info/id/werkingsgebieden/62fef519-b1de-4a0f-911a-c63a5365c17b> <http://vocab.belgif.be/auth/refnis2025/44088>) # Merelbeke-Melle
+    (<http://data.lblod.info/id/werkingsgebieden/b97c1b58-6431-4509-ab94-3300d27759a8> <http://vocab.belgif.be/auth/refnis2025/46030>) # Beveren-Kruibeke-Zwijndrecht
+    (<http://data.lblod.info/id/werkingsgebieden/1f5dd7043ad54d07751da8689d5b47ad9ae0e52dccce8f00cc8debab35f8e2b2> <http://vocab.belgif.be/auth/refnis2025/73110>) # Bilzen-Hoeselt
+    (<http://data.lblod.info/id/werkingsgebieden/fabec9e745fc9efa32afadd8b7268938805b9679dcf3b032c9b9a9a3530d6b59> <http://vocab.belgif.be/auth/refnis2025/73111>) # Tongeren-Borgloon
+    (<http://data.lblod.info/id/werkingsgebieden/fc34bb0a1dbf157ac5e5f8e657dd774210f03d2efa21370dd3b9a6342906c7ab> <http://vocab.belgif.be/auth/refnis2025/71071>) # Tessenderlo-Ham
+    (<http://data.lblod.info/id/werkingsgebieden/e55336a3ecbae33f21e595458ba93eeeb0fa4390626622884d4d32523d0e0033> <http://vocab.belgif.be/auth/refnis2025/71072>) # Hasselt
+  }
+
+  ?werkingsgebied a <http://www.w3.org/ns/prov#Location> .
+
+  OPTIONAL {
+    ?werkingsgebied <http://www.w3.org/2004/02/skos/core#exactMatch> ?preMergerNIS .
+  }
+}


### PR DESCRIPTION
# Context

OP-3342

To follow up with the addition of mergers in OP, we want to add their NIS codes as well into the app. A (new version)[https://github.com/belgif/vocab-belgif/blob/master/prod/data/codelist/refnis2025.nt} of the NIS codes has been created to reflect the state of 2025.

This PR does a few things:
1. Import the 2025 NIS codes
2. Update our `werkingsgebieden` to link to 2025 NIS codes when an exact match is found between the version of 2019 and the one of 2025
3. Add a link from `werkingsgebieden` to 2025 NIS codes for the mergers

# Expected output

The non-mergers should still look the same as before in the frontend but the data should be using mostly 2025 NIS codes.
The mergers should show the following NIS codes:
|                    Fuserende gemeenten                   |           Nieuwe gemeenten           |
|:--------------------------------------------------------:|:------------------------------------:|
|           Antwerpen (11002) + Borsbeek (11007)           |           Antwerpen (11002)          |
|    Galmaarden (23023) + Gooik (23024) + Herne (23032)    |          Pajottegem (23106)          |
|            Ruiselede (37012) + Wingene (37018)           |            Wingene (37021)           |
|             Meulebeke (37007) + Tielt (37015)            |             Tielt (37022)            |
|            De Pinte (44012) + Nazareth (44048)           |       Nazareth-De Pinte (44086)      |
|          Lochristi (44034) + Wachtebeke (44073)          |           Lochristi (44087)          |
|            Lokeren (46014) + Moerbeke (44045)            |            Lokeren (46029)           |
|             Melle (44040) + Merelbeke (44043)            |        Merelbeke-Melle (44088)       |
| Beveren (46003) + Kruibeke (46013) + Zwijndrecht (11056) | Beveren-Kruibeke-Zwijndrecht (46030) |
|             Bilzen (73006) + Hoeselt (73032)             |        Bilzen-Hoeselt (73110)        |
|            Borgloon (73009) + Tongeren (73083)           |       Tongeren-Borgloon (73111)      |
|             Ham (71069) + Tessenderlo (71057)            |        Tessenderlo-Ham (71071)       |
|            Hasselt (71022) + Kortessem (73040)           |            Hasselt (71072)           |