### PR TITLE
Migration to delete betrokkene and update financieringspercentage

### DIFF
--- a/config/migrations/2025/20250107101243-delete-local-involvement-oudenaarde-st-amandus.sparql
+++ b/config/migrations/2025/20250107101243-delete-local-involvement-oudenaarde-st-amandus.sparql
@@ -1,0 +1,35 @@
+DELETE WHERE {
+  graph <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/betrokkenLokaleBesturen/0da11d9fdef2d45f90fd4ebd353ecd3c> ?p ?o.
+  }
+}
+
+;
+
+DELETE WHERE {
+  graph <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/bestuurseenheden/d9f7c0ab4920fdecf3f9a60b92e921b5ca07248fcb0eac2113eb97392ddd6c6c> <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/0da11d9fdef2d45f90fd4ebd353ecd3c>.
+  }
+}
+
+;
+
+DELETE {
+  GRAPH ?g {
+      ?localInvolvementWortegemPetegem <http://data.lblod.info/vocabularies/erediensten/financieringspercentage> ?percentage.
+  }
+}
+INSERT {
+  GRAPH ?g {
+    ?localInvolvementWortegemPetegem <http://data.lblod.info/vocabularies/erediensten/financieringspercentage> 100.
+  }
+}
+WHERE {
+  BIND(<http://mu.semte.ch/graphs/worship-service> AS ?g)
+  GRAPH ?g {
+    ?localInvolvementWortegemPetegem <http://data.lblod.info/vocabularies/erediensten/financieringspercentage> ?percentage.
+  }
+  VALUES ?localInvolvementWortegemPetegem {
+    <http://data.lblod.info/id/betrokkenLokaleBesturen/00b8f19ce0fafa090df049498337aad8>
+  }
+}


### PR DESCRIPTION
## ID
OP-3501

## Description

Remove the betrokken bestuur of St-Amandus, 'Oudenaarde'. And update the financierings percentage to 100 for the other betrokkene 'Wortegem-Petegem'.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How to test

Rsync prod data, run migration and verify that the betrokken bestuur (Oudenaarde) is removed, and the other betrokkene (Wortegem-Petegem) has a percentage of 100.