### PR TITLE
fix: relate merged municipalities and province in shared graph

### DIFF
--- a/config/migrations/2025/20250108143939-fix-municipality-mergers--move-province-hassuborganization-to-shared-graph.sparql
+++ b/config/migrations/2025/20250108143939-fix-municipality-mergers--move-province-hassuborganization-to-shared-graph.sparql
@@ -1,0 +1,23 @@
+PREFIX org: <http://www.w3.org/ns/org#>
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?province org:hasSubOrganization ?municipality.
+  }
+}
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/shared> {
+    ?province org:hasSubOrganization ?municipality.
+  }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?province org:hasSubOrganization ?municipality.
+  }
+  VALUES ?municipality {
+    <http://data.lblod.info/id/bestuurseenheden/19483103-318e-435a-aa37-45e485406ee9> # Beveren-Kruibeke-Zwijndrecht
+    <http://data.lblod.info/id/bestuurseenheden/1ca65d65-54ff-4b44-b750-bd70c91191af> # Nazareth-De Pinte
+    <http://data.lblod.info/id/bestuurseenheden/add1e4eb-9ec7-4ea6-af82-335aa76b7d48> # Pajottegem
+    <http://data.lblod.info/id/bestuurseenheden/b8bb293d-aa22-4b43-bda4-0b6af76e9493> # Merelbeke-Melle
+  }
+}


### PR DESCRIPTION
## Problem description
For worship users the province was is automatically filled in forms when one of
4 merged municipalities is selected. Furthermore, when a province is selected in
a form these same 4 municipalities do not show up as valid options for
municipality fields. The 4 affected municipalities are: Nazareth-De Pinte,
Beveren-Kruibeke-Zwijndrecht, Merelbeke-Melle, and Pajottegem.

In #442 new organisations were created for these municipalities. But their
`org:hasSubOrganization` link with the province was inserted in to the
`<http://mu.semte.ch/graphs/administrative-unit>` graph instead of the
`<http://mu.semte.ch/graphs/shared>`. As can be seen in the last `INSERT` query
in each municipality's migration.

Since worship users cannot read from the `administrative-unit` graph, any
queries concerning the relations between municipalities and provinces miss the
data for these 4 municipalities. Leading to the issues described above.

## Proposed solution
The migration in this PR simply moves the appropriate `org:hasSubOrganization`
triples to the correct graph such that the behaviour for worship and non-worship
users is the same again.

## How to test
1. Run the migration against your local OP stack
2. Log in as a worship user
3. On the organisations overview page:
   - When selecting either of the 4 municipalities in the *Gemeente* filter,
     their province should be automatically filled.
   - When selecting a province in the *Provincie* filter, the municipalities
     should show up as valid options in the *Gemeente* filter
4. On address forms (add a new organisation, edit core data of existing
   organisation, add new site for an organisation, edit existing site for an
   organisation)
   - When manually entering an address:
     + When selecting either of the 4 municipalities, the province field should
       be filled in automatically.
     + When filling in the province field the municipalities should show up as
       valid options for the municipality field.
   - When selecting an address from a list, the province should be automatically
     filled in when selecting an address in either of the 4 municipalities.


For completeness the 4 relevant municipalities and their corresponding
provinces:

| municipality                 | province        |
| ---------------------------- | --------------- |
| Nazareth-De Pinte            | Oost-Vlaanderen |
| Beveren-Kruibeke-Zwijndrecht | Oost-Vlaanderen |
| Merelbeke-Melle              | Oost-Vlaanderen |
| Pajottegem                   | Vlaams-Brabant  |

## Related tickets
- OP-3513
- OP-3514