### PR TITLE
Add missing codes to public producer

### DIFF
--- a/config/delta-producer/public/export.json
+++ b/config/delta-producer/public/export.json
@@ -497,6 +497,58 @@
         "http://mu.semte.ch/vocabularies/core/uuid",
         "http://www.w3.org/2004/02/skos/core#prefLabel"
       ]
+    },
+    {
+      "type": "http://lblod.data.gift/vocabularies/organisatie/MandatarisStatusCode",
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/public"
+      ],
+      "pathToConceptScheme": [
+        "http://www.w3.org/2004/02/skos/core#inScheme"
+      ],
+      "properties": [
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://www.w3.org/2004/02/skos/core#prefLabel"
+      ]
+    },
+    {
+      "type": "http://lblod.data.gift/vocabularies/organisatie/BestuursfunctieCode",
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/public"
+      ],
+      "pathToConceptScheme": [
+        "http://www.w3.org/2004/02/skos/core#inScheme"
+      ],
+      "properties": [
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://www.w3.org/2004/02/skos/core#prefLabel"
+      ]
+    },
+    {
+      "type": "http://data.lblod.info/vocabularies/leidinggevenden/FunctionarisStatusCode",
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/public"
+      ],
+      "pathToConceptScheme": [
+        "http://www.w3.org/2004/02/skos/core#inScheme"
+      ],
+      "properties": [
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://www.w3.org/2004/02/skos/core#prefLabel"
+      ]
+    },
+    {
+      "type": "http://mu.semte.ch/vocabularies/ext/OrganizationClassificationCode",
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/public"
+      ],
+      "pathToConceptScheme": [
+        "http://www.w3.org/2004/02/skos/core#inScheme"
+      ],
+      "properties": [
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://www.w3.org/2004/02/skos/core#prefLabel"
+      ]
     }
   ]
 }

--- a/config/migrations/2025/20250306113500-add-concept-scheme-to-codes-for-public-producer.sparql
+++ b/config/migrations/2025/20250306113500-add-concept-scheme-to-codes-for-public-producer.sparql
@@ -1,0 +1,14 @@
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s <http://www.w3.org/2004/02/skos/core#inScheme> <http://lblod.data.gift/concept-schemes/10caf4a4-1ff5-4c05-917e-56489910d68b> .
+  }
+} WHERE {
+  VALUES ?type {
+    <http://lblod.data.gift/vocabularies/organisatie/MandatarisStatusCode>
+    <http://lblod.data.gift/vocabularies/organisatie/BestuursfunctieCode>
+    <http://data.lblod.info/vocabularies/leidinggevenden/FunctionarisStatusCode>
+    <http://mu.semte.ch/vocabularies/ext/OrganizationClassificationCode>
+  }
+
+  ?s a ?type .
+}


### PR DESCRIPTION
Some codes that should be produced by OP were missing in the public producer. We need it to complete the cleanup up the mandatarissen and leidinggevenden producers in Loket, hence the horfix.

To test it, you can start from a production copy, run a healing of the public producer
```
drc exec delta-producer-background-jobs-initiator curl -X POST http://localhost/public/healing-jobs 
```
Then checkout this branch and
```
drc restart migrations delta-producer-publication-graph-maintainer
drc exec delta-producer-background-jobs-initiator curl -X POST http://localhost/public/healing-jobs 
```

The missing codes should be produced by the healing

