### PR TITLE
Fix: update date of change event st petrus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add missing docker compose keys. [DL-6490]
 - Reorganize delta consumers config to harmonize with the ecosystem
 - Set up the dashboard app [OP-3103]
+- Datafix: correct date of change event of kerkfabriek st petrus [OP-3555]
 ### Deploy notes
 ```
 drc restart migrations; drc logs -ft --tail=200 migrations

--- a/config/migrations/2025/20250321102359-update-date-change-event-kerkfabriek-st-petrus.sparql
+++ b/config/migrations/2025/20250321102359-update-date-change-event-kerkfabriek-st-petrus.sparql
@@ -1,0 +1,15 @@
+PREFIX dct: <http://purl.org/dc/terms/>
+
+DELETE {
+  GRAPH ?g {
+    <http://data.lblod.info/id/veranderingsgebeurtenissen/67C816180F1E719C0DBB7B6C> dct:date ?oldDate .
+  }
+} INSERT {
+  GRAPH ?g {
+    <http://data.lblod.info/id/veranderingsgebeurtenissen/67C816180F1E719C0DBB7B6C> dct:date "2025-03-05"^^xsd:date .
+  }
+} WHERE {
+  GRAPH ?g {
+    <http://data.lblod.info/id/veranderingsgebeurtenissen/67C816180F1E719C0DBB7B6C> dct:date ?oldDate .
+  }
+}


### PR DESCRIPTION
## ID

OP-3555

## Description

Update date of a change event of kerkfabriek st petrus to '05-03-2025'.

## Testing

Use op prod data local to run migration, and verify if change event date updated from '06-03-2025' to '05-03'2025'