### PR TITLE
Add migration to remove bcsd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Backend
 - Completely remove AGB Stekene's data. [OP-3409]
 - Remove gemeente and provincie classifications from admin unit graph [OP-3393]
+- Remove several OCMW bcsd faciliteitgemeenten [OP-3535]
 
 ### Deploy Notes
 - Migration listed in [this comment](https://github.com/lblod/app-organization-portal/pull/491#issuecomment-2587185027) must run on the DEV environment.
@@ -10,6 +11,9 @@
 ```
 drc restart migrations-triggering-indexing && drc logs -ft --tail=200 migrations-triggering-indexing
 ```
+
+`drc restart migrations; drc logs -ft --tail=200 migrations`
+
 
 ## 1.28.5 (2025-01-23)
 ### Frontend

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,9 +36,6 @@ drc pull frontend; drc up -d frontend
 ./scripts/reset-elastic.sh
 ```
 
-`drc restart migrations; drc logs -ft --tail=200 migrations`
-
-
 ## 1.28.5 (2025-01-23)
 ### Frontend
 - Bump to [v1.28.3](https://github.com/lblod/frontend-organization-portal/releases/tag/v1.28.3)

--- a/config/migrations/2025/20250129125705-remove-bcsd-bestuursorganen-faciliteitsgemeenten.sparql
+++ b/config/migrations/2025/20250129125705-remove-bcsd-bestuursorganen-faciliteitsgemeenten.sparql
@@ -20,10 +20,16 @@ WHERE {
       <http://data.lblod.info/id/bestuurseenheden/f9ee0b69624bba3677b18b95110246ee9106377c948ab5d914909eac79f88bcf> # Wezembeek-Oppem
       <http://data.lblod.info/id/bestuurseenheden/785715d2822814f7dc0b3896601b5b777feb1ef9722e1c54f4cdcc697594acca> # Voeren
     }
-    ?bestuursorgaan besluit:bestuurt ?faciliteitEenheid .
-    ?bestuursorgaan org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000009>. # BCSD
 
-    ?boi generiek:isTijdspecialisatieVan ?bestuursorgaan.
+    VALUES ?classification {
+      <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000009>   # BCSD
+      <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/53c0d8cd-f3a2-411d-bece-4bd83ae2bbc9> # BCSD Voorzitter
+    }
+
+    ?bestuursorgaan besluit:bestuurt ?faciliteitEenheid .
+    ?bestuursorgaan org:classification ?classification .
+
+    ?boi generiek:isTijdspecialisatieVan ?bestuursorgaan .
     ?boi mandaat:bindingStart ?startDate .
 
     ?boi ?p ?o.

--- a/config/migrations/2025/20250129125705-remove-bcsd-bestuursorganen-faciliteitsgemeenten.sparql
+++ b/config/migrations/2025/20250129125705-remove-bcsd-bestuursorganen-faciliteitsgemeenten.sparql
@@ -2,12 +2,12 @@ PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
 PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
 
 DELETE {
-  GRAPH ?g {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
     ?boi ?p ?o.
   }
 }
 WHERE {
-  GRAPH ?g {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
     VALUES ?faciliteitEenheid {
       # OCMW
       <http://data.lblod.info/id/bestuurseenheden/76730bd9ab6808230335d90e9ff30ad362a3461ee0239fd978e4313bcdca44c5> # Sint-Genesius-Rode

--- a/config/migrations/2025/20250129125705-remove-bcsd-bestuursorganen-faciliteitsgemeenten.sparql
+++ b/config/migrations/2025/20250129125705-remove-bcsd-bestuursorganen-faciliteitsgemeenten.sparql
@@ -1,5 +1,7 @@
 PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
 PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
 
 DELETE {
   GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
@@ -19,9 +21,9 @@ WHERE {
       <http://data.lblod.info/id/bestuurseenheden/785715d2822814f7dc0b3896601b5b777feb1ef9722e1c54f4cdcc697594acca> # Voeren
     }
     ?bestuursorgaan besluit:bestuurt ?faciliteitEenheid .
-    ?bestuursorgaan besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000009>. # BCSD
+    ?bestuursorgaan org:classification <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000009>. # BCSD
 
-    ?boi mandaat:isTijdspecialisatieVan ?bestuursorgaan.
+    ?boi generiek:isTijdspecialisatieVan ?bestuursorgaan.
     ?boi mandaat:bindingStart ?startDate .
 
     ?boi ?p ?o.

--- a/config/migrations/2025/20250129125705-remove-bcsd-bestuursorganen-faciliteitsgemeenten.sparql
+++ b/config/migrations/2025/20250129125705-remove-bcsd-bestuursorganen-faciliteitsgemeenten.sparql
@@ -1,0 +1,31 @@
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+
+DELETE {
+  GRAPH ?g {
+    ?boi ?p ?o.
+  }
+}
+WHERE {
+  GRAPH ?g {
+    VALUES ?faciliteitEenheid {
+      # OCMW
+      <http://data.lblod.info/id/bestuurseenheden/76730bd9ab6808230335d90e9ff30ad362a3461ee0239fd978e4313bcdca44c5> # Sint-Genesius-Rode
+      <http://data.lblod.info/id/bestuurseenheden/0b5d1664b3cf08550bcfdac0f4b195ab7a46a0f1974726de864dc0edb1565ecc> # Linkebeek
+      <http://data.lblod.info/id/bestuurseenheden/9ba66c8f97bbc6dd3ba2b35d8a6bb79215facbe3e5b3d52672b785449d6f5e58> # Drogenbos
+      <http://data.lblod.info/id/bestuurseenheden/7f2c5143806d6110feb44eba2a91d58e8fd563465b94d0f6b40d13a6a1740940> # Wemmel
+      <http://data.lblod.info/id/bestuurseenheden/45f432ac38d124141638c62f7afd577ab847c3571061b45e3b0b3329f6194048> # Kraainem
+      <http://data.lblod.info/id/bestuurseenheden/f9ee0b69624bba3677b18b95110246ee9106377c948ab5d914909eac79f88bcf> # Wezembeek-Oppem
+      <http://data.lblod.info/id/bestuurseenheden/785715d2822814f7dc0b3896601b5b777feb1ef9722e1c54f4cdcc697594acca> # Voeren
+    }
+    ?bestuursorgaan besluit:bestuurt ?faciliteitEenheid .
+    ?bestuursorgaan besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/5ab0e9b8a3b2ca7c5e000009>. # BCSD
+
+    ?boi mandaat:isTijdspecialisatieVan ?bestuursorgaan.
+    ?boi mandaat:bindingStart ?startDate .
+
+    ?boi ?p ?o.
+
+    FILTER(?startDate >= "2019-01-01T00:00:00"^^xsd:dateTime)
+  }
+}


### PR DESCRIPTION
## ID

OP-3535

## Description

OCMWs for Voeren and 6 facility municipalities should not have a Bijzonder comité voor de sociale dienst.

