### PR TITLE
feat: merge police zones 2025

### DIFF
--- a/config/migrations-triggering-indexing/2025/20250108194417-mergers-2025-police-zones--deactivate-merged-organisations.sparql
+++ b/config/migrations-triggering-indexing/2025/20250108194417-mergers-2025-police-zones--deactivate-merged-organisations.sparql
@@ -1,0 +1,25 @@
+PREFIX regorg: <http://www.w3.org/ns/regorg#>
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:orgStatus ?activeStatus.
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s regorg:orgStatus ?notActiveStatus.
+  }
+} WHERE {
+  VALUES ?s {
+    <http://data.lblod.info/id/bestuurseenheden/150440a8bb763d6f53d24ca1c6f1460cb5817c8a261fd90e74aadac3292c3efe>
+    <http://data.lblod.info/id/bestuurseenheden/41d31a2eb697af977aadf64c73e0bcffb094e0f20e4017fe3b49c507079c0976>
+
+    <http://data.lblod.info/id/bestuurseenheden/330516b323c00851cf4b93e6d5d7a2ef4591f68ae6e71ad9c1f432ee70521bb2>
+    <http://data.lblod.info/id/bestuurseenheden/7dd1250996188607bb1e28df1ebea0b943e8db59c08ea01e3c57672531c43ec6>
+    <http://data.lblod.info/id/bestuurseenheden/541c1603eb8c01968f95d1f262854134499e00d135cd7c9147d307ccbd1e20fd>
+
+    <http://data.lblod.info/id/bestuurseenheden/4deae42b2b25bff407f5abc7cbb6d62eb02afaf2892086341c324fdf2c0e6e92>
+    <http://data.lblod.info/id/bestuurseenheden/b7af3483cb5d0021c6f5864a433b211fce30246ef685621d104b1951915c21c4>
+  }
+  BIND (<http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311> AS ?notActiveStatus)
+  BIND (<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> AS ?activeStatus)
+}

--- a/config/migrations/2025/20250108184340-mergers-2025-police-zones/20250108184654-mergers-2025-police-zones--tongeren-borgloon-herstappe-heers-wellen.sparql
+++ b/config/migrations/2025/20250108184340-mergers-2025-police-zones/20250108184654-mergers-2025-police-zones--tongeren-borgloon-herstappe-heers-wellen.sparql
@@ -1,0 +1,60 @@
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX ch: <http://data.lblod.info/vocabularies/contacthub/>
+PREFIX lblodOrg: <http://lblod.data.gift/vocabularies/organisatie/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?changeEvent a org:ChangeEvent;
+                 mu:uuid ?uuidChangeEvent;
+                 ch:typeWijziging ?mergerChangeEventType;
+                 org:resultingOrganization ?resultingOrganisation;
+                 dct:date "2025-01-01"^^xsd:date;
+                 dct:description "Fusie tussen PZ Alken/Borgloon/Heers/Kortessem/Wellen (= 5379 PZ Kanton Borgloon) en PZ Tongeren/Herstappe (= 5380 PZ Tongeren/Herstappe) resulteert in PZ Tongeren-Borgloon/Herstappe/Heers/Wellen (= 5962 PZ Haspengouw)";
+                 org:originalOrganization ?firstNotActiveOriginal;
+                 org:originalOrganization ?secondNotActiveOriginal;
+                 lblodOrg:veranderingsgebeurtenisResultaat ?firstNotActiveChangeEventResult;
+                 lblodOrg:veranderingsgebeurtenisResultaat ?secondNotActivechangeEventResult;
+                 lblodOrg:veranderingsgebeurtenisResultaat ?resultingOrganisationChangeEventResult.
+
+    ?firstNotActiveChangeEventResult a lblodOrg:VeranderingsgebeurtenisResultaat;
+                                     mu:uuid ?uuidFirstNotActiveChangeEventResult;
+                                     lblodOrg:resulterendeStatus ?notActiveStatus;
+                                     ext:resultingOrganization ?firstNotActiveOriginal.
+
+    ?secondNotActivechangeEventResult a lblodOrg:VeranderingsgebeurtenisResultaat;
+                                      mu:uuid ?uuidSecondNotActiveChangeEventResult;
+                                      lblodOrg:resulterendeStatus ?notActiveStatus;
+                                      ext:resultingOrganization ?secondNotActiveOriginal.
+
+    ?resultingOrganisationChangeEventResult a lblodOrg:VeranderingsgebeurtenisResultaat;
+                                            mu:uuid ?uuidResultingOrganisationChangeEventResult;
+                                            lblodOrg:resulterendeStatus ?activeStatus;
+                                            ext:resultingOrganization ?resultingOrganisation.
+  }
+} WHERE {
+  VALUES (?firstNotActiveOriginal ?secondNotActiveOriginal ?resultingOrganisation) {
+    (<http://data.lblod.info/id/bestuurseenheden/150440a8bb763d6f53d24ca1c6f1460cb5817c8a261fd90e74aadac3292c3efe> # PZ Alken/Borgloon/Heers/Kortessem/Wellen
+     <http://data.lblod.info/id/bestuurseenheden/41d31a2eb697af977aadf64c73e0bcffb094e0f20e4017fe3b49c507079c0976> # PZ Tongeren/Herstappe
+     <http://data.lblod.info/id/bestuurseenheden/677E848329299CC832892A1B> # PZ Tongeren-Borgloon/Herstappe/Heers/Wellen
+     )
+  }
+
+  BIND (SHA256(CONCAT(STR(?firstNotActiveOriginal), STR(?secondNotActiveOriginal), STR(?resultingOrganization))) AS ?uuidChangeEvent) .
+  BIND (IRI(CONCAT("http://data.lblod.info/id/veranderingsgebeurtenissen/", STR(?uuidChangeEvent))) AS ?changeEvent) .
+
+  BIND (SHA256(CONCAT(STR(?firstNotActiveOriginal), "FirstNotActiveMergerChangeEventResult")) AS ?uuidFirstNotActiveChangeEventResult) .
+  BIND (IRI(CONCAT("http://lblod.data.info/id/veranderingsgebeurtenis-resultaten/", STR(?uuidFirstNotActiveChangeEventResult))) AS ?firstNotActiveChangeEventResult) .
+
+  BIND (SHA256(CONCAT(STR(?secondNotActiveOriginal), "SecondNotActiveMergerChangeEventResult")) AS ?uuidSecondNotActiveChangeEventResult) .
+  BIND (IRI(CONCAT("http://lblod.data.info/id/veranderingsgebeurtenis-resultaten/", STR(?uuidSecondNotActiveChangeEventResult))) AS ?secondNotActivechangeEventResult) .
+
+  BIND (SHA256(CONCAT(STR(?firstNotActiveOriginal), STR(?secondNotActiveOriginal), STR(?resultingOrganization), "fusieChangeEventActiveResult")) AS ?uuidResultingOrganisationChangeEventResult) .
+  BIND (IRI(CONCAT("http://lblod.data.info/id/veranderingsgebeurtenis-resultaten/", STR(?uuidResultingOrganisationChangeEventResult))) AS ?resultingOrganisationChangeEventResult) .
+
+  BIND (<http://lblod.data.gift/concepts/fa80032794c841ecac73ff874f856db1> AS ?mergerChangeEventType)
+  BIND (<http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311> AS ?notActiveStatus)
+  BIND (<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> AS ?activeStatus)
+}

--- a/config/migrations/2025/20250108184340-mergers-2025-police-zones/20250108190240-mergers-2025-police-zones--beveren_kruibeke_zwijndrecht-sint_gillis_waas-stekene-temse.sparql
+++ b/config/migrations/2025/20250108184340-mergers-2025-police-zones/20250108190240-mergers-2025-police-zones--beveren_kruibeke_zwijndrecht-sint_gillis_waas-stekene-temse.sparql
@@ -1,0 +1,72 @@
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX ch: <http://data.lblod.info/vocabularies/contacthub/>
+PREFIX lblodOrg: <http://lblod.data.gift/vocabularies/organisatie/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+
+# Add fusion change event
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?changeEvent a org:ChangeEvent;
+                 mu:uuid ?uuidChangeEvent;
+                 ch:typeWijziging ?mergerChangeEventType;
+                 org:resultingOrganization ?resultingOrganisation;
+                 dct:date "2025-01-01"^^xsd:date;
+                 dct:description "Fusie tussen PZ Zwijndrecht (= 5346 PZ Zwijndrecht) en PZ Kruibeke/Temse (= 5433 PZ Kruibeke/Temse) en PZ Beveren/Sint-Gillis-Waas/Stekene (= 5904 Waasland-Noord) resulteert in PZ Beveren-Kruibeke-Zwijndrecht/Sint-Gillis-Waas/Stekene/Temse (= 5964 PZ Scheldewaas)";
+                 org:originalOrganization ?firstNotActiveOriginal;
+                 org:originalOrganization ?secondNotActiveOriginal;
+                 org:originalOrganization ?thirdNotActiveOriginal;
+                 lblodOrg:veranderingsgebeurtenisResultaat ?firstNotActiveChangeEventResult;
+                 lblodOrg:veranderingsgebeurtenisResultaat ?secondNotActiveChangeEventResult;
+                 lblodOrg:veranderingsgebeurtenisResultaat ?thirdNotActiveChangeEventResult;
+                 lblodOrg:veranderingsgebeurtenisResultaat ?resultingOrganisationChangeEventResult.
+
+    ?firstNotActiveChangeEventResult a lblodOrg:VeranderingsgebeurtenisResultaat;
+                                     mu:uuid ?uuidFirstNotActiveChangeEventResult;
+                                     lblodOrg:resulterendeStatus ?notActiveStatus;
+                                     ext:resultingOrganization ?firstNotActiveOriginal.
+
+    ?secondNotActiveChangeEventResult a lblodOrg:VeranderingsgebeurtenisResultaat;
+                                      mu:uuid ?uuidSecondNotActiveChangeEventResult;
+                                      lblodOrg:resulterendeStatus ?notActiveStatus;
+                                      ext:resultingOrganization ?secondNotActiveOriginal.
+
+    ?thirdNotActiveChangeEventResult a lblodOrg:VeranderingsgebeurtenisResultaat;
+                                     mu:uuid ?uuidThirdNotActiveChangeEventResult;
+                                     lblodOrg:resulterendeStatus ?notActiveStatus;
+                                     ext:resultingOrganization ?thirdNotActiveOriginal.
+
+    ?resultingOrganisationChangeEventResult a lblodOrg:VeranderingsgebeurtenisResultaat;
+                                            mu:uuid ?uuidResultingOrganisationChangeEventResult;
+                                            lblodOrg:resulterendeStatus ?activeStatus;
+                                            ext:resultingOrganization ?resultingOrganisation.
+  }
+} WHERE {
+  VALUES (?firstNotActiveOriginal ?secondNotActiveOriginal ?thirdNotActiveOriginal ?resultingOrganisation) {
+    (<http://data.lblod.info/id/bestuurseenheden/330516b323c00851cf4b93e6d5d7a2ef4591f68ae6e71ad9c1f432ee70521bb2> # PZ Zwijndrecht
+     <http://data.lblod.info/id/bestuurseenheden/7dd1250996188607bb1e28df1ebea0b943e8db59c08ea01e3c57672531c43ec6> # PZ Kruibeke/Temse
+     <http://data.lblod.info/id/bestuurseenheden/541c1603eb8c01968f95d1f262854134499e00d135cd7c9147d307ccbd1e20fd> # PZ Beveren/Sint-Gillis-Waas/Stekene
+     <http://data.lblod.info/id/bestuurseenheden/677E959629299CC832892A24> # PZ Beveren-Kruibeke-Zwijndrecht/Sint-Gillis-Waas/Stekene/Temse
+     )
+  }
+
+  BIND (SHA256(CONCAT(STR(?firstNotActiveOriginal), STR(?secondNotActiveOriginal), STR(?resultingOrganization))) AS ?uuidChangeEvent) .
+  BIND (IRI(CONCAT("http://data.lblod.info/id/veranderingsgebeurtenissen/", STR(?uuidChangeEvent))) AS ?changeEvent) .
+
+  BIND (SHA256(CONCAT(STR(?firstNotActiveOriginal), "FirstNotActiveMergerChangeEventResult")) AS ?uuidFirstNotActiveChangeEventResult) .
+  BIND (IRI(CONCAT("http://lblod.data.info/id/veranderingsgebeurtenis-resultaten/", STR(?uuidFirstNotActiveChangeEventResult))) AS ?firstNotActiveChangeEventResult) .
+
+  BIND (SHA256(CONCAT(STR(?secondNotActiveOriginal), "SecondNotActiveMergerChangeEventResult")) AS ?uuidSecondNotActiveChangeEventResult) .
+  BIND (IRI(CONCAT("http://lblod.data.info/id/veranderingsgebeurtenis-resultaten/", STR(?uuidSecondNotActiveChangeEventResult))) AS ?secondNotActiveChangeEventResult) .
+
+  BIND (SHA256(CONCAT(STR(?thirdNotActiveOriginal), "ThirdNotActiveMergerChangeEventResult")) AS ?uuidThirdNotActiveChangeEventResult) .
+  BIND (IRI(CONCAT("http://lblod.data.info/id/veranderingsgebeurtenis-resultaten/", STR(?uuidThirdNotActiveChangeEventResult))) AS ?thirdNotActiveChangeEventResult) .
+
+  BIND (SHA256(CONCAT(STR(?firstNotActiveOriginal), STR(?secondNotActiveOriginal), STR(?thirdNotActiveOriginal), STR(?resultingOrganization), "MergerChangeEventResultActiveResult")) AS ?uuidResultingOrganisationChangeEventResult) .
+  BIND (IRI(CONCAT("http://lblod.data.info/id/veranderingsgebeurtenis-resultaten/", STR(?uuidResultingOrganisationChangeEventResult))) AS ?resultingOrganisationChangeEventResult) .
+
+  BIND (<http://lblod.data.gift/concepts/fa80032794c841ecac73ff874f856db1> AS ?mergerChangeEventType)
+  BIND (<http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311> AS ?notActiveStatus)
+  BIND (<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> AS ?activeStatus)
+}

--- a/config/migrations/2025/20250108184340-mergers-2025-police-zones/20250108193811-mergers-2025-police-zones--vlaamse-ardennen.sparql
+++ b/config/migrations/2025/20250108184340-mergers-2025-police-zones/20250108193811-mergers-2025-police-zones--vlaamse-ardennen.sparql
@@ -1,0 +1,61 @@
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX ch: <http://data.lblod.info/vocabularies/contacthub/>
+PREFIX lblodOrg: <http://lblod.data.gift/vocabularies/organisatie/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+
+# Add fusion change event
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?changeEvent a org:ChangeEvent;
+                 mu:uuid ?uuidChangeEvent;
+                 ch:typeWijziging ?mergerChangeEventType;
+                 org:resultingOrganization ?resultingOrganisation;
+                 dct:date "2025-01-01"^^xsd:date;
+                 dct:description "Fusie tussen PZ Kluisbergen/Kruisem/Oudenaarde/Wortegem-Petegem (= 5425 PZ Vlaamse Ardennen) en PZ Brakel/Horebeke/Maarkedal/Zwalm (= 5426 PZ Brakel) resulteert in PZ Vlaamse Ardennen (= 5915 PZ Vlaamse Ardennen)";
+                 org:originalOrganization ?firstNotActiveOriginal;
+                 org:originalOrganization ?secondNotActiveOriginal;
+                 lblodOrg:veranderingsgebeurtenisResultaat ?firstNotActiveChangeEventResult;
+                 lblodOrg:veranderingsgebeurtenisResultaat ?secondNotActivechangeEventResult;
+                 lblodOrg:veranderingsgebeurtenisResultaat ?resultingOrganisationChangeEventResult.
+
+    ?firstNotActiveChangeEventResult a lblodOrg:VeranderingsgebeurtenisResultaat;
+                                     mu:uuid ?uuidFirstNotActiveChangeEventResult;
+                                     lblodOrg:resulterendeStatus ?notActiveStatus;
+                                     ext:resultingOrganization ?firstNotActiveOriginal.
+
+    ?secondNotActivechangeEventResult a lblodOrg:VeranderingsgebeurtenisResultaat;
+                                      mu:uuid ?uuidSecondNotActiveChangeEventResult;
+                                      lblodOrg:resulterendeStatus ?notActiveStatus;
+                                      ext:resultingOrganization ?secondNotActiveOriginal.
+
+    ?resultingOrganisationChangeEventResult a lblodOrg:VeranderingsgebeurtenisResultaat;
+                                            mu:uuid ?uuidResultingOrganisationChangeEventResult;
+                                            lblodOrg:resulterendeStatus ?activeStatus;
+                                            ext:resultingOrganization ?resultingOrganisation.
+  }
+} WHERE {
+  VALUES (?firstNotActiveOriginal ?secondNotActiveOriginal ?resultingOrganisation) {
+    (<http://data.lblod.info/id/bestuurseenheden/4deae42b2b25bff407f5abc7cbb6d62eb02afaf2892086341c324fdf2c0e6e92> # PZ Kluisbergen/Kruisem/Oudenaarde/Wortegem-Petegem
+     <http://data.lblod.info/id/bestuurseenheden/b7af3483cb5d0021c6f5864a433b211fce30246ef685621d104b1951915c21c4> # PZ Brakel/Horebeke/Maarkedal/Zwalm
+     <http://data.lblod.info/id/bestuurseenheden/677E966229299CC832892A2D> # PZ Vlaamse Ardennen
+     )
+  }
+
+  BIND (SHA256(CONCAT(STR(?firstNotActiveOriginal), STR(?secondNotActiveOriginal), STR(?resultingOrganization))) AS ?uuidChangeEvent) .
+  BIND (IRI(CONCAT("http://data.lblod.info/id/veranderingsgebeurtenissen/", STR(?uuidChangeEvent))) AS ?changeEvent) .
+
+  BIND (SHA256(CONCAT(STR(?firstNotActiveOriginal), "FirstNotActiveMergerChangeEventResult")) AS ?uuidFirstNotActiveChangeEventResult) .
+  BIND (IRI(CONCAT("http://lblod.data.info/id/veranderingsgebeurtenis-resultaten/", STR(?uuidFirstNotActiveChangeEventResult))) AS ?firstNotActiveChangeEventResult) .
+
+  BIND (SHA256(CONCAT(STR(?secondNotActiveOriginal), "SecondNotActiveMergerChangeEventResult")) AS ?uuidSecondNotActiveChangeEventResult) .
+  BIND (IRI(CONCAT("http://lblod.data.info/id/veranderingsgebeurtenis-resultaten/", STR(?uuidSecondNotActiveChangeEventResult))) AS ?secondNotActivechangeEventResult) .
+
+  BIND (SHA256(CONCAT(STR(?firstNotActiveOriginal), STR(?secondNotActiveOriginal), STR(?resultingOrganization), "fusieChangeEventActiveResult")) AS ?uuidResultingOrganisationChangeEventResult) .
+  BIND (IRI(CONCAT("http://lblod.data.info/id/veranderingsgebeurtenis-resultaten/", STR(?uuidResultingOrganisationChangeEventResult))) AS ?resultingOrganisationChangeEventResult) .
+
+  BIND (<http://lblod.data.gift/concepts/fa80032794c841ecac73ff874f856db1> AS ?mergerChangeEventType)
+  BIND (<http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311> AS ?notActiveStatus)
+  BIND (<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> AS ?activeStatus)
+}


### PR DESCRIPTION
## Summary
A number of police zones merge together, resulting in 3 remaining active police zones. All organisations were already created by business, this PR only add the merger change events and updates the necessary organisation statuses.

More concretely the following police zones are involved:

| Original organisations                             | Resulting organisation                                         |
|----------------------------------------------------|----------------------------------------------------------------|
| PZ Alken/Borgloon/Heers/Kortessem/Wellen           | PZ Tongeren-Borgloon/Herstappe/Heers/Wellen                    |
| PZ Tongeren/Herstappe                              |                                                                |
|----------------------------------------------------|----------------------------------------------------------------|
| PZ Zwijndrecht                                     | PZ Beveren-Kruibeke-Zwijndrecht/Sint-Gillis-Waas/Stekene/Temse |
| PZ Kruibeke/Temse                                  |                                                                |
| PZ Beveren/Sint-Gillis-Waas/Stekene                |                                                                |
|----------------------------------------------------|----------------------------------------------------------------|
| PZ Kluisbergen/Kruisem/Oudenaarde/Wortegem-Petegem | PZ Vlaamse Ardennen                                            |
| PZ Brakel/Horebeke/Maarkedal/Zwalm                 |                                                                |

## How to test
- Restart both the `migrations` and the `migrations-triggering-indexing` services to execute the migrations.
- For each of the mergers in the table above:
  + There should be a merger change event linking the organisations as linked in the table
  + Each change event should have as date 01-01-2025
  + The status of each original organisation should be *Not active* (nl. *Niet actief*), whereas the resulting organisations should be *Active* (nl. *Actief*)

## Notes
- This should be tested using PROD data, the resulting PZs are **not** on DEV.
- The `migrations-triggering-indexing` is used to update the statuses of the organisations, using this avoids having to do a full re-index to see the results. But it may take some time before the before the statuses are update in the overview table. The speed of the index updates depends on the load and available resources of your machine.
- The change event descriptions were copied from the ticket.
- For convenience, the URIs for the relevant organisations:

| name                                                           | uri                                                                                                         |
| -------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
| PZ Alken/Borgloon/Heers/Kortessem/Wellen                       | http://data.lblod.info/id/bestuurseenheden/150440a8bb763d6f53d24ca1c6f1460cb5817c8a261fd90e74aadac3292c3efe |
| PZ Beveren-Kruibeke-Zwijndrecht/Sint-Gillis-Waas/Stekene/Temse | http://data.lblod.info/id/bestuurseenheden/677E959629299CC832892A24                                         |
| PZ Beveren/Sint-Gillis-Waas/Stekene                            | http://data.lblod.info/id/bestuurseenheden/541c1603eb8c01968f95d1f262854134499e00d135cd7c9147d307ccbd1e20fd |
| PZ Brakel/Horebeke/Maarkedal/Zwalm                             | http://data.lblod.info/id/bestuurseenheden/b7af3483cb5d0021c6f5864a433b211fce30246ef685621d104b1951915c21c4 |
| PZ Kluisbergen/Kruisem/Oudenaarde/Wortegem-Petegem             | http://data.lblod.info/id/bestuurseenheden/4deae42b2b25bff407f5abc7cbb6d62eb02afaf2892086341c324fdf2c0e6e92 |
| PZ Kruibeke/Temse                                              | http://data.lblod.info/id/bestuurseenheden/7dd1250996188607bb1e28df1ebea0b943e8db59c08ea01e3c57672531c43ec6 |
| PZ Tongeren-Borgloon/Herstappe/Heers/Wellen                    | http://data.lblod.info/id/bestuurseenheden/677E848329299CC832892A1B                                         |
| PZ Tongeren/Herstappe                                          | http://data.lblod.info/id/bestuurseenheden/41d31a2eb697af977aadf64c73e0bcffb094e0f20e4017fe3b49c507079c0976 |
| PZ Vlaamse Ardennen                                            | http://data.lblod.info/id/bestuurseenheden/677E966229299CC832892A2D                                         |
| PZ Zwijndrecht                                                 | http://data.lblod.info/id/bestuurseenheden/330516b323c00851cf4b93e6d5d7a2ef4591f68ae6e71ad9c1f432ee70521bb2 |

## Related tickets
- OP-3454