### PR TITLE
DO NOT MERGE: cleanup site data for DEV environment

### DIFF
--- a/config/migrations/2025/20250213153859-dev-data-cleanup/20250213153859-delete-non-worship-organisations-from-worship-graph.sparql
+++ b/config/migrations/2025/20250213153859-dev-data-cleanup/20250213153859-delete-non-worship-organisations-from-worship-graph.sparql
@@ -1,0 +1,44 @@
+PREFIX organisatie: <https://data.vlaanderen.be/ns/organisatie#>
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+
+# Remove triples for non-worship organisations from the worship graph. The
+# duplicated triples are limited to type and uuid predicates as well as site
+# data.
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?organisation ?organisationP ?organisationO.
+    ?organisationO ?siteP ?siteO.
+    ?address ?addressP ?addressO.
+    ?contactPoint ?contactPointP ?contactPointO.
+  }
+} WHERE {
+  # Limit matched organisations to non-worship organisations
+  VALUES ?g {
+    <http://mu.semte.ch/graphs/administrative-unit>
+    <http://mu.semte.ch/graphs/shared>
+  }
+  GRAPH ?g {
+    ?organisation a org:Organization.
+  }
+  # Explicitly limit to triples for the predicates that are duplicated.
+  # NOTE: Do *not* remove triples for the `ere:betrokkenBestuur` predicate,
+  # these are valid triples for defining local involvements.
+  VALUES ?organisationP {
+    rdf:type
+    mu:uuid
+    org:hasPrimarySite
+    org:hasSite
+  }
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?organisation ?organisationP ?organisationO.
+    OPTIONAL {
+      ?organisationO a org:Site;
+                     organisatie:bestaatUit ?address;
+                     org:siteAddress ?contactPoint;
+                     ?siteP ?siteO.
+      ?address ?addressP ?addressO.
+      ?contactPoint ?contactPointP ?contactPointO.
+    }
+  }
+}

--- a/config/migrations/2025/20250213153859-dev-data-cleanup/20250213163923-delete-worship-organisations-from-administrative-unit-graph.sparql
+++ b/config/migrations/2025/20250213153859-dev-data-cleanup/20250213163923-delete-worship-organisations-from-administrative-unit-graph.sparql
@@ -1,0 +1,38 @@
+PREFIX organisatie: <https://data.vlaanderen.be/ns/organisatie#>
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+
+# Remove triples for worship organisations from the administrative unit
+# graph. The duplicated triples are limited to type and uuid predicates as well
+# as site data.
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?organisation ?organisationP ?organisationO.
+    ?organisationO ?siteP ?siteO.
+    ?address ?addressP ?addressO.
+    ?contactPoint ?contactPointP ?contactPointO.
+  }
+} WHERE {
+  # Limit matched organisations to worship organisations
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?organisation a org:Organization.
+  }
+  # Limit to triples for the predicates that are duplicated
+  VALUES ?organisationP {
+      rdf:type
+      mu:uuid
+      org:hasPrimarySite
+      org:hasSite
+  }
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?organisation ?organisationP ?organisationO.
+    OPTIONAL {
+      ?organisationO a org:Site;
+                     organisatie:bestaatUit ?address;
+                     org:siteAddress ?contactPoint;
+                     ?siteP ?siteO.
+      ?address ?addressP ?addressO.
+      ?contactPoint ?contactPointP ?contactPointO.
+    }
+  }
+}

--- a/config/migrations/2025/20250213153859-dev-data-cleanup/20250213165020-regenerate-full-addresses.sparql
+++ b/config/migrations/2025/20250213153859-dev-data-cleanup/20250213165020-regenerate-full-addresses.sparql
@@ -1,0 +1,74 @@
+PREFIX locn: <http://www.w3.org/ns/locn#>
+PREFIX adres: <https://data.vlaanderen.be/ns/adres#>
+PREFIX organisatie: <https://data.vlaanderen.be/ns/organisatie#>
+PREFIX org: <http://www.w3.org/ns/org#>
+
+# Delete all full address triples
+# NOTE: for some `Adress` multiple `locn:fullAddress` were linked at some
+# point. Simply removing everything and then recreating the correct ones
+# allows simpler queries.
+DELETE {
+  GRAPH ?g {
+    ?address locn:fullAddress ?fullAddress.
+  }
+} WHERE {
+  GRAPH ?g {
+    ?address a locn:Address;
+             locn:fullAddress ?fullAddress.
+  }
+  VALUES ?g {
+    <http://mu.semte.ch/graphs/administrative-unit>
+    <http://mu.semte.ch/graphs/worship-service>
+  }
+}
+;
+# Recreate full address triples in the correct graphs
+# NOTE: split the case for with and without box numbers in different
+# queries. Imo this gives easier to understand queries than adding conditional
+# logic to properly deal with whether or not there is a box number in a single
+# query.
+## Addresses without box numbers
+INSERT {
+  GRAPH ?g {
+    ?address locn:fullAddress ?newFullAddress.
+  }
+} WHERE {
+  GRAPH ?g {
+    ?address a locn:Address;
+             locn:thoroughfare ?street;
+             adres:Adresvoorstelling.huisnummer ?buildingNo;
+             locn:postCode ?postalCode;
+             adres:gemeentenaam ?municipality;
+             adres:land ?country.
+    FILTER NOT EXISTS { ?address adres:Adresvoorstelling.busnummer ?boxNo. }
+    BIND (CONCAT(?street, " ", ?buildingNo, ", ", ?postalCode, " ", ?municipality, ", ", ?country) AS ?newFullAddress)
+  }
+
+  VALUES ?g {
+    <http://mu.semte.ch/graphs/administrative-unit>
+    <http://mu.semte.ch/graphs/worship-service>
+  }
+}
+;
+## Addresses with box numbers
+INSERT {
+  GRAPH ?g {
+    ?address locn:fullAddress ?newFullAddress.
+  }
+} WHERE {
+  GRAPH ?g {
+    ?address a locn:Address;
+             locn:thoroughfare ?street;
+             adres:Adresvoorstelling.huisnummer ?buildingNo;
+             adres:Adresvoorstelling.busnummer ?boxNo;
+             locn:postCode ?postalCode;
+             adres:gemeentenaam ?municipality;
+             adres:land ?country.
+    BIND (CONCAT(?street, " ", ?buildingNo, " ", ?boxNo, ", ", ?postalCode, " ", ?municipality, ", ", ?country) AS ?newFullAddress)
+  }
+
+  VALUES ?g {
+    <http://mu.semte.ch/graphs/administrative-unit>
+    <http://mu.semte.ch/graphs/worship-service>
+  }
+}

--- a/config/migrations/2025/20250213153859-dev-data-cleanup/20250214114302-remove-site-data-from-public-graph.sparql
+++ b/config/migrations/2025/20250213153859-dev-data-cleanup/20250214114302-remove-site-data-from-public-graph.sparql
@@ -1,0 +1,36 @@
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX locn: <http://www.w3.org/ns/locn#>
+PREFIX schema: <http://schema.org/>
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?contactPoint ?p ?o.
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?contactPoint a schema:ContactPoint;
+                  ?p ?o.
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?address ?p ?o.
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?address a locn:Address;
+             ?p ?o.
+  }
+}
+;
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?site ?p ?o.
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?site a org:Site;
+          ?p ?o.
+  }
+}


### PR DESCRIPTION
:warning: Do **not** merge this PR. It is meant to simplify reviewing and testing the proposed migrations. The migrations will be executed locally only on DEV.

The data concerning organisation's sites got messed up at some point in the past. Most likely connected to a bug in the `sync-wegwijs-organization-service` which caused numerous issues with address data. (See [#8](https://github.com/lblod/sync-wegwijs-organization-service/pull/8) and the associated ticket for some background.) The migrations in this PR clean up at least some of the data.

I "clicked around" a bit in the frontend and everything seems to remain working. A second look would be appreciated.

## Remove organisation data from incorrect graphs
For several worship organisations some data was duplicated into the administrative unit graph. Same for non-worship organisations were data was duplicated in the worship graph. The affected data seems to be limited the organisation's UUID, type, and sites, along with their address and contact data. The first two migrations remove the duplicate data from the wrong graph.

I split this into two migrations, each removing from one graph, to keep the queries simpler and reduce the chance of deleting too much/the wrong data.

## Regenerate full addresses
Due to the bug mentioned above, many site addresses have multiple `locn:fullAddress` triples, often containing an unrelated or empty address string. To this end the migration first removes **all** `locn:fullAddress` triples from the worship and administrative-unit graphs. Afterwards it re-inserts new triples for all existing `locn:Address` resources in the same graphs.

The chosen approach of removing all full addresses only to re-insert most of them is a bit aggressive. But does allow to keep the queries rather straightforward compared to trying to delete only the incorrect triples etc.

## Remove site data from the public graph
A bunch of sites, along with their address and contact point data, were put into the public graph. This kind of data is not supposed to be in that graph. The last migration removes it all.