### PR TITLE
cleanup local involvements

### DIFF
--- a/config/migrations/2025/20250108154325-delete-local-involvements/20250108154325-delete-local-involvement-borsbeek.sparql
+++ b/config/migrations/2025/20250108154325-delete-local-involvements/20250108154325-delete-local-involvement-borsbeek.sparql
@@ -1,0 +1,13 @@
+DELETE WHERE {
+  graph <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/betrokkenLokaleBesturen/b38d5606b539da68af04891d9ca08605> ?p ?o.
+  }
+}
+
+;
+
+DELETE WHERE {
+  graph <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/bestuurseenheden/e41ffa04f94bb450a79793020e70d55b5fee5033a5280277998608a9d0913117> <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/b38d5606b539da68af04891d9ca08605>.
+  }
+}

--- a/config/migrations/2025/20250108154325-delete-local-involvements/20250108154750-delete-local-involvement-meulebeke.sparql
+++ b/config/migrations/2025/20250108154325-delete-local-involvements/20250108154750-delete-local-involvement-meulebeke.sparql
@@ -1,0 +1,13 @@
+DELETE WHERE {
+  graph <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/betrokkenLokaleBesturen/1f525a624264469c0a765a33f1c609cc> ?p ?o.
+  }
+}
+
+;
+
+DELETE WHERE {
+  graph <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/bestuurseenheden/5a4b2b4f1de1f3b91b0348a7eb6d6aa0ef9420b8ec31374970c9ffe933a79515> <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/1f525a624264469c0a765a33f1c609cc>.
+  }
+}

--- a/config/migrations/2025/20250108154325-delete-local-involvements/20250108154850-delete-local-involvement-hoeselt.sparql
+++ b/config/migrations/2025/20250108154325-delete-local-involvements/20250108154850-delete-local-involvement-hoeselt.sparql
@@ -1,0 +1,13 @@
+DELETE WHERE {
+  graph <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/betrokkenLokaleBesturen/623B1D5CB72F9F4B3350823E> ?p ?o.
+  }
+}
+
+;
+
+DELETE WHERE {
+  graph <http://mu.semte.ch/graphs/worship-service> {
+    <http://data.lblod.info/id/bestuurseenheden/a3bd0845853278f478f90b14436d3efa99e73249a84d462f0ddc2e5b6e37a156> <http://data.lblod.info/vocabularies/erediensten/betrokkenBestuur> <http://data.lblod.info/id/betrokkenLokaleBesturen/623B1D5CB72F9F4B3350823E>.
+  }
+}


### PR DESCRIPTION
## ID
OP-3512

## Description

Remove 3 local involvements of 'borsbeek', 'meulebeke' and 'hoeselt'.

Note that I didn't update the financing values, as the ticket described that it will be done in the frontend.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How to test

Rsync prod data, run migration and verify that the local involvements are removed.