### PR TITLE
remove province and commune classifications from admin graph

### DIFF
--- a/config/migrations/2025/20250124100000-delete-duplicate-classifications.sparql
+++ b/config/migrations/2025/20250124100000-delete-duplicate-classifications.sparql
@@ -1,0 +1,17 @@
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?adminUnit org:classification ?c
+  }
+}
+
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?adminUnit org:classification ?c
+  }
+  ?c skos:prefLabel ?l .
+  FILTER (?l IN ("Gemeente", "Provincie"))
+}


### PR DESCRIPTION
Remove the province and commune classifications from the admin unit graph - as they are already stored in the shared graph.