### PR TITLE
Upgrade `triplestore` and `publication-triplestore` to `v1.3.0-rc.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,15 @@
 - Bump to version [TODO](Link to frontend release)
 ### Backend
 - Datafix: move status for municipalities and provinces to the `shared` graph such that it can be read by worship users [OP-3469]
+- Bump `triplestore` and `publication-triplestore` to `v1.3.0-rc.1`. [OP-2492] [OP-3547]
 ### Deploy notes
 ```
 drc restart migrations; drc logs -ft --tail=200 migrations
 drc pull frontend; drc up -d frontend
 ```
+#### For upgrade databases
+[This README](https://github.com/Riadabd/upgrade-virtuoso) provides the necessary steps for upgrading the database. **NOTE**: This will involve shutting down the app for small period of time (around 30 minutes).
+
 
 ## v1.30.3 (2025-03-04)
 ### Frontend

--- a/config/db/virtuoso-production.ini
+++ b/config/db/virtuoso-production.ini
@@ -231,10 +231,12 @@ DefaultHost  = localhost:8890
 ;DefaultGraph           = http://localhost:8890/dataspace
 ;ImmutableGraphs        = http://localhost:8890/dataspace
 ResultSetMaxRows           = 1000000 ; 1 million
+MaxConstructTriples        = 10000 ; More info on this addition here: https://github.com/redpencilio/docker-virtuoso/pull/29
 ;MaxQueryCostEstimationTime = 4000	; in seconds
 MaxQueryExecutionTime      = 1200	; in seconds
 DefaultQuery               = select distinct ?Concept where {[] a ?Concept} LIMIT 100
 DeferInferenceRulesInit    = 0	; controls inference rules loading
+MaxMemInUse                = 0 ; limits the amount of memory for construct dict (0=unlimited). More info on this addition here: https://github.com/redpencilio/docker-virtuoso/pull/29
 ;PingService            = http://rpc.pingthesemanticweb.com/
 
 [Plugins]

--- a/config/db/virtuoso.ini
+++ b/config/db/virtuoso.ini
@@ -231,10 +231,12 @@ DefaultHost  = localhost:8890
 ;DefaultGraph           = http://localhost:8890/dataspace
 ;ImmutableGraphs        = http://localhost:8890/dataspace
 ResultSetMaxRows           = 1000000 ; 1 million
+MaxConstructTriples        = 10000 ; More info on this addition here: https://github.com/redpencilio/docker-virtuoso/pull/29
 ;MaxQueryCostEstimationTime = 4000	; in seconds
 MaxQueryExecutionTime      = 1200	; in seconds
 DefaultQuery               = select distinct ?Concept where {[] a ?Concept} LIMIT 100
 DeferInferenceRulesInit    = 0	; controls inference rules loading
+MaxMemInUse                = 0 ; limits the amount of memory for construct dict (0=unlimited). More info on this addition here: https://github.com/redpencilio/docker-virtuoso/pull/29
 ;PingService            = http://rpc.pingthesemanticweb.com/
 
 [Plugins]

--- a/config/publication-triplestore/virtuoso-production.ini
+++ b/config/publication-triplestore/virtuoso-production.ini
@@ -231,10 +231,12 @@ DefaultHost  = localhost:8890
 ;DefaultGraph           = http://localhost:8890/dataspace
 ;ImmutableGraphs        = http://localhost:8890/dataspace
 ResultSetMaxRows           = 1000000 ; 1 million
+MaxConstructTriples        = 10000 ; More info on this addition here: https://github.com/redpencilio/docker-virtuoso/pull/29
 ;MaxQueryCostEstimationTime = 4000	; in seconds
 MaxQueryExecutionTime      = 1200	; in seconds
 DefaultQuery               = select distinct ?Concept where {[] a ?Concept} LIMIT 100
 DeferInferenceRulesInit    = 0	; controls inference rules loading
+MaxMemInUse                = 0 ; limits the amount of memory for construct dict (0=unlimited). More info on this addition here: https://github.com/redpencilio/docker-virtuoso/pull/29
 ;PingService            = http://rpc.pingthesemanticweb.com/
 
 [Plugins]

--- a/config/publication-triplestore/virtuoso.ini
+++ b/config/publication-triplestore/virtuoso.ini
@@ -231,10 +231,12 @@ DefaultHost  = localhost:8890
 ;DefaultGraph           = http://localhost:8890/dataspace
 ;ImmutableGraphs        = http://localhost:8890/dataspace
 ResultSetMaxRows           = 1000000 ; 1 million
+MaxConstructTriples        = 10000 ; More info on this addition here: https://github.com/redpencilio/docker-virtuoso/pull/29
 ;MaxQueryCostEstimationTime = 4000	; in seconds
 MaxQueryExecutionTime      = 1200	; in seconds
 DefaultQuery               = select distinct ?Concept where {[] a ?Concept} LIMIT 100
 DeferInferenceRulesInit    = 0	; controls inference rules loading
+MaxMemInUse                = 0 ; limits the amount of memory for construct dict (0=unlimited). More info on this addition here: https://github.com/redpencilio/docker-virtuoso/pull/29
 ;PingService            = http://rpc.pingthesemanticweb.com/
 
 [Plugins]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     restart: always
     logging: *default-logging
   triplestore:
-    image: tenforce/virtuoso:1.3.2-virtuoso7.2.5.1
+    image: redpencil/virtuoso:1.3.0-rc.1
     environment:
       SPARQL_UPDATE: "true"
       DEFAULT_GRAPH: "http://mu.semte.ch/application"
@@ -310,7 +310,7 @@ services:
   # DELTA GENERAL
   ################################################################################
   publication-triplestore:
-    image: redpencil/virtuoso:1.2.0-rc.1
+    image: redpencil/virtuoso:1.3.0-rc.1
     environment:
       SPARQL_UPDATE: "true"
       DEFAULT_GRAPH: "http://mu.semte.ch/application"


### PR DESCRIPTION
## Ticket IDs

Fixes OP-2492 and OP-3547

## Ticket Description

This is a routine database upgrade that bumps it to the most recent stable build of `virtuoso`. This bump also fixes weird sorting behavior (you can find more info on this in the tickets listed above).

The upgrade steps are laid out [here](https://github.com/Riadabd/upgrade-virtuoso).