### PR TITLE
fix: add governing bodies for AGBs for the new legislature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 ## Unreleased
 
+## v1.30.2 (TODO)
+### Backend
+- Datafix: add new timed governing bodies for new legislature for AGBs [DL-6418]
+### Deploy notes
+- Restart the migration service
+- Start a healing job the public producer, or wait for it to kick in overnight
+#### Deploy commands
+```
+drc restart migrations; drc logs -ft --tail=200 migrations
+drc exec delta-producer-background-jobs-initiator curl -X POST http://localhost/public/healing-jobs
+```
+
 ## v1.30.1 (2025-02-20)
 ### Backend
  - Bestuursorgaanclassificatiecode of VGC was in wrong graph, so it wouldn't export. [DL-6428]
@@ -8,6 +20,7 @@
 ```
 drc restart migrations
 ```
+
 ## v1.30.0 (2025-02-19)
 ### Frontend
 - Bump to version [v1.29.0](https://github.com/lblod/frontend-organization-portal/releases/tag/v1.29.0)

--- a/config/migrations/2025/20250225102801-agb-update-governing-bodies-new-legislature/20250225102801-insert-end-dates-agb-governing-bodies.sparql
+++ b/config/migrations/2025/20250225102801-agb-update-governing-bodies-new-legislature/20250225102801-insert-end-dates-agb-governing-bodies.sparql
@@ -1,0 +1,23 @@
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?timedBody mandaat:bindingEinde "2024-12-31"^^xsd:dateTime
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+          ?agb a besluit:Bestuurseenheid;
+           org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36a82ba0-7ff1-4697-a9dd-2e94df73b721>. # AGB
+      ?body besluit:bestuurt ?agb;
+            org:classification ?classification.
+      ?timedBody generiek:isTijdspecialisatieVan ?body.
+      FILTER NOT EXISTS {?timedBody mandaat:bindingEinde ?endDate.}
+  }
+  VALUES ?classification {
+    <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> # Algemene vergadering
+    <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> # Raad van bestuur
+  }
+}

--- a/config/migrations/2025/20250225102801-agb-update-governing-bodies-new-legislature/20250225112043-insert-timed-governing-bodies-new-legislature.sparql
+++ b/config/migrations/2025/20250225102801-agb-update-governing-bodies-new-legislature/20250225112043-insert-timed-governing-bodies-new-legislature.sparql
@@ -1,0 +1,32 @@
+PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+  ?timedGoverningBody a besluit:Bestuursorgaan;
+                      mu:uuid ?timedGoverningBodyUuid;
+                      generiek:isTijdspecialisatieVan ?governingBody;
+                      mandaat:bindingStart "2025-01-02"^^xsd:dateTime;
+                      mandaat:bindingEinde "2030-12-31"^^xsd:dateTime.
+  }
+} WHERE {
+  VALUES ?governingBodyClassification {
+    <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> # Algemene vergadering
+    <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> # Raad van bestuur
+  }
+
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?agb a besluit:Bestuurseenheid;
+         org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36a82ba0-7ff1-4697-a9dd-2e94df73b721>; # AGB
+         mu:uuid ?organizationUuid.
+    ?governingBody besluit:bestuurt ?agb;
+                   org:classification ?governingBodyClassification.
+  }
+
+  BIND(SHA256(CONCAT(STR(?governingBodyClassification), " 2025 ", STR(?governingBody),  STR(?organizationUuid))) AS ?timedGoverningBodyUuid)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/bestuursorganen/", STR(?timedGoverningBodyUuid))) AS ?timedGoverningBody)
+}


### PR DESCRIPTION
## Problem summary
The governing bodies for AGBs follow the legislative period of their corresponding municipality. For the new legislature no new corresponding time-specialised governing bodies were created. This resulted in complaints from vendors that AGBs could not link dossiers to the *correct* governing bodies.

## Proposed solution
Add new timed governing bodies for all AGBs for the current legislature and set the end date for the governing bodies for the previous legislature. More specifically this concerns the governing bodies with classifications *Raad van bestuur* and *Algemene vergadering*.

The set start and end dates were provided by business in the follow-up ticket.

## How to test
Follow the instructions added to the changelog and check that:
- all AGBs now have an inactive and active *Raad van bestuur* and *Algemene vergadering*
- the new data is also present in the producer graph, after the healing has finished.

Note, this cannot be immediately checked via the frontend as the governing bodies tab is not enabled for AGBs. Best is to check the data directly in the triplestore. Some queries that can be useful in this regard:

1. Count the number of timed *Raad van bestuur* and *Algemene vergadering* governing bodies for AGBs. After the migrations have run this should have doubled.

``` sparql
PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
PREFIX org: <http://www.w3.org/ns/org#>
PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
PREFIX skos: <http://www.w3.org/2004/02/skos/core#>

SELECT ?classLabel count(DISTINCT ?timedBody)
WHERE {
  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
    ?agb a besluit:Bestuurseenheid;
         org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36a82ba0-7ff1-4697-a9dd-2e94df73b721>. # AGB
    ?body besluit:bestuurt ?agb;
          org:classification ?class.
    ?timedBody generiek:isTijdspecialisatieVan ?body.
  }
  VALUES ?class {
    <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> # Algemene vergadering
    <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> # Raad van bestuur
  }
  ?class skos:prefLabel ?classLabel.
}

```

2. Check for timed *Raad van bestuur* and *Algemene vergadering* without an end date. Their should be 0 after running the migration:

``` sparql
PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
PREFIX org: <http://www.w3.org/ns/org#>
PREFIX generiek: <https://data.vlaanderen.be/ns/generiek#>
PREFIX mandaat: <http://data.vlaanderen.be/ns/mandaat#>

SELECT count(DISTINCT ?timedBody)
WHERE {
  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
    ?agb a besluit:Bestuurseenheid;
         org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36a82ba0-7ff1-4697-a9dd-2e94df73b721>. # AGB
    ?body besluit:bestuurt ?agb;
          org:classification ?class.
    ?timedBody generiek:isTijdspecialisatieVan ?body.
    FILTER NOT EXISTS {?timedBody mandaat:bindingEinde ?endDate.}
  }
  VALUES ?class {
    <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/b52094ff-21a2-4da8-8dbe-f513365d1528> # Algemene vergadering
    <http://data.vlaanderen.be/id/concept/BestuursorgaanClassificatieCode/013cc838-173a-4657-b1ae-b00c048df943> # Raad van bestuur
  }
}
```

To check the public producer graph with the above queries
- change the queried graph to `http://redpencil.data.gift/id/deltas/producer/public`
- query the `publication-triplestore` instead of the `triplestore`


Note, if you do want to check via the frontend you can enable the governing bodies tab for AGBs by removing [this line in the administrative unit model](https://github.com/lblod/frontend-organization-portal/blob/development/app/models/administrative-unit.js#L184).

## Related tickets
- OP-3552: the originally reported bug that should be solved with this PR
- OP-3543: follow up ticket further extend the support for AGB's governing bodies, contains additional background information