### PR TITLE
Hotfix/vgc classificatie code to public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 ## Unreleased
 
+## v1.30.1 (2025-02-20)
+### Backend
+ - Bestuursorgaanclassificatiecode of VGC was in wrong graph, so it wouldn't export. [DL-6428]
+### Deploy notes
+```
+drc restart migrations
+```
 ## v1.30.0 (2025-02-19)
 ### Frontend
 - Bump to version [v1.29.0](https://github.com/lblod/frontend-organization-portal/releases/tag/v1.29.0)

--- a/config/migrations/2025/20250220114834-vgc-classificatie-code-to-public.sparql
+++ b/config/migrations/2025/20250220114834-vgc-classificatie-code-to-public.sparql
@@ -1,0 +1,21 @@
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s ?p ?o
+  }
+}
+INSERT {
+   GRAPH <http://mu.semte.ch/graphs/public> {
+     ?s ?p ?o
+   }
+}
+WHERE {
+
+  VALUES ?s {
+    <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/7148e12a-ae03-4a7b-bb16-7b6269b84175>
+    <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/ff20fa3e-806b-4160-b74b-7483fe3a6ecd>
+  }
+
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?s ?p ?o
+  }
+}


### PR DESCRIPTION
Bestuursorgaanclassificatiecode of VGC was in wrong graph, so it wouldn't export for deltas producers. [DL-6428]