### PR TITLE
fix: index municipality names as keywords instead of regular text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@
 - Bump to [v1.28.2](https://github.com/lblod/frontend-organization-portal/releases/tag/v1.28.2)
 ### Backend
 - Datafix: correct merger change events for worship organisations (OP-3534)
+- Avoid municipality filter to include partial matches (OP-3509)
 ### Deploy notes
 - `drc restart migrations-triggering-indexing; drc logs -ft --tail=200 migrations-triggering-indexing`
 - `drc pull frontend; drc up -d frontend`
+- Perform a full re-index by executing `./scripts/reset-elastic.sh`
 
 ## 1.28.4 (2025-01-16)
 ### Backend

--- a/config/search/config.json
+++ b/config/search/config.json
@@ -223,7 +223,7 @@
             }
           },
           "organization_municipality": {
-            "type": "text",
+            "type": "keyword",
             "fields": {
               "field": {
                 "type": "keyword",
@@ -385,7 +385,7 @@
             }
           },
           "organization_municipality": {
-            "type": "text",
+            "type": "keyword",
             "fields": {
               "field": {
                 "type": "keyword",
@@ -540,7 +540,7 @@
             }
           },
           "organization_municipality": {
-            "type": "text",
+            "type": "keyword",
             "fields": {
               "field": {
                 "type": "keyword",
@@ -727,7 +727,7 @@
             }
           },
           "organization_municipality": {
-            "type": "text",
+            "type": "keyword",
             "fields": {
               "field": {
                 "type": "keyword",
@@ -880,7 +880,7 @@
             }
           },
           "municipality": {
-            "type": "text",
+            "type": "keyword",
             "fields": {
               "field": {
                 "type": "keyword",

--- a/config/search/dev/config.json
+++ b/config/search/dev/config.json
@@ -195,7 +195,7 @@
             }
           },
           "organization_municipality": {
-            "type": "text",
+            "type": "keyword",
             "fields": {
               "field": {
                 "type": "keyword",
@@ -357,7 +357,7 @@
             }
           },
           "organization_municipality": {
-            "type": "text",
+            "type": "keyword",
             "fields": {
               "field": {
                 "type": "keyword",
@@ -512,7 +512,7 @@
             }
           },
           "organization_municipality": {
-            "type": "text",
+            "type": "keyword",
             "fields": {
               "field": {
                 "type": "keyword",
@@ -700,7 +700,7 @@
             }
           },
           "organization_municipality": {
-            "type": "text",
+            "type": "keyword",
             "fields": {
               "field": {
                 "type": "keyword",
@@ -853,7 +853,7 @@
             }
           },
           "municipality": {
-            "type": "text",
+            "type": "keyword",
             "fields": {
               "field": {
                 "type": "keyword",


### PR DESCRIPTION
Index municipality names as keywords instead of as plain text. This prevents them from being split at word separators. Thereby avoiding that searches for a municipality name, as used by the frontend's municipality filter, return organisations whose municipality is a partial match.

For example, previously the results when searching for "Puurs" also included the organisations located in "Sint-Amands-Puurs". The latter was tokenized into three terms, therefore also matching plain "Puurs". By treating the municipality name as keyword this split non longer happens.

## Reproducing the bug
1. Boot up a local OP stack
2. Open up the frontend and login as a user, a non-worship role is the most convenient
3. On the organisations overview page, use the municipality (*nl. Gemeente*) filter in the sidebar to limit the organisation to those located in one of the following:
    - Puurs (includes results for Puurs-Sint-Amands)
    - Sint-Amands (includes results for Puurs-Sint-Amands)
    - De Pinte (includes results for Nazareth-De Pinte)
    - Nazareth (includes results for Nazareth-De Pinte)
    - Melle (includes results for Merelbeke-Melle)
    - Merelbeke (includes results for Merelbeke-Melle)
    - Beveren (includes results for Beveren-Kruibeke-Zwijndrecht)
    - Kruibeke (includes results for Beveren-Kruibeke-Zwijndrecht)
    - Zwijndrecht (includes results for Beveren-Kruibeke-Zwijndrecht)
    - Hoeselt (includes results for Bilzen-Hoeselt)
    - Borgloon (includes results for Tongeren-Borgloon)
    - Tessenderlo (includes results for Tessenderlo-Ham)
4. The resulting list of organisations should entries whose municipality is not an exact match for the filtered value. The exact results may vary a bit depending on which data set (QA/PROD/DEV) you loaded.

## How to test
:warning: Testing this requires a full re-index, this typically takes several hours. One way to shorten this is to comment out the non-organisation indexes in the search configuration. This does break the filters in the persons module.

1. Fully re-index the data in your local stack by running `scripts/reset-elastic.sh`
2. When filtering on one the municipalities listed above the results should now only contain organisations whose municipality exactly matches the filtered one. More specifically:
    - Puurs and Sint-Amands should have as resulting organisations a non-active municipality and OCMW (and no organisations in the worship module.)
    - For the remaining municipalities the resulting organisations should be empty, both in the non-worship as well as the worship module. (These municipalities are involved in the 2025 mergers and the addresses for organisations have already been updated in #488)

## Notes
- The `organization_municipality` indices for persons do not seem to be actively used by the app. These will likely be removed later, but were updated in this PR for completeness.
- The expected behaviour as described above assumes you are using fairly recent data, which includes the data migrations for the 2025 municipality mergers. The observed behaviour is most likely different if you are using older data.
- Any changes to the search configuration for (further) local testing should be done in the `search/dev/config.json`. (Alternatively, you can overwrite the `search` service configuration in `docker-compose.dev.yml`)

## Related tickets
- OP-3509