### PR TITLE
Chore/flush landing zones leidinggevenden and mandatarissen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 ## Unreleased
 
+## v1.30.6 (2025-03-25)
+### Backend
+- Flushed landingzones [DL-6552]
+### Deploy notes
+```
+drc restart migrations
+```
+
 ## v1.30.5 (2025-03-10)
 ### Backend
  - Added `http://www.w3.org/ns/prov#Location` to delta stream 'public' [DL-6496]

--- a/config/migrations/2025/20250324155635-flush-leidinggevenden-landingzone.sparql
+++ b/config/migrations/2025/20250324155635-flush-leidinggevenden-landingzone.sparql
@@ -1,0 +1,22 @@
+DELETE {
+ GRAPH <http://mu.semte.ch/graphs/landing-zone/leidinggevenden> {
+  ?s a ?type;
+    ?p ?o.
+ }
+}
+WHERE {
+ VALUES ?type {
+   <http://mu.semte.ch/vocabularies/ext/BestuurseenheidClassificatieCode>
+   <http://data.vlaanderen.be/ns/besluit#Bestuurseenheid>
+   <http://data.vlaanderen.be/ns/besluit#Bestuursorgaan>
+   <http://mu.semte.ch/vocabularies/ext/BestuursorgaanClassificatieCode>
+   <http://mu.semte.ch/vocabularies/ext/BestuursfunctieCode>
+   <http://data.lblod.info/vocabularies/leidinggevenden/FunctionarisStatusCode>
+   <http://www.w3.org/ns/prov#Location>
+ }
+
+ GRAPH <http://mu.semte.ch/graphs/landing-zone/leidinggevenden> {
+  ?s a ?type;
+    ?p ?o.
+ }
+}

--- a/config/migrations/2025/20250324155644-flush-mandatarissen-landingzone.sparql
+++ b/config/migrations/2025/20250324155644-flush-mandatarissen-landingzone.sparql
@@ -1,0 +1,23 @@
+DELETE {
+ GRAPH <http://mu.semte.ch/graphs/landing-zone/mandatarissen> {
+  ?s a ?type;
+    ?p ?o.
+ }
+}
+WHERE {
+ VALUES ?type {
+  <http://mu.semte.ch/vocabularies/ext/MandatarisStatusCode>
+  <http://data.vlaanderen.be/ns/mandaat#Mandaat>
+  <http://mu.semte.ch/vocabularies/ext/BestuursfunctieCode>
+  <http://data.vlaanderen.be/ns/besluit#Bestuursorgaan>
+  <http://mu.semte.ch/vocabularies/ext/BestuursorgaanClassificatieCode>
+  <http://data.vlaanderen.be/ns/besluit#Bestuurseenheid>
+  <http://mu.semte.ch/vocabularies/ext/BestuurseenheidClassificatieCode>
+  <http://www.w3.org/ns/prov#Location>
+ }
+
+ GRAPH <http://mu.semte.ch/graphs/landing-zone/mandatarissen> {
+  ?s a ?type;
+    ?p ?o.
+ }
+}


### PR DESCRIPTION
A migration to flush the landing zones of consumers for bits of the data. Since this data is not actively maintained anymore by the producers, this might lead to obsolete information and confusion situations at the consumer side.  Context: deploy story DL-6552