### PR TITLE
Produce NIS codes and countries in public producer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,14 @@
 - Set up the dashboard app [OP-3103]
 - Datafix: correct date of change event of kerkfabriek st petrus [OP-3555]
 - Update OCMWv to VVMW [OP-3565] and back. It's technically a nil-operation. But you should run the migrations nevertheless.
+- Extend the public producer to include NIS codes [CLBV-980]
 ### Deploy notes
 ```
 drc restart migrations-triggering-indexing
 drc restart migrations; drc logs -ft --tail=200 migrations
 drc pull frontend; drc up -d frontend
 drc up -d mandatarissen-consumer leidinggevenden-consumer worship-services-main-info-consumer worship-services-private-info-consumer
+drc restart delta-producer-publication-graph-maintainer
 ```
 #### For upgrade databases
 [This README](https://github.com/Riadabd/upgrade-virtuoso) provides the necessary steps for upgrading the database. **NOTE**: This will involve shutting down the app for small period of time (around 30 minutes).

--- a/config/delta-producer/public/export.json
+++ b/config/delta-producer/public/export.json
@@ -564,6 +564,31 @@
         "http://www.opengis.net/ont/geosparql#sfWithin",
         "http://www.w3.org/2004/02/skos/core#exactMatch"
       ]
+    },
+    {
+      "type": "http://www.w3.org/2004/02/skos/core#Concept",
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/public"
+      ],
+      "pathToConceptScheme": [
+        "http://www.w3.org/2004/02/skos/core#inScheme"
+      ],
+      "properties": [
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://www.w3.org/2004/02/skos/core#altLabel",
+        "http://www.w3.org/2004/02/skos/core#broadMatch",
+        "http://www.w3.org/2004/02/skos/core#broader",
+        "http://www.w3.org/2004/02/skos/core#exactMatch",
+        "http://www.w3.org/2004/02/skos/core#inScheme",
+        "http://www.w3.org/2004/02/skos/core#narrowMatch",
+        "http://www.w3.org/2004/02/skos/core#narrower",
+        "http://www.w3.org/2004/02/skos/core#notation",
+        "http://www.w3.org/2004/02/skos/core#prefLabel",
+        "http://www.w3.org/2004/02/skos/core#relatedMatch",
+        "http://www.w3.org/2004/02/skos/core#topConceptOf",
+        "https://schema.org/endDate",
+        "https://schema.org/startDate"
+      ]
     }
   ]
 }

--- a/config/delta-producer/public/export.json
+++ b/config/delta-producer/public/export.json
@@ -589,6 +589,16 @@
         "https://schema.org/endDate",
         "https://schema.org/startDate"
       ]
+    },
+    {
+      "type": "http://publications.europa.eu/ontology/euvoc#Country",
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/public"
+      ],
+      "properties": [
+        "http://www.w3.org/2004/02/skos/core#prefLabel",
+        "http://www.w3.org/2000/01/rdf-schema#label"
+      ]
     }
   ]
 }

--- a/config/migrations/2025/20250325131100-add-public-producer-concept-scheme-to-nis-codes.sparql
+++ b/config/migrations/2025/20250325131100-add-public-producer-concept-scheme-to-nis-codes.sparql
@@ -1,0 +1,15 @@
+INSERT  {
+   GRAPH <http://mu.semte.ch/graphs/public> {
+     ?s skos:inScheme <http://lblod.data.gift/concept-schemes/10caf4a4-1ff5-4c05-917e-56489910d68b>.
+   }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    VALUES ?nisScheme {
+      <http://vocab.belgif.be/auth/refnis2025>
+      <http://vocab.belgif.be/auth/refnis2019>
+    }
+
+    ?s a <http://www.w3.org/2004/02/skos/core#Concept> ;
+      <http://www.w3.org/2004/02/skos/core#inScheme> ?nisScheme .
+  }
+}


### PR DESCRIPTION
# Context

[CLBV-980]

We want to stop using the `organizations-public-info` gradually. For that, in `app-contactgegevens`, we need the public producer to produce the NIS codes (which are public so it fits with the description :) ). This is what this PR does.

**_Update_**: we also need the countries there, it's a codelist and OP is the master of it so it makes sense to also produce it I think.

# Test instructions

On a running stack:
```
drc restart migrations delta-producer-publication-graph-maintainer 
drc exec delta-producer-background-jobs-initiator curl -X POST http://localhost/public/healing-jobs
```
And check that the produced deltas are containing the NIS codes and the countries.