### PR TITLE
chore: additional example environment settings for worship consumers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -446,6 +446,8 @@ services:
     image: lblod/delta-consumer:0.1.0
     environment:
       DCR_SYNC_BASE_URL: "https://loket.lblod.info/"
+      DCR_SYNC_LOGIN_ENDPOINT: "https://loket.lblod.info/sync/worship-services-sensitive/login"
+      DCR_SECRET_KEY: "<override with secret key>"
       DCR_SERVICE_NAME: "worship-services-main-info-consumer"
       DCR_SYNC_DATASET_SUBJECT: "http://data.lblod.info/datasets/delta-producer/dumps/WorshipServicesSensitiveCacheGraphDump"
       DCR_INITIAL_SYNC_JOB_OPERATION: "http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/consumer/wsSensitive"
@@ -479,6 +481,8 @@ services:
     image: lblod/delta-consumer:0.1.0
     environment:
       DCR_SYNC_BASE_URL: "https://loket.lblod.info/"
+      DCR_SYNC_LOGIN_ENDPOINT: "https://loket.lblod.info/sync/worship-services-sensitive/login"
+      DCR_SECRET_KEY: "<override with secret key>"
       DCR_SERVICE_NAME: "worship-services-private-info-consumer"
       DCR_SYNC_DATASET_SUBJECT: "http://data.lblod.info/datasets/delta-producer/dumps/WorshipServicesSensitiveCacheGraphDump"
       DCR_INITIAL_SYNC_JOB_OPERATION: "http://redpencil.data.gift/id/jobs/concept/JobOperation/deltas/consumer/wsSensitive"


### PR DESCRIPTION
This adds example entries for `DCR_SYNC_LOGIN_ENDPOINT` and `DCR_SECRET_KEY`
environment settings for the worship consumers. The example value for
`DCR_SYNC_LOGIN_ENDPOINT` was chosen to match the value for `DCR_SYNC_BASE_URL`.

These environment settings need to be set correctly for both
consumers. Including examples in the `docker-compose.yml` makes this more
explicit.