### PR TITLE
fix: merger change event between St.-Amandus and Sint-Martinus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## 1.28.5 (TODO)
+### Backend
+- Datafix: correct merger change events for worship organisations (OP-3534)
+### Deploy notes
+- `drc restart migrations-triggering-indexing; drc logs -ft --tail=200 migrations-triggering-indexing`
+
 ## 1.28.4 (2025-01-16)
 ### Backend
 #### Data

--- a/config/migrations-triggering-indexing/20250114093158-fix-merger-change-event-sint_martinus-st_amandus.sparql
+++ b/config/migrations-triggering-indexing/20250114093158-fix-merger-change-event-sint_martinus-st_amandus.sparql
@@ -1,0 +1,23 @@
+PREFIX regorg: <http://www.w3.org/ns/regorg#>
+PREFIX org: <http://www.w3.org/ns/org#>
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?stAmandus regorg:orgStatus ?oldStatus.
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?stAmandus regorg:orgStatus ?notActiveStatus.
+
+    ?mergerChangeEvent org:originalOrganization ?stAmandus.
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?stAmandus regorg:orgStatus ?oldStatus.
+  }
+  VALUES ?stAmandus {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b18a5d3943087d509d76dcceeba102c3>
+  }
+  BIND (<http://data.lblod.info/id/veranderingsgebeurtenissen/677E445E29299CC832892A0F> AS ?mergerChangeEvent)
+  BIND (<http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311> AS ?notActiveStatus)
+}


### PR DESCRIPTION
The worship service the worship organisation *St.-Amandus* was not included as `orginalOrganization` in its merger change event. As a result it was not listed as involved organisation in the change event details. Furthermore, its status was not correctly updated to "Not active".

The new migration corrects the relevant change event by adding a link to the worship organisation and updating the organisation's status.

## How to test
- Restart the correct migrations service, see command in the changelog.
- Verify that
  + The status of *St.-Amandus* has changed to "Niet actief"
  + The merger change event should now list *St.-Amandus* as involved organisation.

The URIs of the relevant resources can be found in the ticket and the migration itself.

## Notes
- Should be tested with PROD data
- The index updates may take some time, depending on the available resources, the status of *St.-Amandus* in the organisations overview table will only change when they are done. The status on its core data page is immedialtly accurate (barring when cached data is used).
- On the core data page for *St.-Amandus* the date in the "Gewijzigd op ..." field below the status pill will **not** change. This date is taken from the most recent change event for which the organisation is a *resulting organisation* instead of considering all change events for the organisation. This will be improved in a separate ticket, the comments for the related ticket contain more background information.

## Related tickets
- OP-3534