### PR TITLE
feat: allow local migrations that trigger indexing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ docker-compose.override.yml
 
 /config/migrations/private-data/*
 /config/migrations/local/*
+/config/migrations-triggering-indexing/local/*
 
 /config/proxy/nginx.htpasswd
 

--- a/config/migrations-triggering-indexing/local/README.md
+++ b/config/migrations-triggering-indexing/local/README.md
@@ -1,0 +1,3 @@
+# Motivation
+
+This folder is designed to contain migration files specific to a specific deployed instance of the app. These files will be ignored by git. The typical use case for this folder includes migrations containing sensitive data or those related to a re-sync of consumers. Migrations that should be applied to all instances of the app should be stored outside of this folder, but within the 'migrations-triggering-indexing' folder.


### PR DESCRIPTION
Add support for environment-local migrations that trigger indexing. This is
similar to local migrations for the regular `migrations` service are placed in
the `config/migrations/local/` folder.