### PR TITLE
chore: move status for municipalities and provinces in shared graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 ## Unreleased
+### Frontend
+- Bump to version [TODO](Link to frontend release)
+### Backend
+- Datafix: move status for municipalities and provinces to the `shared` graph such that it can be read by worship users [OP-3469]
+### Deploy notes
+```
+drc restart migrations; drc logs -ft --tail=200 migrations
+drc pull frontend; drc up -d frontend
+```
 
 ## v1.30.0 (2025-02-19)
 ### Frontend
@@ -14,7 +23,6 @@
 - Remove several OCMW bcsd faciliteitgemeenten [OP-3535]
 - Completely remove AGB Stekene's data. [OP-3409]
 - Remove reasoner service, replaced by new consumer logic
-
 ### Deploy Notes
 - Before pulling the changes
   + Shut down the reasoner and thank it for its good service: `drc down reasoner`

--- a/config/migrations/2025/20250220171921-move-status-for-municipalities-and-provinces-to-shared-graph.sparql
+++ b/config/migrations/2025/20250220171921-move-status-for-municipalities-and-provinces-to-shared-graph.sparql
@@ -1,0 +1,28 @@
+PREFIX regorg: <http://www.w3.org/ns/regorg#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX org: <http://www.w3.org/ns/org#>
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?organisation regorg:orgStatus ?status.
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/shared> {
+    ?organisation regorg:orgStatus ?status.
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/shared> {
+    ?organisation a besluit:Bestuurseenheid;
+                  org:classification ?class.
+    FILTER (?class IN
+            (
+             <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001>, # Municipality
+             <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000000> # Province
+             )
+            )
+  }
+
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?organisation regorg:orgStatus ?status.
+  }
+}


### PR DESCRIPTION
For new frontend functionality concerning local involvements a worship user
should be able to read the status for municipalities and provinces. This
migration moves these triples to the `shared` graph such worship users have read
access.

The status for municipalities and provinces cannot be changed by users so they
do not require write access. The status of these types of organisations can only
be changed manually via migrations, for example when municipalities merge as was
done in #482. This PR makes the situation for statuses essentially the same as
was already the case for the (legal) names for municipalities and provinces.

This should not impact:
- The produced data as the producers already take the `shared` graph into
  account.
- The search indexes as this is based on the access rights.
- The consumers as OP is the master of this data.

## Related PRs
- Frontend PR for which this data move is needed: https://github.com/lblod/frontend-organization-portal/pull/670

## Related tickets
- OP-3469