### PR TITLE
Add migration and instructions to reset kbo sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 # Changelog
+## Unreleased
+### Backend
+- Fix KBO statuses not being displayed [OP-3584]
+### Deploy Notes
+```
+drc restart migrations; drc logs -ft --tail=200 migrations
+drc up -d kbo-data-sync
+drc exec kbo-data-sync curl -X POST http://localhost/sync-all-kbo-data
+```
 ## v1.31.2 (2025-04-02)
 ### Backend
 - Extend the public producer to include: [CLBV-980]

--- a/config/migrations/2025/20250409115500-reset-kbo-organization-modified-to-resync.sparql
+++ b/config/migrations/2025/20250409115500-reset-kbo-organization-modified-to-resync.sparql
@@ -1,0 +1,14 @@
+DELETE {
+  GRAPH ?g {
+    ?s <http://purl.org/dc/terms/modified> ?modified .
+  }
+} INSERT {
+  GRAPH ?g {
+    ?s <http://purl.org/dc/terms/modified> "1000-01-01"^^xsd:date .
+  }
+} WHERE {
+  GRAPH ?g {
+    ?s a <http://mu.semte.ch/vocabularies/ext/KboOrganisatie> ;
+      <http://purl.org/dc/terms/modified> ?modified .
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -312,7 +312,7 @@ services:
     restart: always
     logging: *default-logging
   kbo-data-sync:
-    image: lblod/sync-wegwijs-organization-service:2.0.2 # TODO bump when https://github.com/lblod/sync-wegwijs-organization-service/pull/9 is released
+    image: lblod/sync-wegwijs-organization-service:2.0.3
     links:
       - db:database
     labels:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -312,7 +312,7 @@ services:
     restart: always
     logging: *default-logging
   kbo-data-sync:
-    image: lblod/sync-wegwijs-organization-service:2.0.2
+    image: lblod/sync-wegwijs-organization-service:2.0.2 # TODO bump when https://github.com/lblod/sync-wegwijs-organization-service/pull/9 is released
     links:
       - db:database
     labels:


### PR DESCRIPTION
# Context

[OP-3584]

To be tested with https://github.com/lblod/sync-wegwijs-organization-service/pull/9

Follow the changelog for testing instructions! The idea is to set the "modified" date of the KBO organizations extremely far in the past so that they will be updated again with the proper data types. Once the healing ran, you should be able to see statuses again in the frontend.