### PR TITLE
refactor: determine docker compose command based on system

### DIFF
--- a/scripts/reset-elastic.sh
+++ b/scripts/reset-elastic.sh
@@ -1,11 +1,19 @@
 #!/bin/bash
+version=$(docker compose version)
+
+if [ $? -eq 0 ]; then
+    DRC_COMMAND="docker compose"
+else
+    DRC_COMMAND="docker-compose"
+fi
+
 echo "warning this will run queries on the triplestore and delete containers, you have 3 seconds to press ctrl+c"
 sleep 3
-docker-compose rm -fs elasticsearch search
+eval "$DRC_COMMAND rm -fs elasticsearch search"
 sudo rm -rf data/elasticsearch/
-docker-compose exec -T triplestore isql-v <<EOF
+eval "$DRC_COMMAND exec -T triplestore isql-v <<EOF
 SPARQL DELETE WHERE {   GRAPH <http://mu.semte.ch/authorization> {     ?s ?p ?o.   } };
 exec('checkpoint');
 exit;
-EOF
-docker-compose up -d --remove-orphan
+EOF"
+eval "$DRC_COMMAND up -d --remove-orphans"


### PR DESCRIPTION
This makes the `reset-elastic.sh` script more flexible by automatically determining whether to use `docker-compose` or `docker compose`. The script now essentially checks the exit status for `docker compose version`. If that command executes successfully use `docker compose`, otherwise fall back to `docker-compose`.

Furthermore, this replaces the `--remove-orphan` flag in the last command by `--remove-orphanS`, which was introduced in [v1.7.0](https://docs.docker.com/compose/releases/release-notes/#170). I was unable to find when the singular variant `--remove-orphan` was introduced or removed.

## Alternative approach
It is possible to take a more fine-grained approach by extracting the version numbers from the output of `docker compose version` and/or `docker-compose --version`, for instance using `sed` with an appropriate regex. But in my opinion this adds extra complexity to achieve the same functionality.

## Notes
- I only tested the full script on my local machine which has `docker compose` v2.32.4 installed.
- I tested the logic to determine the docker compose command on the OP development server using the following script:

``` bash
#!/bin/bash
version=$(docker compose version)

if [ $? -eq 0 ]; then
    DRC_COMMAND="docker compose"
else
    DRC_COMMAND="docker-compose"
fi

echo "$DRC_COMMAND"
```