### PR TITLE
fix: update NIS2019 end dates and link werkingsgebieden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,14 @@
 ## Unreleased
 ### Backend
 - Fix KBO statuses not being displayed [OP-3584]
+- datafix: update NIS2019 end dates and link additional NIS2025 to werkingsgebieden [part of OP-3566]
 ### Deploy Notes
 ```
 drc restart migrations; drc logs -ft --tail=200 migrations
 drc up -d kbo-data-sync
 drc exec kbo-data-sync curl -X POST http://localhost/sync-all-kbo-data
 ```
+
 ## v1.31.2 (2025-04-02)
 ### Backend
 - Extend the public producer to include: [CLBV-980]

--- a/config/migrations/2025/20250416181230-fix--refnis-2025/20250416181230-refnis2019-after-2025-municipality-mergers.graph
+++ b/config/migrations/2025/20250416181230-fix--refnis-2025/20250416181230-refnis2019-after-2025-municipality-mergers.graph
@@ -1,0 +1,1 @@
+http://mu.semte.ch/graphs/refnis2019-data-temp

--- a/config/migrations/2025/20250416181230-fix--refnis-2025/20250416181230-refnis2019-after-2025-municipality-mergers.ttl
+++ b/config/migrations/2025/20250416181230-fix--refnis-2025/20250416181230-refnis2019-after-2025-municipality-mergers.ttl
@@ -1,0 +1,6847 @@
+@prefix schema: <http://schema.org/> .
+@prefix void: <http://rdfs.org/ns/void#> .
+@prefix eli: <http://data.europa.eu/eli/ontology#> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix hydra: <http://www.w3.org/ns/hydra/core#> .
+@prefix cv: <http://data.europa.eu/m8g/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix schemas: <https://schema.org/> .
+@prefix rov: <http://www.w3.org/ns/regorg#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix locn: <http://www.w3.org/ns/locn#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix cpsv: <http://purl.org/vocab/cpsv#> .
+
+<http://vocab.belgif.be/auth/refnis2019> a skos:ConceptScheme;
+  dcterms:title "REFNIS-2019"@nl, "REFNIS-2019"@fr, "REFNIS-2019"@de, "REFNIS-2019"@en;
+  dcterms:description "REFNIS (vanaf 2019): de administratieve indeling gebeurt aan de hand van vier territoriale eenheden: gewesten, provincies, bestuurlijke arrondissementen en gemeenten."@nl,
+    "REFNIS (à partir de 2019): la division administrative repose sur quatre unités territoriales : les régions, les provinces, les arrondissements administratifs et les communes."@fr,
+    "REFNIS (ab 2019)"@de, "REFNIS (starting in 2019)"@en;
+  dcterms:creator <https://org.belgif.be/id/CbeRegisteredEntity/0314595348/statbel>;
+  dcterms:rightsHolder <https://org.belgif.be/id/CbeRegisteredEntity/0314595348/statbel>;
+  owl:versionInfo "Draft version 2024-12-01";
+  dcterms:license <http://statbel.fgov.be/en/statistics/opendata/licence/>;
+  dcterms:modified "2024-12-11T18:13:00"^^xsd:dateTime;
+  dcterms:source <https://economie.fgov.be/en/themes/enterprises/crossroads-bank-enterprises/services-administrations/tables-codes>,
+    <https://statbel.fgov.be/fr/propos-de-statbel/methodologie/classifications/geographie>;
+  skos:hasTopConcept <http://vocab.belgif.be/auth/refnis2019/1000> .
+
+<https://org.belgif.be/id/CbeRegisteredEntity/0314595348/statbel> rov:legalName "Statbel"@nl,
+    "Statbel"@fr, "Statbel"@de, "Statbel"@en .
+
+<http://statbel.fgov.be/en/statistics/opendata/licence/> dcterms:title "Statbel open data licentie"@nl,
+    "Statbel licence open data"@fr, "Statbel open data license"@en, "Statbel open data lizenz"@de .
+
+<http://vocab.belgif.be/auth/refnis2019/1000> a skos:Concept;
+  skos:topConceptOf <http://vocab.belgif.be/auth/refnis2019>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "1000";
+  skos:prefLabel "Belgien"@de, "Belgique"@fr, "België"@nl;
+  skos:exactMatch <https://sws.geonames.org/2802361/>, <http://vocab.belgif.be/auth/territory/150>,
+    <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE>, <http://vocab.belgif.be/auth/refnis1995/1000>,
+    <http://vocab.belgif.be/auth/refnis2025/1000>;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/2000>, <http://vocab.belgif.be/auth/refnis2019/3000>,
+    <http://vocab.belgif.be/auth/refnis2019/4000> .
+
+<http://vocab.belgif.be/auth/refnis2019/2000> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/1000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "2000";
+  skos:prefLabel "Flämische Region"@de, "Région flamande"@fr, "Vlaams Gewest"@nl;
+  skos:exactMatch <https://sws.geonames.org/3337388/>, <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE2>,
+    <http://vocab.belgif.be/auth/refnis1995/2000>, <http://vocab.belgif.be/auth/refnis2025/2000>;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/10000>, <http://vocab.belgif.be/auth/refnis2019/20001>,
+    <http://vocab.belgif.be/auth/refnis2019/30000>, <http://vocab.belgif.be/auth/refnis2019/40000>,
+    <http://vocab.belgif.be/auth/refnis2019/70000> .
+
+<http://vocab.belgif.be/auth/refnis2019/3000> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/1000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "3000";
+  skos:prefLabel "Wallonische Region"@de, "Région wallonne"@fr, "Waals Gewest"@nl;
+  skos:exactMatch <https://sws.geonames.org/3337387/>, <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE3>,
+    <http://vocab.belgif.be/auth/refnis1995/3000>, <http://vocab.belgif.be/auth/refnis2025/3000>;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/20002>, <http://vocab.belgif.be/auth/refnis2019/50000>,
+    <http://vocab.belgif.be/auth/refnis2019/60000>, <http://vocab.belgif.be/auth/refnis2019/80000>,
+    <http://vocab.belgif.be/auth/refnis2019/90000> .
+
+<http://vocab.belgif.be/auth/refnis2019/4000> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/1000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "4000";
+  skos:prefLabel "Region Brüssel-Hauptstadt"@de, "Région de Bruxelles-Capitale"@fr,
+    "Brussels Hoofdstedelijk Gewest"@nl;
+  skos:exactMatch <https://sws.geonames.org/2800867/>, <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE1>,
+    <http://vocab.belgif.be/auth/refnis1995/4000>, <http://vocab.belgif.be/auth/refnis2025/4000>;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/21000> .
+
+<http://vocab.belgif.be/auth/refnis2019/10000> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/2000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "10000";
+  skos:prefLabel "Provinz Antwerpen"@de, "Province d’Anvers"@fr, "Provincie Antwerpen"@nl;
+  skos:exactMatch <https://sws.geonames.org/2803136/>, <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE21>,
+    <http://vocab.belgif.be/auth/refnis1995/10000>;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "2025-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/11000>, <http://vocab.belgif.be/auth/refnis2019/12000>,
+    <http://vocab.belgif.be/auth/refnis2019/13000>;
+  skos:narrowMatch <http://vocab.belgif.be/auth/refnis2025/10000> .
+
+<http://vocab.belgif.be/auth/refnis2019/20001> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/2000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "20001";
+  skos:prefLabel "Provinz Flämisch-Brabant"@de, "Province du Brabant flamand"@fr, "Provincie Vlaams-Brabant"@nl;
+  skos:exactMatch <https://sws.geonames.org/3333250/>, <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE24>,
+    <http://vocab.belgif.be/auth/refnis2025/20001>;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:broadMatch <http://vocab.belgif.be/auth/refnis1995/20000>;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/23000>, <http://vocab.belgif.be/auth/refnis2019/24000> .
+
+<http://vocab.belgif.be/auth/refnis2019/20002> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/3000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "20002";
+  skos:prefLabel "Provinz Wallonisch-Brabant"@de, "Province du Brabant wallon"@fr, "Provincie Waals-Brabant"@nl;
+  skos:exactMatch <https://sws.geonames.org/3333251/>, <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE31>,
+    <http://vocab.belgif.be/auth/refnis2025/20002>;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:broadMatch <http://vocab.belgif.be/auth/refnis1995/20000>;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/25000> .
+
+<http://vocab.belgif.be/auth/refnis2019/30000> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/2000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "30000";
+  skos:prefLabel "Provinz Westflandern"@de, "Province de Flandre occidentale"@fr, "Provincie West-Vlaanderen"@nl;
+  skos:exactMatch <https://sws.geonames.org/2783770/>, <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE25>,
+    <http://vocab.belgif.be/auth/refnis1995/30000>, <http://vocab.belgif.be/auth/refnis2025/30000>;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/31000>, <http://vocab.belgif.be/auth/refnis2019/32000>,
+    <http://vocab.belgif.be/auth/refnis2019/33000>, <http://vocab.belgif.be/auth/refnis2019/34000>,
+    <http://vocab.belgif.be/auth/refnis2019/35000>, <http://vocab.belgif.be/auth/refnis2019/36000>,
+    <http://vocab.belgif.be/auth/refnis2019/37000>, <http://vocab.belgif.be/auth/refnis2019/38000> .
+
+<http://vocab.belgif.be/auth/refnis2019/40000> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/2000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "40000";
+  skos:prefLabel "Provinz Ostflandern"@de, "Province de Flandre orientale"@fr, "Provincie Oost-Vlaanderen"@nl;
+  skos:exactMatch <https://sws.geonames.org/2789733/>, <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE23>,
+    <http://vocab.belgif.be/auth/refnis1995/40000>;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "2025-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/41000>, <http://vocab.belgif.be/auth/refnis2019/42000>,
+    <http://vocab.belgif.be/auth/refnis2019/43000>, <http://vocab.belgif.be/auth/refnis2019/44000>,
+    <http://vocab.belgif.be/auth/refnis2019/45000>, <http://vocab.belgif.be/auth/refnis2019/46000>;
+  skos:broadMatch <http://vocab.belgif.be/auth/refnis2025/40000> .
+
+<http://vocab.belgif.be/auth/refnis2019/50000> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/3000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "50000";
+  skos:prefLabel "Provinz Hennegau"@de, "Province du Hainaut"@fr, "Provincie Henegouwen"@nl;
+  skos:exactMatch <https://sws.geonames.org/2796741/>, <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE32>,
+    <http://vocab.belgif.be/auth/refnis1995/50000>, <http://vocab.belgif.be/auth/refnis2025/50000>;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/51000>, <http://vocab.belgif.be/auth/refnis2019/52000>,
+    <http://vocab.belgif.be/auth/refnis2019/53000>, <http://vocab.belgif.be/auth/refnis2019/55000>,
+    <http://vocab.belgif.be/auth/refnis2019/56000>, <http://vocab.belgif.be/auth/refnis2019/57000>,
+    <http://vocab.belgif.be/auth/refnis2019/58000> .
+
+<http://vocab.belgif.be/auth/refnis2019/60000> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/3000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "60000";
+  skos:prefLabel "Provinz Lüttich"@de, "Province de Liège"@fr, "Provincie Luik"@nl;
+  skos:exactMatch <https://sws.geonames.org/2792411/>, <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE33>,
+    <http://vocab.belgif.be/auth/refnis1995/60000>, <http://vocab.belgif.be/auth/refnis2025/60000>;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/61000>, <http://vocab.belgif.be/auth/refnis2019/62000>,
+    <http://vocab.belgif.be/auth/refnis2019/63000>, <http://vocab.belgif.be/auth/refnis2019/64000> .
+
+<http://vocab.belgif.be/auth/refnis2019/70000> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/2000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "70000";
+  skos:prefLabel "Provinz Limburg"@de, "Province du Limbourg"@fr, "Provincie Limburg"@nl;
+  skos:exactMatch <https://sws.geonames.org/2792347/>, <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE22>,
+    <http://vocab.belgif.be/auth/refnis1995/70000>, <http://vocab.belgif.be/auth/refnis2025/70000>;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/71000>, <http://vocab.belgif.be/auth/refnis2019/72000>,
+    <http://vocab.belgif.be/auth/refnis2019/73000> .
+
+<http://vocab.belgif.be/auth/refnis2019/80000> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/3000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "80000";
+  skos:prefLabel "Provinz Luxemburg"@de, "Province du Luxembourg"@fr, "Provincie Luxemburg"@nl;
+  skos:exactMatch <https://sws.geonames.org/2791993/>, <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE34>,
+    <http://vocab.belgif.be/auth/refnis1995/80000>, <http://vocab.belgif.be/auth/refnis2025/80000>;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/81000>, <http://vocab.belgif.be/auth/refnis2019/82000>,
+    <http://vocab.belgif.be/auth/refnis2019/83000>, <http://vocab.belgif.be/auth/refnis2019/84000>,
+    <http://vocab.belgif.be/auth/refnis2019/85000> .
+
+<http://vocab.belgif.be/auth/refnis2019/90000> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/3000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "90000";
+  skos:prefLabel "Provinz Namur"@de, "Province de Namur"@fr, "Provincie Namen"@nl;
+  skos:exactMatch <https://sws.geonames.org/2790469/>, <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE35>,
+    <http://vocab.belgif.be/auth/refnis1995/90000>, <http://vocab.belgif.be/auth/refnis2025/90000>;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/91000>, <http://vocab.belgif.be/auth/refnis2019/92000>,
+    <http://vocab.belgif.be/auth/refnis2019/93000> .
+
+<http://vocab.belgif.be/auth/refnis2019/11000> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/10000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "11000";
+  skos:prefLabel "Bezirk Antwerpen"@de, "Arrondissement d’Anvers"@fr, "Arrondissement Antwerpen"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "2025-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE211>, <http://vocab.belgif.be/auth/refnis1995/11000>;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/11001>, <http://vocab.belgif.be/auth/refnis2019/11002>,
+    <http://vocab.belgif.be/auth/refnis2019/11004>, <http://vocab.belgif.be/auth/refnis2019/11005>,
+    <http://vocab.belgif.be/auth/refnis2019/11007>, <http://vocab.belgif.be/auth/refnis2019/11008>,
+    <http://vocab.belgif.be/auth/refnis2019/11009>, <http://vocab.belgif.be/auth/refnis2019/11013>,
+    <http://vocab.belgif.be/auth/refnis2019/11016>, <http://vocab.belgif.be/auth/refnis2019/11018>,
+    <http://vocab.belgif.be/auth/refnis2019/11021>, <http://vocab.belgif.be/auth/refnis2019/11022>,
+    <http://vocab.belgif.be/auth/refnis2019/11023>, <http://vocab.belgif.be/auth/refnis2019/11024>,
+    <http://vocab.belgif.be/auth/refnis2019/11025>, <http://vocab.belgif.be/auth/refnis2019/11029>,
+    <http://vocab.belgif.be/auth/refnis2019/11030>, <http://vocab.belgif.be/auth/refnis2019/11035>,
+    <http://vocab.belgif.be/auth/refnis2019/11037>, <http://vocab.belgif.be/auth/refnis2019/11038>,
+    <http://vocab.belgif.be/auth/refnis2019/11039>, <http://vocab.belgif.be/auth/refnis2019/11040>,
+    <http://vocab.belgif.be/auth/refnis2019/11044>, <http://vocab.belgif.be/auth/refnis2019/11050>,
+    <http://vocab.belgif.be/auth/refnis2019/11052>, <http://vocab.belgif.be/auth/refnis2019/11053>,
+    <http://vocab.belgif.be/auth/refnis2019/11054>, <http://vocab.belgif.be/auth/refnis2019/11055>,
+    <http://vocab.belgif.be/auth/refnis2019/11056>, <http://vocab.belgif.be/auth/refnis2019/11057>;
+  skos:narrowMatch <http://vocab.belgif.be/auth/refnis2025/11000> .
+
+<http://vocab.belgif.be/auth/refnis2019/12000> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/10000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "12000";
+  skos:prefLabel "Bezirk Mechelen"@de, "Arrondissement de Malines"@fr, "Arrondissement Mechelen"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE212>, <http://vocab.belgif.be/auth/refnis1995/12000>,
+    <http://vocab.belgif.be/auth/refnis2025/12000>;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/12002>, <http://vocab.belgif.be/auth/refnis2019/12005>,
+    <http://vocab.belgif.be/auth/refnis2019/12007>, <http://vocab.belgif.be/auth/refnis2019/12009>,
+    <http://vocab.belgif.be/auth/refnis2019/12014>, <http://vocab.belgif.be/auth/refnis2019/12021>,
+    <http://vocab.belgif.be/auth/refnis2019/12025>, <http://vocab.belgif.be/auth/refnis2019/12026>,
+    <http://vocab.belgif.be/auth/refnis2019/12029>, <http://vocab.belgif.be/auth/refnis2019/12041>,
+    <http://vocab.belgif.be/auth/refnis2019/12034>, <http://vocab.belgif.be/auth/refnis2019/12035>,
+    <http://vocab.belgif.be/auth/refnis2019/12040> .
+
+<http://vocab.belgif.be/auth/refnis2019/13000> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/10000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "13000";
+  skos:prefLabel "Bezirk Turnhout"@de, "Arrondissement de Turnhout"@fr, "Arrondissement Turnhout"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE213>, <http://vocab.belgif.be/auth/refnis1995/13000>,
+    <http://vocab.belgif.be/auth/refnis2025/13000>;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/13001>, <http://vocab.belgif.be/auth/refnis2019/13002>,
+    <http://vocab.belgif.be/auth/refnis2019/13003>, <http://vocab.belgif.be/auth/refnis2019/13004>,
+    <http://vocab.belgif.be/auth/refnis2019/13006>, <http://vocab.belgif.be/auth/refnis2019/13008>,
+    <http://vocab.belgif.be/auth/refnis2019/13010>, <http://vocab.belgif.be/auth/refnis2019/13011>,
+    <http://vocab.belgif.be/auth/refnis2019/13012>, <http://vocab.belgif.be/auth/refnis2019/13013>,
+    <http://vocab.belgif.be/auth/refnis2019/13014>, <http://vocab.belgif.be/auth/refnis2019/13016>,
+    <http://vocab.belgif.be/auth/refnis2019/13017>, <http://vocab.belgif.be/auth/refnis2019/13019>,
+    <http://vocab.belgif.be/auth/refnis2019/13021>, <http://vocab.belgif.be/auth/refnis2019/13023>,
+    <http://vocab.belgif.be/auth/refnis2019/13025>, <http://vocab.belgif.be/auth/refnis2019/13029>,
+    <http://vocab.belgif.be/auth/refnis2019/13031>, <http://vocab.belgif.be/auth/refnis2019/13035>,
+    <http://vocab.belgif.be/auth/refnis2019/13036>, <http://vocab.belgif.be/auth/refnis2019/13037>,
+    <http://vocab.belgif.be/auth/refnis2019/13040>, <http://vocab.belgif.be/auth/refnis2019/13044>,
+    <http://vocab.belgif.be/auth/refnis2019/13046>, <http://vocab.belgif.be/auth/refnis2019/13049>,
+    <http://vocab.belgif.be/auth/refnis2019/13053> .
+
+<http://vocab.belgif.be/auth/refnis2019/21000> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/4000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "21000";
+  skos:prefLabel "Bezirk Brüssel-Hauptstadt"@de, "Arrondissement de Bruxelles-Capitale"@fr,
+    "Arrondissement Brussel-Hoofdstad"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE100>, <http://vocab.belgif.be/auth/refnis1995/21000>,
+    <http://vocab.belgif.be/auth/refnis2025/21000>;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/21001>, <http://vocab.belgif.be/auth/refnis2019/21002>,
+    <http://vocab.belgif.be/auth/refnis2019/21003>, <http://vocab.belgif.be/auth/refnis2019/21004>,
+    <http://vocab.belgif.be/auth/refnis2019/21005>, <http://vocab.belgif.be/auth/refnis2019/21006>,
+    <http://vocab.belgif.be/auth/refnis2019/21007>, <http://vocab.belgif.be/auth/refnis2019/21008>,
+    <http://vocab.belgif.be/auth/refnis2019/21009>, <http://vocab.belgif.be/auth/refnis2019/21010>,
+    <http://vocab.belgif.be/auth/refnis2019/21011>, <http://vocab.belgif.be/auth/refnis2019/21012>,
+    <http://vocab.belgif.be/auth/refnis2019/21013>, <http://vocab.belgif.be/auth/refnis2019/21014>,
+    <http://vocab.belgif.be/auth/refnis2019/21015>, <http://vocab.belgif.be/auth/refnis2019/21016>,
+    <http://vocab.belgif.be/auth/refnis2019/21017>, <http://vocab.belgif.be/auth/refnis2019/21018>,
+    <http://vocab.belgif.be/auth/refnis2019/21019> .
+
+<http://vocab.belgif.be/auth/refnis2019/23000> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/20001>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "23000";
+  skos:prefLabel "Bezirk Halle-Vilvoorde"@de, "Arrondissement de Hal-Vilvorde"@fr, "Arrondissement Halle-Vilvoorde"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE241>, <http://vocab.belgif.be/auth/refnis1995/23000>,
+    <http://vocab.belgif.be/auth/refnis2025/23000>;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/23002>, <http://vocab.belgif.be/auth/refnis2019/23003>,
+    <http://vocab.belgif.be/auth/refnis2019/23009>, <http://vocab.belgif.be/auth/refnis2019/23016>,
+    <http://vocab.belgif.be/auth/refnis2019/23023>, <http://vocab.belgif.be/auth/refnis2019/23024>,
+    <http://vocab.belgif.be/auth/refnis2019/23025>, <http://vocab.belgif.be/auth/refnis2019/23027>,
+    <http://vocab.belgif.be/auth/refnis2019/23032>, <http://vocab.belgif.be/auth/refnis2019/23033>,
+    <http://vocab.belgif.be/auth/refnis2019/23038>, <http://vocab.belgif.be/auth/refnis2019/23039>,
+    <http://vocab.belgif.be/auth/refnis2019/23044>, <http://vocab.belgif.be/auth/refnis2019/23045>,
+    <http://vocab.belgif.be/auth/refnis2019/23047>, <http://vocab.belgif.be/auth/refnis2019/23050>,
+    <http://vocab.belgif.be/auth/refnis2019/23052>, <http://vocab.belgif.be/auth/refnis2019/23060>,
+    <http://vocab.belgif.be/auth/refnis2019/23062>, <http://vocab.belgif.be/auth/refnis2019/23064>,
+    <http://vocab.belgif.be/auth/refnis2019/23077>, <http://vocab.belgif.be/auth/refnis2019/23081>,
+    <http://vocab.belgif.be/auth/refnis2019/23086>, <http://vocab.belgif.be/auth/refnis2019/23088>,
+    <http://vocab.belgif.be/auth/refnis2019/23094>, <http://vocab.belgif.be/auth/refnis2019/23096>,
+    <http://vocab.belgif.be/auth/refnis2019/23097>, <http://vocab.belgif.be/auth/refnis2019/23098>,
+    <http://vocab.belgif.be/auth/refnis2019/23099>, <http://vocab.belgif.be/auth/refnis2019/23100>,
+    <http://vocab.belgif.be/auth/refnis2019/23101>, <http://vocab.belgif.be/auth/refnis2019/23102>,
+    <http://vocab.belgif.be/auth/refnis2019/23103>, <http://vocab.belgif.be/auth/refnis2019/23104>,
+    <http://vocab.belgif.be/auth/refnis2019/23105> .
+
+<http://vocab.belgif.be/auth/refnis2019/24000> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/20001>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "24000";
+  skos:prefLabel "Bezirk Löwen"@de, "Arrondissement de Louvain"@fr, "Arrondissement Leuven"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE242>, <http://vocab.belgif.be/auth/refnis1995/24000>,
+    <http://vocab.belgif.be/auth/refnis2025/24000>;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/24001>, <http://vocab.belgif.be/auth/refnis2019/24007>,
+    <http://vocab.belgif.be/auth/refnis2019/24008>, <http://vocab.belgif.be/auth/refnis2019/24009>,
+    <http://vocab.belgif.be/auth/refnis2019/24011>, <http://vocab.belgif.be/auth/refnis2019/24014>,
+    <http://vocab.belgif.be/auth/refnis2019/24016>, <http://vocab.belgif.be/auth/refnis2019/24020>,
+    <http://vocab.belgif.be/auth/refnis2019/24028>, <http://vocab.belgif.be/auth/refnis2019/24033>,
+    <http://vocab.belgif.be/auth/refnis2019/24038>, <http://vocab.belgif.be/auth/refnis2019/24041>,
+    <http://vocab.belgif.be/auth/refnis2019/24043>, <http://vocab.belgif.be/auth/refnis2019/24045>,
+    <http://vocab.belgif.be/auth/refnis2019/24048>, <http://vocab.belgif.be/auth/refnis2019/24054>,
+    <http://vocab.belgif.be/auth/refnis2019/24055>, <http://vocab.belgif.be/auth/refnis2019/24059>,
+    <http://vocab.belgif.be/auth/refnis2019/24062>, <http://vocab.belgif.be/auth/refnis2019/24066>,
+    <http://vocab.belgif.be/auth/refnis2019/24086>, <http://vocab.belgif.be/auth/refnis2019/24094>,
+    <http://vocab.belgif.be/auth/refnis2019/24104>, <http://vocab.belgif.be/auth/refnis2019/24107>,
+    <http://vocab.belgif.be/auth/refnis2019/24109>, <http://vocab.belgif.be/auth/refnis2019/24130>,
+    <http://vocab.belgif.be/auth/refnis2019/24133>, <http://vocab.belgif.be/auth/refnis2019/24134>,
+    <http://vocab.belgif.be/auth/refnis2019/24135>, <http://vocab.belgif.be/auth/refnis2019/24137> .
+
+<http://vocab.belgif.be/auth/refnis2019/25000> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/20002>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "25000";
+  skos:prefLabel "Bezirk Nivelles"@de, "Arrondissement de Nivelles"@fr, "Arrondissement Nijvel"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE310>, <http://vocab.belgif.be/auth/refnis1995/25000>,
+    <http://vocab.belgif.be/auth/refnis2025/25000>;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/25005>, <http://vocab.belgif.be/auth/refnis2019/25014>,
+    <http://vocab.belgif.be/auth/refnis2019/25015>, <http://vocab.belgif.be/auth/refnis2019/25018>,
+    <http://vocab.belgif.be/auth/refnis2019/25023>, <http://vocab.belgif.be/auth/refnis2019/25031>,
+    <http://vocab.belgif.be/auth/refnis2019/25037>, <http://vocab.belgif.be/auth/refnis2019/25043>,
+    <http://vocab.belgif.be/auth/refnis2019/25044>, <http://vocab.belgif.be/auth/refnis2019/25048>,
+    <http://vocab.belgif.be/auth/refnis2019/25050>, <http://vocab.belgif.be/auth/refnis2019/25068>,
+    <http://vocab.belgif.be/auth/refnis2019/25072>, <http://vocab.belgif.be/auth/refnis2019/25084>,
+    <http://vocab.belgif.be/auth/refnis2019/25091>, <http://vocab.belgif.be/auth/refnis2019/25105>,
+    <http://vocab.belgif.be/auth/refnis2019/25107>, <http://vocab.belgif.be/auth/refnis2019/25110>,
+    <http://vocab.belgif.be/auth/refnis2019/25112>, <http://vocab.belgif.be/auth/refnis2019/25117>,
+    <http://vocab.belgif.be/auth/refnis2019/25118>, <http://vocab.belgif.be/auth/refnis2019/25119>,
+    <http://vocab.belgif.be/auth/refnis2019/25120>, <http://vocab.belgif.be/auth/refnis2019/25121>,
+    <http://vocab.belgif.be/auth/refnis2019/25122>, <http://vocab.belgif.be/auth/refnis2019/25123>,
+    <http://vocab.belgif.be/auth/refnis2019/25124> .
+
+<http://vocab.belgif.be/auth/refnis2019/31000> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/30000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "31000";
+  skos:prefLabel "Bezirk Brügge"@de, "Arrondissement de Bruges"@fr, "Arrondissement Brugge"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE251>, <http://vocab.belgif.be/auth/refnis1995/31000>,
+    <http://vocab.belgif.be/auth/refnis2025/31000>;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/31003>, <http://vocab.belgif.be/auth/refnis2019/31004>,
+    <http://vocab.belgif.be/auth/refnis2019/31005>, <http://vocab.belgif.be/auth/refnis2019/31006>,
+    <http://vocab.belgif.be/auth/refnis2019/31012>, <http://vocab.belgif.be/auth/refnis2019/31022>,
+    <http://vocab.belgif.be/auth/refnis2019/31033>, <http://vocab.belgif.be/auth/refnis2019/31040>,
+    <http://vocab.belgif.be/auth/refnis2019/31042>, <http://vocab.belgif.be/auth/refnis2019/31043> .
+
+<http://vocab.belgif.be/auth/refnis2019/32000> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/30000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "32000";
+  skos:prefLabel "Bezirk Diksmuide"@de, "Arrondissement de Dixmude"@fr, "Arrondissement Diksmuide"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE252>, <http://vocab.belgif.be/auth/refnis1995/32000>,
+    <http://vocab.belgif.be/auth/refnis2025/32000>;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/32003>, <http://vocab.belgif.be/auth/refnis2019/32006>,
+    <http://vocab.belgif.be/auth/refnis2019/32010>, <http://vocab.belgif.be/auth/refnis2019/32011>,
+    <http://vocab.belgif.be/auth/refnis2019/32030> .
+
+<http://vocab.belgif.be/auth/refnis2019/33000> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/30000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "33000";
+  skos:prefLabel "Bezirk Ypern"@de, "Arrondissement d’Ypres"@fr, "Arrondissement Ieper"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE253>, <http://vocab.belgif.be/auth/refnis1995/33000>,
+    <http://vocab.belgif.be/auth/refnis2025/33000>;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/33011>, <http://vocab.belgif.be/auth/refnis2019/33016>,
+    <http://vocab.belgif.be/auth/refnis2019/33021>, <http://vocab.belgif.be/auth/refnis2019/33029>,
+    <http://vocab.belgif.be/auth/refnis2019/33037>, <http://vocab.belgif.be/auth/refnis2019/33039>,
+    <http://vocab.belgif.be/auth/refnis2019/33040>, <http://vocab.belgif.be/auth/refnis2019/33041> .
+
+<http://vocab.belgif.be/auth/refnis2019/34000> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/30000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "34000";
+  skos:prefLabel "Bezirk Kortrijk"@de, "Arrondissement de Courtrai"@fr, "Arrondissement Kortrijk"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE254>, <http://vocab.belgif.be/auth/refnis1995/34000>,
+    <http://vocab.belgif.be/auth/refnis2025/34000>;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/34002>, <http://vocab.belgif.be/auth/refnis2019/34003>,
+    <http://vocab.belgif.be/auth/refnis2019/34009>, <http://vocab.belgif.be/auth/refnis2019/34013>,
+    <http://vocab.belgif.be/auth/refnis2019/34022>, <http://vocab.belgif.be/auth/refnis2019/34023>,
+    <http://vocab.belgif.be/auth/refnis2019/34025>, <http://vocab.belgif.be/auth/refnis2019/34027>,
+    <http://vocab.belgif.be/auth/refnis2019/34040>, <http://vocab.belgif.be/auth/refnis2019/34041>,
+    <http://vocab.belgif.be/auth/refnis2019/34042>, <http://vocab.belgif.be/auth/refnis2019/34043> .
+
+<http://vocab.belgif.be/auth/refnis2019/35000> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/30000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "35000";
+  skos:prefLabel "Bezirk Ostende"@de, "Arrondissement d’Ostende"@fr, "Arrondissement Oostende"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE255>, <http://vocab.belgif.be/auth/refnis1995/35000>,
+    <http://vocab.belgif.be/auth/refnis2025/35000>;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/35002>, <http://vocab.belgif.be/auth/refnis2019/35005>,
+    <http://vocab.belgif.be/auth/refnis2019/35006>, <http://vocab.belgif.be/auth/refnis2019/35011>,
+    <http://vocab.belgif.be/auth/refnis2019/35013>, <http://vocab.belgif.be/auth/refnis2019/35014>,
+    <http://vocab.belgif.be/auth/refnis2019/35029> .
+
+<http://vocab.belgif.be/auth/refnis2019/36000> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/30000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "36000";
+  skos:prefLabel "Bezirk Roeselare"@de, "Arrondissement de Roulers"@fr, "Arrondissement Roeselare"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE256>, <http://vocab.belgif.be/auth/refnis1995/36000>,
+    <http://vocab.belgif.be/auth/refnis2025/36000>;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/36006>, <http://vocab.belgif.be/auth/refnis2019/36007>,
+    <http://vocab.belgif.be/auth/refnis2019/36008>, <http://vocab.belgif.be/auth/refnis2019/36010>,
+    <http://vocab.belgif.be/auth/refnis2019/36011>, <http://vocab.belgif.be/auth/refnis2019/36012>,
+    <http://vocab.belgif.be/auth/refnis2019/36015>, <http://vocab.belgif.be/auth/refnis2019/36019> .
+
+<http://vocab.belgif.be/auth/refnis2019/37000> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/30000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "37000";
+  skos:prefLabel "Bezirk Tielt"@de, "Arrondissement de Tielt"@fr, "Arrondissement Tielt"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE257>, <http://vocab.belgif.be/auth/refnis1995/37000>,
+    <http://vocab.belgif.be/auth/refnis2025/37000>;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/37002>, <http://vocab.belgif.be/auth/refnis2019/37007>,
+    <http://vocab.belgif.be/auth/refnis2019/37010>, <http://vocab.belgif.be/auth/refnis2019/37011>,
+    <http://vocab.belgif.be/auth/refnis2019/37012>, <http://vocab.belgif.be/auth/refnis2019/37015>,
+    <http://vocab.belgif.be/auth/refnis2019/37017>, <http://vocab.belgif.be/auth/refnis2019/37018>,
+    <http://vocab.belgif.be/auth/refnis2019/37020> .
+
+<http://vocab.belgif.be/auth/refnis2019/38000> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/30000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "38000";
+  skos:prefLabel "Bezirk Veurne"@de, "Arrondissement de Furnes"@fr, "Arrondissement Veurne"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE258>, <http://vocab.belgif.be/auth/refnis1995/38000>,
+    <http://vocab.belgif.be/auth/refnis2025/38000>;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/38002>, <http://vocab.belgif.be/auth/refnis2019/38008>,
+    <http://vocab.belgif.be/auth/refnis2019/38014>, <http://vocab.belgif.be/auth/refnis2019/38016>,
+    <http://vocab.belgif.be/auth/refnis2019/38025> .
+
+<http://vocab.belgif.be/auth/refnis2019/41000> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/40000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "41000";
+  skos:prefLabel "Bezirk Aalst"@de, "Arrondissement d’Alost"@fr, "Arrondissement Aalst"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE231>, <http://vocab.belgif.be/auth/refnis1995/41000>,
+    <http://vocab.belgif.be/auth/refnis2025/41000>;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/41002>, <http://vocab.belgif.be/auth/refnis2019/41011>,
+    <http://vocab.belgif.be/auth/refnis2019/41018>, <http://vocab.belgif.be/auth/refnis2019/41024>,
+    <http://vocab.belgif.be/auth/refnis2019/41027>, <http://vocab.belgif.be/auth/refnis2019/41034>,
+    <http://vocab.belgif.be/auth/refnis2019/41048>, <http://vocab.belgif.be/auth/refnis2019/41063>,
+    <http://vocab.belgif.be/auth/refnis2019/41081>, <http://vocab.belgif.be/auth/refnis2019/41082> .
+
+<http://vocab.belgif.be/auth/refnis2019/42000> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/40000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "42000";
+  skos:prefLabel "Bezirk Dendermonde"@de, "Arrondissement de Termonde"@fr, "Arrondissement Dendermonde"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE232>, <http://vocab.belgif.be/auth/refnis1995/42000>,
+    <http://vocab.belgif.be/auth/refnis2025/42000>;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/42003>, <http://vocab.belgif.be/auth/refnis2019/42004>,
+    <http://vocab.belgif.be/auth/refnis2019/42006>, <http://vocab.belgif.be/auth/refnis2019/42008>,
+    <http://vocab.belgif.be/auth/refnis2019/42010>, <http://vocab.belgif.be/auth/refnis2019/42011>,
+    <http://vocab.belgif.be/auth/refnis2019/42023>, <http://vocab.belgif.be/auth/refnis2019/42025>,
+    <http://vocab.belgif.be/auth/refnis2019/42026>, <http://vocab.belgif.be/auth/refnis2019/42028> .
+
+<http://vocab.belgif.be/auth/refnis2019/43000> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/40000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "43000";
+  skos:prefLabel "Bezirk Eeklo"@de, "Arrondissement d’Eeklo"@fr, "Arrondissement Eeklo"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE233>, <http://vocab.belgif.be/auth/refnis1995/43000>,
+    <http://vocab.belgif.be/auth/refnis2025/43000>;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/43002>, <http://vocab.belgif.be/auth/refnis2019/43005>,
+    <http://vocab.belgif.be/auth/refnis2019/43007>, <http://vocab.belgif.be/auth/refnis2019/43010>,
+    <http://vocab.belgif.be/auth/refnis2019/43014>, <http://vocab.belgif.be/auth/refnis2019/43018> .
+
+<http://vocab.belgif.be/auth/refnis2019/44000> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/40000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "44000";
+  skos:prefLabel "Bezirk Gent"@de, "Arrondissement de Gand"@fr, "Arrondissement Gent"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE234>, <http://vocab.belgif.be/auth/refnis1995/44000>,
+    <http://vocab.belgif.be/auth/refnis2025/44000>;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/44083>, <http://vocab.belgif.be/auth/refnis2019/44012>,
+    <http://vocab.belgif.be/auth/refnis2019/44013>, <http://vocab.belgif.be/auth/refnis2019/44019>,
+    <http://vocab.belgif.be/auth/refnis2019/44020>, <http://vocab.belgif.be/auth/refnis2019/44021>,
+    <http://vocab.belgif.be/auth/refnis2019/44034>, <http://vocab.belgif.be/auth/refnis2019/44040>,
+    <http://vocab.belgif.be/auth/refnis2019/44043>, <http://vocab.belgif.be/auth/refnis2019/44045>,
+    <http://vocab.belgif.be/auth/refnis2019/44048>, <http://vocab.belgif.be/auth/refnis2019/44052>,
+    <http://vocab.belgif.be/auth/refnis2019/44064>, <http://vocab.belgif.be/auth/refnis2019/44073>,
+    <http://vocab.belgif.be/auth/refnis2019/44081>, <http://vocab.belgif.be/auth/refnis2019/44084>,
+    <http://vocab.belgif.be/auth/refnis2019/44085> .
+
+<http://vocab.belgif.be/auth/refnis2019/45000> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/40000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "45000";
+  skos:prefLabel "Bezirk Oudenaarde"@de, "Arrondissement d’Audenarde"@fr, "Arrondissement Oudenaarde"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE235>, <http://vocab.belgif.be/auth/refnis1995/45000>,
+    <http://vocab.belgif.be/auth/refnis2025/45000>;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/45035>, <http://vocab.belgif.be/auth/refnis2019/45041>,
+    <http://vocab.belgif.be/auth/refnis2019/45059>, <http://vocab.belgif.be/auth/refnis2019/45060>,
+    <http://vocab.belgif.be/auth/refnis2019/45061>, <http://vocab.belgif.be/auth/refnis2019/45062>,
+    <http://vocab.belgif.be/auth/refnis2019/45063>, <http://vocab.belgif.be/auth/refnis2019/45064>,
+    <http://vocab.belgif.be/auth/refnis2019/45065>, <http://vocab.belgif.be/auth/refnis2019/45068> .
+
+<http://vocab.belgif.be/auth/refnis2019/46000> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/40000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "46000";
+  skos:prefLabel "Bezirk Sint-Niklaas"@de, "Arrondissement de Saint-Nicolas"@fr, "Arrondissement Sint-Niklaas"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "2025-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE236>, <http://vocab.belgif.be/auth/refnis1995/46000>;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/46003>, <http://vocab.belgif.be/auth/refnis2019/46013>,
+    <http://vocab.belgif.be/auth/refnis2019/46014>, <http://vocab.belgif.be/auth/refnis2019/46020>,
+    <http://vocab.belgif.be/auth/refnis2019/46021>, <http://vocab.belgif.be/auth/refnis2019/46024>,
+    <http://vocab.belgif.be/auth/refnis2019/46025>;
+  skos:broadMatch <http://vocab.belgif.be/auth/refnis2025/46000> .
+
+<http://vocab.belgif.be/auth/refnis2019/51000> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/50000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "51000";
+  skos:prefLabel "Bezirk Ath"@de, "Arrondissement d’Ath"@fr, "Arrondissement Aat"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:narrowMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE321>, <http://vocab.belgif.be/auth/refnis1995/51000>;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/51004>, <http://vocab.belgif.be/auth/refnis2019/51008>,
+    <http://vocab.belgif.be/auth/refnis2019/51009>, <http://vocab.belgif.be/auth/refnis2019/51012>,
+    <http://vocab.belgif.be/auth/refnis2019/51014>, <http://vocab.belgif.be/auth/refnis2019/51017>,
+    <http://vocab.belgif.be/auth/refnis2019/51019>, <http://vocab.belgif.be/auth/refnis2019/51065>,
+    <http://vocab.belgif.be/auth/refnis2019/51067>, <http://vocab.belgif.be/auth/refnis2019/51068>,
+    <http://vocab.belgif.be/auth/refnis2019/51069>;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2025/51000> .
+
+<http://vocab.belgif.be/auth/refnis2019/52000> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/50000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "52000";
+  skos:prefLabel "Bezirk Charleroi"@de, "Arrondissement de Charleroi"@fr, "Arrondissement Charleroi"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE322>, <http://vocab.belgif.be/auth/refnis1995/52000>,
+    <http://vocab.belgif.be/auth/refnis2025/52000>;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/52010>, <http://vocab.belgif.be/auth/refnis2019/52011>,
+    <http://vocab.belgif.be/auth/refnis2019/52012>, <http://vocab.belgif.be/auth/refnis2019/52015>,
+    <http://vocab.belgif.be/auth/refnis2019/52018>, <http://vocab.belgif.be/auth/refnis2019/52021>,
+    <http://vocab.belgif.be/auth/refnis2019/52022>, <http://vocab.belgif.be/auth/refnis2019/52025>,
+    <http://vocab.belgif.be/auth/refnis2019/52048>, <http://vocab.belgif.be/auth/refnis2019/52055>,
+    <http://vocab.belgif.be/auth/refnis2019/52074>, <http://vocab.belgif.be/auth/refnis2019/52075> .
+
+<http://vocab.belgif.be/auth/refnis2019/53000> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/50000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "53000";
+  skos:prefLabel "Bezirk Mons"@de, "Arrondissement de Mons"@fr, "Arrondissement Bergen"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE323>, <http://vocab.belgif.be/auth/refnis1995/53000>,
+    <http://vocab.belgif.be/auth/refnis2025/53000>;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/53014>, <http://vocab.belgif.be/auth/refnis2019/53020>,
+    <http://vocab.belgif.be/auth/refnis2019/53028>, <http://vocab.belgif.be/auth/refnis2019/53039>,
+    <http://vocab.belgif.be/auth/refnis2019/53044>, <http://vocab.belgif.be/auth/refnis2019/53046>,
+    <http://vocab.belgif.be/auth/refnis2019/53053>, <http://vocab.belgif.be/auth/refnis2019/53065>,
+    <http://vocab.belgif.be/auth/refnis2019/53068>, <http://vocab.belgif.be/auth/refnis2019/53070>,
+    <http://vocab.belgif.be/auth/refnis2019/53082>, <http://vocab.belgif.be/auth/refnis2019/53083>,
+    <http://vocab.belgif.be/auth/refnis2019/53084> .
+
+<http://vocab.belgif.be/auth/refnis2019/55000> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/50000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "55000";
+  skos:prefLabel "Bezirk Soignies"@de, "Arrondissement de Soignies"@fr, "Arrondissement Zinnik"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE325>, <http://vocab.belgif.be/auth/refnis1995/55000>,
+    <http://vocab.belgif.be/auth/refnis2025/55000>;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/55085>, <http://vocab.belgif.be/auth/refnis2019/55086>,
+    <http://vocab.belgif.be/auth/refnis2019/55004>, <http://vocab.belgif.be/auth/refnis2019/55035>,
+    <http://vocab.belgif.be/auth/refnis2019/55040>, <http://vocab.belgif.be/auth/refnis2019/55050> .
+
+<http://vocab.belgif.be/auth/refnis2019/56000> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/50000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "56000";
+  skos:prefLabel "Bezirk Thuin"@de, "Arrondissement de Thuin"@fr, "Arrondissement Thuin"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE326>, <http://vocab.belgif.be/auth/refnis1995/56000>,
+    <http://vocab.belgif.be/auth/refnis2025/56000>;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/56001>, <http://vocab.belgif.be/auth/refnis2019/56005>,
+    <http://vocab.belgif.be/auth/refnis2019/56016>, <http://vocab.belgif.be/auth/refnis2019/56022>,
+    <http://vocab.belgif.be/auth/refnis2019/56029>, <http://vocab.belgif.be/auth/refnis2019/56044>,
+    <http://vocab.belgif.be/auth/refnis2019/56049>, <http://vocab.belgif.be/auth/refnis2019/56051>,
+    <http://vocab.belgif.be/auth/refnis2019/56078>, <http://vocab.belgif.be/auth/refnis2019/56086>,
+    <http://vocab.belgif.be/auth/refnis2019/56088> .
+
+<http://vocab.belgif.be/auth/refnis2019/57000> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/50000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "57000";
+  skos:prefLabel "Bezirk Tournai-Mouscron"@de, "Arrondissement de Tournai-Mouscron"@fr,
+    "Arrondissement Doornik-Moeskroen"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:narrowMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE327>, <http://vocab.belgif.be/auth/refnis1995/57000>,
+    <http://vocab.belgif.be/auth/refnis1995/54000>;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/57003>, <http://vocab.belgif.be/auth/refnis2019/57018>,
+    <http://vocab.belgif.be/auth/refnis2019/57027>, <http://vocab.belgif.be/auth/refnis2019/57062>,
+    <http://vocab.belgif.be/auth/refnis2019/57064>, <http://vocab.belgif.be/auth/refnis2019/57072>,
+    <http://vocab.belgif.be/auth/refnis2019/57081>, <http://vocab.belgif.be/auth/refnis2019/57093>,
+    <http://vocab.belgif.be/auth/refnis2019/57094>, <http://vocab.belgif.be/auth/refnis2019/57095>,
+    <http://vocab.belgif.be/auth/refnis2019/57096>, <http://vocab.belgif.be/auth/refnis2019/57097>;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2025/57000> .
+
+<http://vocab.belgif.be/auth/refnis2019/58000> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/50000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "58000";
+  skos:prefLabel "Bezirk La Louvière"@de, "Arrondissement de La Louvière"@fr, "Arrondissement La Louvière"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:relatedMatch <http://vocab.belgif.be/auth/refnis1995/55000>, <http://vocab.belgif.be/auth/refnis1995/56000>;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/58001>, <http://vocab.belgif.be/auth/refnis2019/58002>,
+    <http://vocab.belgif.be/auth/refnis2019/58003>, <http://vocab.belgif.be/auth/refnis2019/58004>;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis2025/58000> .
+
+<http://vocab.belgif.be/auth/refnis2019/61000> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/60000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "61000";
+  skos:prefLabel "Bezirk Huy"@de, "Arrondissement de Huy"@fr, "Arrondissement Hoei"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE331>, <http://vocab.belgif.be/auth/refnis1995/61000>,
+    <http://vocab.belgif.be/auth/refnis2025/61000>;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/61003>, <http://vocab.belgif.be/auth/refnis2019/61010>,
+    <http://vocab.belgif.be/auth/refnis2019/61012>, <http://vocab.belgif.be/auth/refnis2019/61019>,
+    <http://vocab.belgif.be/auth/refnis2019/61024>, <http://vocab.belgif.be/auth/refnis2019/61028>,
+    <http://vocab.belgif.be/auth/refnis2019/61031>, <http://vocab.belgif.be/auth/refnis2019/61039>,
+    <http://vocab.belgif.be/auth/refnis2019/61041>, <http://vocab.belgif.be/auth/refnis2019/61043>,
+    <http://vocab.belgif.be/auth/refnis2019/61048>, <http://vocab.belgif.be/auth/refnis2019/61063>,
+    <http://vocab.belgif.be/auth/refnis2019/61068>, <http://vocab.belgif.be/auth/refnis2019/61072>,
+    <http://vocab.belgif.be/auth/refnis2019/61079>, <http://vocab.belgif.be/auth/refnis2019/61080>,
+    <http://vocab.belgif.be/auth/refnis2019/61081> .
+
+<http://vocab.belgif.be/auth/refnis2019/62000> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/60000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "62000";
+  skos:prefLabel "Bezirk Lüttich"@de, "Arrondissement de Liège"@fr, "Arrondissement Luik"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE332>, <http://vocab.belgif.be/auth/refnis1995/62000>,
+    <http://vocab.belgif.be/auth/refnis2025/62000>;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/62003>, <http://vocab.belgif.be/auth/refnis2019/62006>,
+    <http://vocab.belgif.be/auth/refnis2019/62009>, <http://vocab.belgif.be/auth/refnis2019/62011>,
+    <http://vocab.belgif.be/auth/refnis2019/62015>, <http://vocab.belgif.be/auth/refnis2019/62022>,
+    <http://vocab.belgif.be/auth/refnis2019/62026>, <http://vocab.belgif.be/auth/refnis2019/62027>,
+    <http://vocab.belgif.be/auth/refnis2019/62032>, <http://vocab.belgif.be/auth/refnis2019/62038>,
+    <http://vocab.belgif.be/auth/refnis2019/62051>, <http://vocab.belgif.be/auth/refnis2019/62060>,
+    <http://vocab.belgif.be/auth/refnis2019/62063>, <http://vocab.belgif.be/auth/refnis2019/62079>,
+    <http://vocab.belgif.be/auth/refnis2019/62093>, <http://vocab.belgif.be/auth/refnis2019/62096>,
+    <http://vocab.belgif.be/auth/refnis2019/62099>, <http://vocab.belgif.be/auth/refnis2019/62100>,
+    <http://vocab.belgif.be/auth/refnis2019/62108>, <http://vocab.belgif.be/auth/refnis2019/62118>,
+    <http://vocab.belgif.be/auth/refnis2019/62119>, <http://vocab.belgif.be/auth/refnis2019/62120>,
+    <http://vocab.belgif.be/auth/refnis2019/62121>, <http://vocab.belgif.be/auth/refnis2019/62122> .
+
+<http://vocab.belgif.be/auth/refnis2019/63000> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/60000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "63000";
+  skos:prefLabel "Bezirk Verviers"@de, "Arrondissement de Verviers"@fr, "Arrondissement Verviers"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <http://vocab.belgif.be/auth/refnis1995/63000>, <http://vocab.belgif.be/auth/refnis2025/63000>;
+  skos:narrowMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE335>;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/63001>, <http://vocab.belgif.be/auth/refnis2019/63003>,
+    <http://vocab.belgif.be/auth/refnis2019/63004>, <http://vocab.belgif.be/auth/refnis2019/63012>,
+    <http://vocab.belgif.be/auth/refnis2019/63013>, <http://vocab.belgif.be/auth/refnis2019/63020>,
+    <http://vocab.belgif.be/auth/refnis2019/63023>, <http://vocab.belgif.be/auth/refnis2019/63035>,
+    <http://vocab.belgif.be/auth/refnis2019/63038>, <http://vocab.belgif.be/auth/refnis2019/63040>,
+    <http://vocab.belgif.be/auth/refnis2019/63045>, <http://vocab.belgif.be/auth/refnis2019/63046>,
+    <http://vocab.belgif.be/auth/refnis2019/63048>, <http://vocab.belgif.be/auth/refnis2019/63049>,
+    <http://vocab.belgif.be/auth/refnis2019/63057>, <http://vocab.belgif.be/auth/refnis2019/63058>,
+    <http://vocab.belgif.be/auth/refnis2019/63061>, <http://vocab.belgif.be/auth/refnis2019/63067>,
+    <http://vocab.belgif.be/auth/refnis2019/63072>, <http://vocab.belgif.be/auth/refnis2019/63073>,
+    <http://vocab.belgif.be/auth/refnis2019/63075>, <http://vocab.belgif.be/auth/refnis2019/63076>,
+    <http://vocab.belgif.be/auth/refnis2019/63079>, <http://vocab.belgif.be/auth/refnis2019/63080>,
+    <http://vocab.belgif.be/auth/refnis2019/63084>, <http://vocab.belgif.be/auth/refnis2019/63086>,
+    <http://vocab.belgif.be/auth/refnis2019/63087>, <http://vocab.belgif.be/auth/refnis2019/63088>,
+    <http://vocab.belgif.be/auth/refnis2019/63089> .
+
+<http://vocab.belgif.be/auth/refnis2019/64000> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/60000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "64000";
+  skos:prefLabel "Bezirk Waremme"@de, "Arrondissement de Waremme"@fr, "Arrondissement Borgworm"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE334>, <http://vocab.belgif.be/auth/refnis1995/64000>,
+    <http://vocab.belgif.be/auth/refnis2025/64000>;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/64008>, <http://vocab.belgif.be/auth/refnis2019/64015>,
+    <http://vocab.belgif.be/auth/refnis2019/64021>, <http://vocab.belgif.be/auth/refnis2019/64023>,
+    <http://vocab.belgif.be/auth/refnis2019/64025>, <http://vocab.belgif.be/auth/refnis2019/64029>,
+    <http://vocab.belgif.be/auth/refnis2019/64034>, <http://vocab.belgif.be/auth/refnis2019/64047>,
+    <http://vocab.belgif.be/auth/refnis2019/64056>, <http://vocab.belgif.be/auth/refnis2019/64063>,
+    <http://vocab.belgif.be/auth/refnis2019/64065>, <http://vocab.belgif.be/auth/refnis2019/64074>,
+    <http://vocab.belgif.be/auth/refnis2019/64075>, <http://vocab.belgif.be/auth/refnis2019/64076> .
+
+<http://vocab.belgif.be/auth/refnis2019/71000> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/70000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "71000";
+  skos:prefLabel "Bezirk Hasselt"@de, "Arrondissement de Hasselt"@fr, "Arrondissement Hasselt"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "2025-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE221>, <http://vocab.belgif.be/auth/refnis1995/71000>;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/71002>, <http://vocab.belgif.be/auth/refnis2019/71004>,
+    <http://vocab.belgif.be/auth/refnis2019/71011>, <http://vocab.belgif.be/auth/refnis2019/71016>,
+    <http://vocab.belgif.be/auth/refnis2019/71017>, <http://vocab.belgif.be/auth/refnis2019/71020>,
+    <http://vocab.belgif.be/auth/refnis2019/71022>, <http://vocab.belgif.be/auth/refnis2019/71024>,
+    <http://vocab.belgif.be/auth/refnis2019/71034>, <http://vocab.belgif.be/auth/refnis2019/71037>,
+    <http://vocab.belgif.be/auth/refnis2019/71045>, <http://vocab.belgif.be/auth/refnis2019/71053>,
+    <http://vocab.belgif.be/auth/refnis2019/71057>, <http://vocab.belgif.be/auth/refnis2019/71066>,
+    <http://vocab.belgif.be/auth/refnis2019/71067>, <http://vocab.belgif.be/auth/refnis2019/71069>,
+    <http://vocab.belgif.be/auth/refnis2019/71070>;
+  skos:broadMatch <http://vocab.belgif.be/auth/refnis2025/71000> .
+
+<http://vocab.belgif.be/auth/refnis2019/72000> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/70000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "72000";
+  skos:prefLabel "Bezirk Maaseik"@de, "Arrondissement de Maaseik"@fr, "Arrondissement Maaseik"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE222>, <http://vocab.belgif.be/auth/refnis1995/72000>,
+    <http://vocab.belgif.be/auth/refnis2025/72000>;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/72003>, <http://vocab.belgif.be/auth/refnis2019/72004>,
+    <http://vocab.belgif.be/auth/refnis2019/72018>, <http://vocab.belgif.be/auth/refnis2019/72020>,
+    <http://vocab.belgif.be/auth/refnis2019/72021>, <http://vocab.belgif.be/auth/refnis2019/72030>,
+    <http://vocab.belgif.be/auth/refnis2019/72037>, <http://vocab.belgif.be/auth/refnis2019/72038>,
+    <http://vocab.belgif.be/auth/refnis2019/72039>, <http://vocab.belgif.be/auth/refnis2019/72041>,
+    <http://vocab.belgif.be/auth/refnis2019/72042>, <http://vocab.belgif.be/auth/refnis2019/72043> .
+
+<http://vocab.belgif.be/auth/refnis2019/73000> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/70000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "73000";
+  skos:prefLabel "Bezirk Tongeren"@de, "Arrondissement de Tongres"@fr, "Arrondissement Tongeren"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "2025-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE223>, <http://vocab.belgif.be/auth/refnis1995/73000>;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/73001>, <http://vocab.belgif.be/auth/refnis2019/73006>,
+    <http://vocab.belgif.be/auth/refnis2019/73009>, <http://vocab.belgif.be/auth/refnis2019/73022>,
+    <http://vocab.belgif.be/auth/refnis2019/73028>, <http://vocab.belgif.be/auth/refnis2019/73032>,
+    <http://vocab.belgif.be/auth/refnis2019/73040>, <http://vocab.belgif.be/auth/refnis2019/73042>,
+    <http://vocab.belgif.be/auth/refnis2019/73066>, <http://vocab.belgif.be/auth/refnis2019/73083>,
+    <http://vocab.belgif.be/auth/refnis2019/73098>, <http://vocab.belgif.be/auth/refnis2019/73107>,
+    <http://vocab.belgif.be/auth/refnis2019/73109>;
+  skos:narrowMatch <http://vocab.belgif.be/auth/refnis2025/73000> .
+
+<http://vocab.belgif.be/auth/refnis2019/81000> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/80000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "81000";
+  skos:prefLabel "Bezirk Arlon"@de, "Arrondissement d’Arlon"@fr, "Arrondissement Aarlen"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE341>, <http://vocab.belgif.be/auth/refnis1995/81000>,
+    <http://vocab.belgif.be/auth/refnis2025/81000>;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/81001>, <http://vocab.belgif.be/auth/refnis2019/81003>,
+    <http://vocab.belgif.be/auth/refnis2019/81004>, <http://vocab.belgif.be/auth/refnis2019/81013>,
+    <http://vocab.belgif.be/auth/refnis2019/81015> .
+
+<http://vocab.belgif.be/auth/refnis2019/82000> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/80000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "82000";
+  skos:prefLabel "Bezirk Bastogne"@de, "Arrondissement de Bastogne"@fr, "Arrondissement Bastenaken"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE342>, <http://vocab.belgif.be/auth/refnis1995/82000>,
+    <http://vocab.belgif.be/auth/refnis2025/82000>;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/82003>, <http://vocab.belgif.be/auth/refnis2019/82005>,
+    <http://vocab.belgif.be/auth/refnis2019/82009>, <http://vocab.belgif.be/auth/refnis2019/82014>,
+    <http://vocab.belgif.be/auth/refnis2019/82032>, <http://vocab.belgif.be/auth/refnis2019/82036>,
+    <http://vocab.belgif.be/auth/refnis2019/82037>, <http://vocab.belgif.be/auth/refnis2019/82038> .
+
+<http://vocab.belgif.be/auth/refnis2019/83000> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/80000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "83000";
+  skos:prefLabel "Bezirk Marche-en-Famenne"@de, "Arrondissement de Marche-en-Famenne"@fr,
+    "Arrondissement Marche-en-Famenne"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE343>, <http://vocab.belgif.be/auth/refnis1995/83000>,
+    <http://vocab.belgif.be/auth/refnis2025/83000>;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/83012>, <http://vocab.belgif.be/auth/refnis2019/83013>,
+    <http://vocab.belgif.be/auth/refnis2019/83028>, <http://vocab.belgif.be/auth/refnis2019/83031>,
+    <http://vocab.belgif.be/auth/refnis2019/83034>, <http://vocab.belgif.be/auth/refnis2019/83040>,
+    <http://vocab.belgif.be/auth/refnis2019/83044>, <http://vocab.belgif.be/auth/refnis2019/83049>,
+    <http://vocab.belgif.be/auth/refnis2019/83055> .
+
+<http://vocab.belgif.be/auth/refnis2019/84000> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/80000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "84000";
+  skos:prefLabel "Bezirk Neufchâteau"@de, "Arrondissement de Neufchâteau"@fr, "Arrondissement Neufchâteau"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE344>, <http://vocab.belgif.be/auth/refnis1995/84000>,
+    <http://vocab.belgif.be/auth/refnis2025/84000>;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/84009>, <http://vocab.belgif.be/auth/refnis2019/84010>,
+    <http://vocab.belgif.be/auth/refnis2019/84016>, <http://vocab.belgif.be/auth/refnis2019/84029>,
+    <http://vocab.belgif.be/auth/refnis2019/84033>, <http://vocab.belgif.be/auth/refnis2019/84035>,
+    <http://vocab.belgif.be/auth/refnis2019/84043>, <http://vocab.belgif.be/auth/refnis2019/84050>,
+    <http://vocab.belgif.be/auth/refnis2019/84059>, <http://vocab.belgif.be/auth/refnis2019/84068>,
+    <http://vocab.belgif.be/auth/refnis2019/84075>, <http://vocab.belgif.be/auth/refnis2019/84077> .
+
+<http://vocab.belgif.be/auth/refnis2019/85000> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/80000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "85000";
+  skos:prefLabel "Bezirk Virton"@de, "Arrondissement de Virton"@fr, "Arrondissement Virton"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE345>, <http://vocab.belgif.be/auth/refnis1995/85000>,
+    <http://vocab.belgif.be/auth/refnis2025/85000>;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/85007>, <http://vocab.belgif.be/auth/refnis2019/85009>,
+    <http://vocab.belgif.be/auth/refnis2019/85011>, <http://vocab.belgif.be/auth/refnis2019/85024>,
+    <http://vocab.belgif.be/auth/refnis2019/85026>, <http://vocab.belgif.be/auth/refnis2019/85034>,
+    <http://vocab.belgif.be/auth/refnis2019/85039>, <http://vocab.belgif.be/auth/refnis2019/85045>,
+    <http://vocab.belgif.be/auth/refnis2019/85046>, <http://vocab.belgif.be/auth/refnis2019/85047> .
+
+<http://vocab.belgif.be/auth/refnis2019/91000> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/90000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "91000";
+  skos:prefLabel "Bezirk Dinant"@de, "Arrondissement de Dinant"@fr, "Arrondissement Dinant"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE351>, <http://vocab.belgif.be/auth/refnis1995/91000>,
+    <http://vocab.belgif.be/auth/refnis2025/91000>;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/91005>, <http://vocab.belgif.be/auth/refnis2019/91013>,
+    <http://vocab.belgif.be/auth/refnis2019/91015>, <http://vocab.belgif.be/auth/refnis2019/91030>,
+    <http://vocab.belgif.be/auth/refnis2019/91034>, <http://vocab.belgif.be/auth/refnis2019/91054>,
+    <http://vocab.belgif.be/auth/refnis2019/91059>, <http://vocab.belgif.be/auth/refnis2019/91064>,
+    <http://vocab.belgif.be/auth/refnis2019/91072>, <http://vocab.belgif.be/auth/refnis2019/91103>,
+    <http://vocab.belgif.be/auth/refnis2019/91114>, <http://vocab.belgif.be/auth/refnis2019/91120>,
+    <http://vocab.belgif.be/auth/refnis2019/91141>, <http://vocab.belgif.be/auth/refnis2019/91142>,
+    <http://vocab.belgif.be/auth/refnis2019/91143> .
+
+<http://vocab.belgif.be/auth/refnis2019/92000> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/90000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "92000";
+  skos:prefLabel "Bezirk Namur"@de, "Arrondissement de Namur"@fr, "Arrondissement Namen"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE352>, <http://vocab.belgif.be/auth/refnis1995/92000>,
+    <http://vocab.belgif.be/auth/refnis2025/92000>;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/92003>, <http://vocab.belgif.be/auth/refnis2019/92006>,
+    <http://vocab.belgif.be/auth/refnis2019/92035>, <http://vocab.belgif.be/auth/refnis2019/92045>,
+    <http://vocab.belgif.be/auth/refnis2019/92048>, <http://vocab.belgif.be/auth/refnis2019/92054>,
+    <http://vocab.belgif.be/auth/refnis2019/92087>, <http://vocab.belgif.be/auth/refnis2019/92094>,
+    <http://vocab.belgif.be/auth/refnis2019/92097>, <http://vocab.belgif.be/auth/refnis2019/92101>,
+    <http://vocab.belgif.be/auth/refnis2019/92114>, <http://vocab.belgif.be/auth/refnis2019/92137>,
+    <http://vocab.belgif.be/auth/refnis2019/92138>, <http://vocab.belgif.be/auth/refnis2019/92140>,
+    <http://vocab.belgif.be/auth/refnis2019/92141>, <http://vocab.belgif.be/auth/refnis2019/92142> .
+
+<http://vocab.belgif.be/auth/refnis2019/93000> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/90000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "93000";
+  skos:prefLabel "Bezirk Philippeville"@de, "Arrondissement de Philippeville"@fr, "Arrondissement Philippeville"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <http://rdfdata.eionet.europa.eu/ramon/nuts2008/BE353>, <http://vocab.belgif.be/auth/refnis1995/93000>,
+    <http://vocab.belgif.be/auth/refnis2025/93000>;
+  skos:narrower <http://vocab.belgif.be/auth/refnis2019/93010>, <http://vocab.belgif.be/auth/refnis2019/93014>,
+    <http://vocab.belgif.be/auth/refnis2019/93018>, <http://vocab.belgif.be/auth/refnis2019/93022>,
+    <http://vocab.belgif.be/auth/refnis2019/93056>, <http://vocab.belgif.be/auth/refnis2019/93088>,
+    <http://vocab.belgif.be/auth/refnis2019/93090> .
+
+<http://vocab.belgif.be/auth/refnis2019/11001> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/11000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "11001";
+  skos:prefLabel "Aartselaar"@de, "Aartselaar"@fr, "Aartselaar"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2803421/>, <http://www.wikidata.org/entity/Q303246>,
+    <http://vocab.belgif.be/auth/refnis1995/11001>, <http://vocab.belgif.be/auth/refnis2025/11001> .
+
+<http://vocab.belgif.be/auth/refnis2019/11002> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/11000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "11002";
+  skos:prefLabel "Antwerpen"@de, "Anvers"@fr, "Antwerpen"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "2025-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2803139/>, <http://www.wikidata.org/entity/Q12892>;
+  skos:narrowMatch <http://vocab.belgif.be/auth/refnis1995/11002>;
+  skos:broadMatch <http://vocab.belgif.be/auth/refnis2025/11002> .
+
+<http://vocab.belgif.be/auth/refnis2019/11004> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/11000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "11004";
+  skos:prefLabel "Boechout"@de, "Boechout"@fr, "Boechout"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2801744/>, <http://www.wikidata.org/entity/Q723822>,
+    <http://vocab.belgif.be/auth/refnis1995/11004>, <http://vocab.belgif.be/auth/refnis2025/11004> .
+
+<http://vocab.belgif.be/auth/refnis2019/11005> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/11000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "11005";
+  skos:prefLabel "Boom"@de, "Boom"@fr, "Boom"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2801495/>, <http://www.wikidata.org/entity/Q723972>,
+    <http://vocab.belgif.be/auth/refnis1995/11005>, <http://vocab.belgif.be/auth/refnis2025/11005> .
+
+<http://vocab.belgif.be/auth/refnis2019/11007> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/11000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "11007";
+  skos:prefLabel "Borsbeek"@de, "Borsbeek"@fr, "Borsbeek"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "2025-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2801439/>, <http://www.wikidata.org/entity/Q724055>,
+    <http://vocab.belgif.be/auth/refnis1995/11007>;
+  skos:broadMatch <http://vocab.belgif.be/auth/refnis2025/11002> .
+
+<http://vocab.belgif.be/auth/refnis2019/11008> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/11000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "11008";
+  skos:prefLabel "Brasschaat"@de, "Brasschaat"@fr, "Brasschaat"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2801118/>, <http://www.wikidata.org/entity/Q693513>,
+    <http://vocab.belgif.be/auth/refnis1995/11008>, <http://vocab.belgif.be/auth/refnis2025/11008> .
+
+<http://vocab.belgif.be/auth/refnis2019/11009> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/11000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "11009";
+  skos:prefLabel "Brecht"@de, "Brecht"@fr, "Brecht"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2801107/>, <http://www.wikidata.org/entity/Q724131>,
+    <http://vocab.belgif.be/auth/refnis1995/11009>, <http://vocab.belgif.be/auth/refnis2025/11009> .
+
+<http://vocab.belgif.be/auth/refnis2019/11013> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/11000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "11013";
+  skos:prefLabel "Edegem"@de, "Edegem"@fr, "Edegem"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2799008/>, <http://www.wikidata.org/entity/Q724238>,
+    <http://vocab.belgif.be/auth/refnis1995/11013>, <http://vocab.belgif.be/auth/refnis2025/11013> .
+
+<http://vocab.belgif.be/auth/refnis2019/11016> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/11000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "11016";
+  skos:prefLabel "Essen"@de, "Essen"@fr, "Essen"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2798616/>, <http://www.wikidata.org/entity/Q724283>,
+    <http://vocab.belgif.be/auth/refnis1995/11016>, <http://vocab.belgif.be/auth/refnis2025/11016> .
+
+<http://vocab.belgif.be/auth/refnis2019/11018> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/11000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "11018";
+  skos:prefLabel "Hemiksem"@de, "Hemiksem"@fr, "Hemiksem"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2796086/>, <http://www.wikidata.org/entity/Q724448>,
+    <http://vocab.belgif.be/auth/refnis1995/11018>, <http://vocab.belgif.be/auth/refnis2025/11018> .
+
+<http://vocab.belgif.be/auth/refnis2019/11021> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/11000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "11021";
+  skos:prefLabel "Hove"@de, "Hove"@fr, "Hove"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2795233/>, <http://www.wikidata.org/entity/Q649982>,
+    <http://vocab.belgif.be/auth/refnis1995/11021>, <http://vocab.belgif.be/auth/refnis2025/11021> .
+
+<http://vocab.belgif.be/auth/refnis2019/11022> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/11000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "11022";
+  skos:prefLabel "Kalmthout"@de, "Kalmthout"@fr, "Kalmthout"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2794789/>, <http://www.wikidata.org/entity/Q724777>,
+    <http://vocab.belgif.be/auth/refnis1995/11022>, <http://vocab.belgif.be/auth/refnis2025/11022> .
+
+<http://vocab.belgif.be/auth/refnis2019/11023> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/11000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "11023";
+  skos:prefLabel "Kapellen"@de, "Kapellen"@fr, "Kapellen"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2794733/>, <http://www.wikidata.org/entity/Q724942>,
+    <http://vocab.belgif.be/auth/refnis1995/11023>, <http://vocab.belgif.be/auth/refnis2025/11023> .
+
+<http://vocab.belgif.be/auth/refnis2019/11024> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/11000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "11024";
+  skos:prefLabel "Kontich"@de, "Kontich"@fr, "Kontich"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2794118/>, <http://www.wikidata.org/entity/Q725074>,
+    <http://vocab.belgif.be/auth/refnis1995/11024>, <http://vocab.belgif.be/auth/refnis2025/11024> .
+
+<http://vocab.belgif.be/auth/refnis2019/11025> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/11000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "11025";
+  skos:prefLabel "Lint"@de, "Lint"@fr, "Lint"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2792294/>, <http://www.wikidata.org/entity/Q725268>,
+    <http://vocab.belgif.be/auth/refnis1995/11025>, <http://vocab.belgif.be/auth/refnis2025/11025> .
+
+<http://vocab.belgif.be/auth/refnis2019/11029> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/11000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "11029";
+  skos:prefLabel "Mortsel"@de, "Mortsel"@fr, "Mortsel"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2790677/>, <http://www.wikidata.org/entity/Q688781>,
+    <http://vocab.belgif.be/auth/refnis1995/11029>, <http://vocab.belgif.be/auth/refnis2025/11029> .
+
+<http://vocab.belgif.be/auth/refnis2019/11030> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/11000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "11030";
+  skos:prefLabel "Niel"@de, "Niel"@fr, "Niel"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2790226/>, <http://www.wikidata.org/entity/Q912054>,
+    <http://vocab.belgif.be/auth/refnis1995/11030>, <http://vocab.belgif.be/auth/refnis2025/11030> .
+
+<http://vocab.belgif.be/auth/refnis2019/11035> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/11000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "11035";
+  skos:prefLabel "Ranst"@de, "Ranst"@fr, "Ranst"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2788349/>, <http://www.wikidata.org/entity/Q501748>,
+    <http://vocab.belgif.be/auth/refnis1995/11035>, <http://vocab.belgif.be/auth/refnis2025/11035> .
+
+<http://vocab.belgif.be/auth/refnis2019/11037> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/11000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "11037";
+  skos:prefLabel "Rumst"@de, "Rumst"@fr, "Rumst"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2787522/>, <http://www.wikidata.org/entity/Q943446>,
+    <http://vocab.belgif.be/auth/refnis1995/11037>, <http://vocab.belgif.be/auth/refnis2025/11037> .
+
+<http://vocab.belgif.be/auth/refnis2019/11038> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/11000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "11038";
+  skos:prefLabel "Schelle"@de, "Schelle"@fr, "Schelle"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2787081/>, <http://www.wikidata.org/entity/Q911968>,
+    <http://vocab.belgif.be/auth/refnis1995/11038>, <http://vocab.belgif.be/auth/refnis2025/11038> .
+
+<http://vocab.belgif.be/auth/refnis2019/11039> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/11000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "11039";
+  skos:prefLabel "Schilde"@de, "Schilde"@fr, "Schilde"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2787049/>, <http://www.wikidata.org/entity/Q263177>,
+    <http://vocab.belgif.be/auth/refnis1995/11039>, <http://vocab.belgif.be/auth/refnis2025/11039> .
+
+<http://vocab.belgif.be/auth/refnis2019/11040> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/11000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "11040";
+  skos:prefLabel "Schoten"@de, "Schoten"@fr, "Schoten"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2786964/>, <http://www.wikidata.org/entity/Q655203>,
+    <http://vocab.belgif.be/auth/refnis1995/11040>, <http://vocab.belgif.be/auth/refnis2025/11040> .
+
+<http://vocab.belgif.be/auth/refnis2019/11044> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/11000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "11044";
+  skos:prefLabel "Stabroek"@de, "Stabroek"@fr, "Stabroek"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2786230/>, <http://www.wikidata.org/entity/Q595654>,
+    <http://vocab.belgif.be/auth/refnis1995/11044>, <http://vocab.belgif.be/auth/refnis2025/11044> .
+
+<http://vocab.belgif.be/auth/refnis2019/11050> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/11000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "11050";
+  skos:prefLabel "Wijnegem"@de, "Wijnegem"@fr, "Wijnegem"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2783685/>, <http://www.wikidata.org/entity/Q527808>,
+    <http://vocab.belgif.be/auth/refnis1995/11050>, <http://vocab.belgif.be/auth/refnis2025/11050> .
+
+<http://vocab.belgif.be/auth/refnis2019/11052> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/11000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "11052";
+  skos:prefLabel "Wommelgem"@de, "Wommelgem"@fr, "Wommelgem"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2783463/>, <http://www.wikidata.org/entity/Q839037>,
+    <http://vocab.belgif.be/auth/refnis1995/11052>, <http://vocab.belgif.be/auth/refnis2025/11052> .
+
+<http://vocab.belgif.be/auth/refnis2019/11053> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/11000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "11053";
+  skos:prefLabel "Wuustwezel"@de, "Wuustwezel"@fr, "Wuustwezel"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2783417/>, <http://www.wikidata.org/entity/Q912045>,
+    <http://vocab.belgif.be/auth/refnis1995/11053>, <http://vocab.belgif.be/auth/refnis2025/11053> .
+
+<http://vocab.belgif.be/auth/refnis2019/11054> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/11000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "11054";
+  skos:prefLabel "Zandhoven"@de, "Zandhoven"@fr, "Zandhoven"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2783348/>, <http://www.wikidata.org/entity/Q146656>,
+    <http://vocab.belgif.be/auth/refnis1995/11054>, <http://vocab.belgif.be/auth/refnis2025/11054> .
+
+<http://vocab.belgif.be/auth/refnis2019/11055> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/11000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "11055";
+  skos:prefLabel "Zoersel"@de, "Zoersel"@fr, "Zoersel"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2783205/>, <http://www.wikidata.org/entity/Q218253>,
+    <http://vocab.belgif.be/auth/refnis1995/11055>, <http://vocab.belgif.be/auth/refnis2025/11055> .
+
+<http://vocab.belgif.be/auth/refnis2019/11056> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/11000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "11056";
+  skos:prefLabel "Zwijndrecht"@de, "Zwijndrecht"@fr, "Zwijndrecht"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "2025-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2783082/>, <http://www.wikidata.org/entity/Q244690>,
+    <http://vocab.belgif.be/auth/refnis1995/11056>;
+  skos:broadMatch <http://vocab.belgif.be/auth/refnis2025/46030> .
+
+<http://vocab.belgif.be/auth/refnis2019/11057> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/11000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "11057";
+  skos:prefLabel "Malle"@de, "Malle"@fr, "Malle"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2789746/>, <http://www.wikidata.org/entity/Q917591>,
+    <http://vocab.belgif.be/auth/refnis1995/11057>, <http://vocab.belgif.be/auth/refnis2025/11057> .
+
+<http://vocab.belgif.be/auth/refnis2019/12002> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/12000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "12002";
+  skos:prefLabel "Berlaar"@de, "Berlaar"@fr, "Berlaar"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2802157/>, <http://www.wikidata.org/entity/Q723774>,
+    <http://vocab.belgif.be/auth/refnis1995/12002>, <http://vocab.belgif.be/auth/refnis2025/12002> .
+
+<http://vocab.belgif.be/auth/refnis2019/12005> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/12000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "12005";
+  skos:prefLabel "Bonheiden"@de, "Bonheiden"@fr, "Bonheiden"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2801540/>, <http://www.wikidata.org/entity/Q528222>,
+    <http://vocab.belgif.be/auth/refnis1995/12005>, <http://vocab.belgif.be/auth/refnis2025/12005> .
+
+<http://vocab.belgif.be/auth/refnis2019/12007> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/12000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "12007";
+  skos:prefLabel "Bornem"@de, "Bornem"@fr, "Bornem"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2801448/>, <http://www.wikidata.org/entity/Q724025>,
+    <http://vocab.belgif.be/auth/refnis1995/12007>, <http://vocab.belgif.be/auth/refnis2025/12007> .
+
+<http://vocab.belgif.be/auth/refnis2019/12009> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/12000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "12009";
+  skos:prefLabel "Duffel"@de, "Duffel"@fr, "Duffel"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2799091/>, <http://www.wikidata.org/entity/Q615109>,
+    <http://vocab.belgif.be/auth/refnis1995/12009>, <http://vocab.belgif.be/auth/refnis2025/12009> .
+
+<http://vocab.belgif.be/auth/refnis2019/12014> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/12000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "12014";
+  skos:prefLabel "Heist-op-den-Berg"@de, "Heist-op-den-Berg"@fr, "Heist-op-den-Berg"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2796154/>, <http://www.wikidata.org/entity/Q257979>,
+    <http://vocab.belgif.be/auth/refnis1995/12014>, <http://vocab.belgif.be/auth/refnis2025/12014> .
+
+<http://vocab.belgif.be/auth/refnis2019/12021> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/12000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "12021";
+  skos:prefLabel "Lier"@de, "Lierre"@fr, "Lier"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2792406/>, <http://www.wikidata.org/entity/Q12460>,
+    <http://vocab.belgif.be/auth/refnis1995/12021>, <http://vocab.belgif.be/auth/refnis2025/12021> .
+
+<http://vocab.belgif.be/auth/refnis2019/12025> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/12000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "12025";
+  skos:prefLabel "Mechelen"@de, "Malines"@fr, "Mechelen"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2791538/>, <http://www.wikidata.org/entity/Q162022>,
+    <http://vocab.belgif.be/auth/refnis1995/12025>, <http://vocab.belgif.be/auth/refnis2025/12025> .
+
+<http://vocab.belgif.be/auth/refnis2019/12026> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/12000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "12026";
+  skos:prefLabel "Nijlen"@de, "Nijlen"@fr, "Nijlen"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2790136/>, <http://www.wikidata.org/entity/Q912084>,
+    <http://vocab.belgif.be/auth/refnis1995/12026>, <http://vocab.belgif.be/auth/refnis2025/12026> .
+
+<http://vocab.belgif.be/auth/refnis2019/12029> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/12000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "12029";
+  skos:prefLabel "Putte"@de, "Putte"@fr, "Putte"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2788523/>, <http://www.wikidata.org/entity/Q929397>,
+    <http://vocab.belgif.be/auth/refnis1995/12029>, <http://vocab.belgif.be/auth/refnis2025/12029> .
+
+<http://vocab.belgif.be/auth/refnis2019/12041> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/12000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "12041";
+  skos:prefLabel "Puurs-Sint-Amands"@de, "Puurs-Sint-Amands"@fr, "Puurs-Sint-Amands"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <http://www.wikidata.org/entity/Q45202943>, <http://vocab.belgif.be/auth/refnis2025/12041>;
+  skos:narrowMatch <https://sws.geonames.org/2788507/>, <http://www.wikidata.org/entity/Q908546>,
+    <http://vocab.belgif.be/auth/refnis1995/12030> .
+
+<http://vocab.belgif.be/auth/refnis2019/12034> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/12000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "12034";
+  skos:prefLabel "Sint-Amands"@de, "Sint-Amands"@fr, "Sint-Amands"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2786747/>, <http://www.wikidata.org/entity/Q912030>,
+    <http://vocab.belgif.be/auth/refnis1995/12034>, <http://vocab.belgif.be/auth/refnis2025/12034> .
+
+<http://vocab.belgif.be/auth/refnis2019/12035> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/12000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "12035";
+  skos:prefLabel "Sint-Katelijne-Waver"@de, "Sint-Katelijne-Waver"@fr, "Sint-Katelijne-Waver"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2786642/>, <http://www.wikidata.org/entity/Q696578>,
+    <http://vocab.belgif.be/auth/refnis1995/12035>, <http://vocab.belgif.be/auth/refnis2025/12035> .
+
+<http://vocab.belgif.be/auth/refnis2019/12040> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/12000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "12040";
+  skos:prefLabel "Willebroek"@de, "Willebroek"@fr, "Willebroek"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2783633/>, <http://www.wikidata.org/entity/Q695278>,
+    <http://vocab.belgif.be/auth/refnis1995/12040>, <http://vocab.belgif.be/auth/refnis2025/12040> .
+
+<http://vocab.belgif.be/auth/refnis2019/13001> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/13000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "13001";
+  skos:prefLabel "Arendonk"@de, "Arendonk"@fr, "Arendonk"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2803084/>, <http://www.wikidata.org/entity/Q641905>,
+    <http://vocab.belgif.be/auth/refnis1995/13001>, <http://vocab.belgif.be/auth/refnis2025/13001> .
+
+<http://vocab.belgif.be/auth/refnis2019/13002> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/13000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "13002";
+  skos:prefLabel "Baarle-Hertog"@de, "Baerle-Duc"@fr, "Baarle-Hertog"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2802817/>, <http://www.wikidata.org/entity/Q244959>,
+    <http://vocab.belgif.be/auth/refnis1995/13002>, <http://vocab.belgif.be/auth/refnis2025/13002> .
+
+<http://vocab.belgif.be/auth/refnis2019/13003> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/13000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "13003";
+  skos:prefLabel "Balen"@de, "Balen"@fr, "Balen"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2802744/>, <http://www.wikidata.org/entity/Q723651>,
+    <http://vocab.belgif.be/auth/refnis1995/13003>, <http://vocab.belgif.be/auth/refnis2025/13003> .
+
+<http://vocab.belgif.be/auth/refnis2019/13004> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/13000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "13004";
+  skos:prefLabel "Beerse"@de, "Beerse"@fr, "Beerse"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2802436/>, <http://www.wikidata.org/entity/Q723728>,
+    <http://vocab.belgif.be/auth/refnis1995/13004>, <http://vocab.belgif.be/auth/refnis2025/13004> .
+
+<http://vocab.belgif.be/auth/refnis2019/13006> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/13000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "13006";
+  skos:prefLabel "Dessel"@de, "Dessel"@fr, "Dessel"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2799512/>, <http://www.wikidata.org/entity/Q386732>,
+    <http://vocab.belgif.be/auth/refnis1995/13006>, <http://vocab.belgif.be/auth/refnis2025/13006> .
+
+<http://vocab.belgif.be/auth/refnis2019/13008> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/13000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "13008";
+  skos:prefLabel "Geel"@de, "Geel"@fr, "Geel"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2797780/>, <http://www.wikidata.org/entity/Q464454>,
+    <http://vocab.belgif.be/auth/refnis1995/13008>, <http://vocab.belgif.be/auth/refnis2025/13008> .
+
+<http://vocab.belgif.be/auth/refnis2019/13010> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/13000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "13010";
+  skos:prefLabel "Grobbendonk"@de, "Grobbendonk"@fr, "Grobbendonk"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2797095/>, <http://www.wikidata.org/entity/Q724389>,
+    <http://vocab.belgif.be/auth/refnis1995/13010>, <http://vocab.belgif.be/auth/refnis2025/13010> .
+
+<http://vocab.belgif.be/auth/refnis2019/13011> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/13000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "13011";
+  skos:prefLabel "Herentals"@de, "Herentals"@fr, "Herentals"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2796010/>, <http://www.wikidata.org/entity/Q383723>,
+    <http://vocab.belgif.be/auth/refnis1995/13011>, <http://vocab.belgif.be/auth/refnis2025/13011> .
+
+<http://vocab.belgif.be/auth/refnis2019/13012> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/13000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "13012";
+  skos:prefLabel "Herenthout"@de, "Herenthout"@fr, "Herenthout"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2796006/>, <http://www.wikidata.org/entity/Q724534>,
+    <http://vocab.belgif.be/auth/refnis1995/13012>, <http://vocab.belgif.be/auth/refnis2025/13012> .
+
+<http://vocab.belgif.be/auth/refnis2019/13013> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/13000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "13013";
+  skos:prefLabel "Herselt"@de, "Herselt"@fr, "Herselt"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2795934/>, <http://www.wikidata.org/entity/Q280182>,
+    <http://vocab.belgif.be/auth/refnis1995/13013>, <http://vocab.belgif.be/auth/refnis2025/13013> .
+
+<http://vocab.belgif.be/auth/refnis2019/13014> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/13000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "13014";
+  skos:prefLabel "Hoogstraten"@de, "Hoogstraten"@fr, "Hoogstraten"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2795399/>, <http://www.wikidata.org/entity/Q724638>,
+    <http://vocab.belgif.be/auth/refnis1995/13014>, <http://vocab.belgif.be/auth/refnis2025/13014> .
+
+<http://vocab.belgif.be/auth/refnis2019/13016> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/13000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "13016";
+  skos:prefLabel "Hulshout"@de, "Hulshout"@fr, "Hulshout"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2795171/>, <http://www.wikidata.org/entity/Q518758>,
+    <http://vocab.belgif.be/auth/refnis1995/13016>, <http://vocab.belgif.be/auth/refnis2025/13016> .
+
+<http://vocab.belgif.be/auth/refnis2019/13017> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/13000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "13017";
+  skos:prefLabel "Kasterlee"@de, "Kasterlee"@fr, "Kasterlee"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2794664/>, <http://www.wikidata.org/entity/Q725029>,
+    <http://vocab.belgif.be/auth/refnis1995/13017>, <http://vocab.belgif.be/auth/refnis2025/13017> .
+
+<http://vocab.belgif.be/auth/refnis2019/13019> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/13000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "13019";
+  skos:prefLabel "Lille"@de, "Lille"@fr, "Lille"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2792361/>, <http://www.wikidata.org/entity/Q725235>,
+    <http://vocab.belgif.be/auth/refnis1995/13019>, <http://vocab.belgif.be/auth/refnis2025/13019> .
+
+<http://vocab.belgif.be/auth/refnis2019/13021> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/13000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "13021";
+  skos:prefLabel "Meerhout"@de, "Meerhout"@fr, "Meerhout"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2791495/>, <http://www.wikidata.org/entity/Q846207>,
+    <http://vocab.belgif.be/auth/refnis1995/13021>, <http://vocab.belgif.be/auth/refnis2025/13021> .
+
+<http://vocab.belgif.be/auth/refnis2019/13023> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/13000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "13023";
+  skos:prefLabel "Merksplas"@de, "Merksplas"@fr, "Merksplas"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2791298/>, <http://www.wikidata.org/entity/Q532277>,
+    <http://vocab.belgif.be/auth/refnis1995/13023>, <http://vocab.belgif.be/auth/refnis2025/13023> .
+
+<http://vocab.belgif.be/auth/refnis2019/13025> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/13000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "13025";
+  skos:prefLabel "Mol"@de, "Mol"@fr, "Mol"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2791068/>, <http://www.wikidata.org/entity/Q465710>,
+    <http://vocab.belgif.be/auth/refnis1995/13025>, <http://vocab.belgif.be/auth/refnis2025/13025> .
+
+<http://vocab.belgif.be/auth/refnis2019/13029> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/13000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "13029";
+  skos:prefLabel "Olen"@de, "Olen"@fr, "Olen"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2789887/>, <http://www.wikidata.org/entity/Q839044>,
+    <http://vocab.belgif.be/auth/refnis1995/13029>, <http://vocab.belgif.be/auth/refnis2025/13029> .
+
+<http://vocab.belgif.be/auth/refnis2019/13031> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/13000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "13031";
+  skos:prefLabel "Oud-Turnhout"@de, "Oud-Turnhout"@fr, "Oud-Turnhout"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2789484/>, <http://www.wikidata.org/entity/Q943555>,
+    <http://vocab.belgif.be/auth/refnis1995/13031>, <http://vocab.belgif.be/auth/refnis2025/13031> .
+
+<http://vocab.belgif.be/auth/refnis2019/13035> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/13000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "13035";
+  skos:prefLabel "Ravels"@de, "Ravels"@fr, "Ravels"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2788313/>, <http://www.wikidata.org/entity/Q839119>,
+    <http://vocab.belgif.be/auth/refnis1995/13035>, <http://vocab.belgif.be/auth/refnis2025/13035> .
+
+<http://vocab.belgif.be/auth/refnis2019/13036> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/13000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "13036";
+  skos:prefLabel "Retie"@de, "Retie"@fr, "Retie"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2788139/>, <http://www.wikidata.org/entity/Q912062>,
+    <http://vocab.belgif.be/auth/refnis1995/13036>, <http://vocab.belgif.be/auth/refnis2025/13036> .
+
+<http://vocab.belgif.be/auth/refnis2019/13037> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/13000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "13037";
+  skos:prefLabel "Rijkevorsel"@de, "Rijkevorsel"@fr, "Rijkevorsel"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2788052/>, <http://www.wikidata.org/entity/Q929459>,
+    <http://vocab.belgif.be/auth/refnis1995/13037>, <http://vocab.belgif.be/auth/refnis2025/13037> .
+
+<http://vocab.belgif.be/auth/refnis2019/13040> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/13000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "13040";
+  skos:prefLabel "Turnhout"@de, "Turnhout"@fr, "Turnhout"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2785142/>, <http://www.wikidata.org/entity/Q271783>,
+    <http://vocab.belgif.be/auth/refnis1995/13040>, <http://vocab.belgif.be/auth/refnis2025/13040> .
+
+<http://vocab.belgif.be/auth/refnis2019/13044> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/13000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "13044";
+  skos:prefLabel "Vorselaar"@de, "Vorselaar"@fr, "Vorselaar"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2784371/>, <http://www.wikidata.org/entity/Q909914>,
+    <http://vocab.belgif.be/auth/refnis1995/13044>, <http://vocab.belgif.be/auth/refnis2025/13044> .
+
+<http://vocab.belgif.be/auth/refnis2019/13046> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/13000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "13046";
+  skos:prefLabel "Vosselaar"@de, "Vosselaar"@fr, "Vosselaar"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2784350/>, <http://www.wikidata.org/entity/Q929485>,
+    <http://vocab.belgif.be/auth/refnis1995/13046>, <http://vocab.belgif.be/auth/refnis2025/13046> .
+
+<http://vocab.belgif.be/auth/refnis2019/13049> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/13000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "13049";
+  skos:prefLabel "Westerlo"@de, "Westerlo"@fr, "Westerlo"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2783802/>, <http://www.wikidata.org/entity/Q475931>,
+    <http://vocab.belgif.be/auth/refnis1995/13049>, <http://vocab.belgif.be/auth/refnis2025/13049> .
+
+<http://vocab.belgif.be/auth/refnis2019/13053> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/13000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "13053";
+  skos:prefLabel "Laakdal"@de, "Laakdal"@fr, "Laakdal"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2784365/>, <http://www.wikidata.org/entity/Q725122>,
+    <http://vocab.belgif.be/auth/refnis1995/13053>, <http://vocab.belgif.be/auth/refnis2025/13053> .
+
+<http://vocab.belgif.be/auth/refnis2019/21001> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/21000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "21001";
+  skos:prefLabel "Anderlecht"@de, "Anderlecht"@fr, "Anderlecht"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2803202/>, <http://www.wikidata.org/entity/Q12886>,
+    <http://vocab.belgif.be/auth/refnis1995/21001>, <http://vocab.belgif.be/auth/refnis2025/21001> .
+
+<http://vocab.belgif.be/auth/refnis2019/21002> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/21000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "21002";
+  skos:prefLabel "Auderghem"@de, "Auderghem"@fr, "Oudergem"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2802961/>, <http://www.wikidata.org/entity/Q272228>,
+    <http://vocab.belgif.be/auth/refnis1995/21002>, <http://vocab.belgif.be/auth/refnis2025/21002> .
+
+<http://vocab.belgif.be/auth/refnis2019/21003> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/21000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "21003";
+  skos:prefLabel "Berchem-Sainte-Agathe"@de, "Berchem-Sainte-Agathe"@fr, "Sint-Agatha-Berchem"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2802248/>, <http://www.wikidata.org/entity/Q272272>,
+    <http://vocab.belgif.be/auth/refnis1995/21003>, <http://vocab.belgif.be/auth/refnis2025/21003> .
+
+<http://vocab.belgif.be/auth/refnis2019/21004> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/21000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "21004";
+  skos:prefLabel "Brüssel"@de, "Bruxelles"@fr, "Brussel"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/3337389/>, <http://www.wikidata.org/entity/Q239>,
+    <http://vocab.belgif.be/auth/refnis1995/21004>, <http://vocab.belgif.be/auth/refnis2025/21004> .
+
+<http://vocab.belgif.be/auth/refnis2019/21005> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/21000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "21005";
+  skos:prefLabel "Etterbeek"@de, "Etterbeek"@fr, "Etterbeek"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2798579/>, <http://www.wikidata.org/entity/Q192859>,
+    <http://vocab.belgif.be/auth/refnis1995/21005>, <http://vocab.belgif.be/auth/refnis2025/21005> .
+
+<http://vocab.belgif.be/auth/refnis2019/21006> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/21000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "21006";
+  skos:prefLabel "Evere"@de, "Evere"@fr, "Evere"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2798555/>, <http://www.wikidata.org/entity/Q321718>,
+    <http://vocab.belgif.be/auth/refnis1995/21006>, <http://vocab.belgif.be/auth/refnis2025/21006> .
+
+<http://vocab.belgif.be/auth/refnis2019/21007> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/21000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "21007";
+  skos:prefLabel "Forest"@de, "Forest"@fr, "Vorst"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2798142/>, <http://www.wikidata.org/entity/Q72946>,
+    <http://vocab.belgif.be/auth/refnis1995/21007>, <http://vocab.belgif.be/auth/refnis2025/21007> .
+
+<http://vocab.belgif.be/auth/refnis2019/21008> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/21000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "21008";
+  skos:prefLabel "Ganshoren"@de, "Ganshoren"@fr, "Ganshoren"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2797845/>, <http://www.wikidata.org/entity/Q366552>,
+    <http://vocab.belgif.be/auth/refnis1995/21008>, <http://vocab.belgif.be/auth/refnis2025/21008> .
+
+<http://vocab.belgif.be/auth/refnis2019/21009> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/21000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "21009";
+  skos:prefLabel "Ixelles"@de, "Ixelles"@fr, "Elsene"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2795012/>, <http://www.wikidata.org/entity/Q208713>,
+    <http://vocab.belgif.be/auth/refnis1995/21009>, <http://vocab.belgif.be/auth/refnis2025/21009> .
+
+<http://vocab.belgif.be/auth/refnis2019/21010> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/21000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "21010";
+  skos:prefLabel "Jette"@de, "Jette"@fr, "Jette"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2794915/>, <http://www.wikidata.org/entity/Q241918>,
+    <http://vocab.belgif.be/auth/refnis1995/21010>, <http://vocab.belgif.be/auth/refnis2025/21010> .
+
+<http://vocab.belgif.be/auth/refnis2019/21011> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/21000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "21011";
+  skos:prefLabel "Koekelberg"@de, "Koekelberg"@fr, "Koekelberg"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2794192/>, <http://www.wikidata.org/entity/Q219244>,
+    <http://vocab.belgif.be/auth/refnis1995/21011>, <http://vocab.belgif.be/auth/refnis2025/21011> .
+
+<http://vocab.belgif.be/auth/refnis2019/21012> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/21000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "21012";
+  skos:prefLabel "Molenbeek-Saint-Jean"@de, "Molenbeek-Saint-Jean"@fr, "Sint-Jans-Molenbeek"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2791019/>, <http://www.wikidata.org/entity/Q180775>,
+    <http://vocab.belgif.be/auth/refnis1995/21012>, <http://vocab.belgif.be/auth/refnis2025/21012> .
+
+<http://vocab.belgif.be/auth/refnis2019/21013> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/21000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "21013";
+  skos:prefLabel "Saint-Gilles"@de, "Saint-Gilles"@fr, "Sint-Gillis"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2787415/>, <http://www.wikidata.org/entity/Q237674>,
+    <http://vocab.belgif.be/auth/refnis1995/21013>, <http://vocab.belgif.be/auth/refnis2025/21013> .
+
+<http://vocab.belgif.be/auth/refnis2019/21014> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/21000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "21014";
+  skos:prefLabel "Saint-Josse-ten-Noode"@de, "Saint-Josse-ten-Noode"@fr, "Sint-Joost-ten-Node"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2787388/>, <http://www.wikidata.org/entity/Q272243>,
+    <http://vocab.belgif.be/auth/refnis1995/21014>, <http://vocab.belgif.be/auth/refnis2025/21014> .
+
+<http://vocab.belgif.be/auth/refnis2019/21015> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/21000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "21015";
+  skos:prefLabel "Schaerbeek"@de, "Schaerbeek"@fr, "Schaarbeek"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2787150/>, <http://www.wikidata.org/entity/Q12887>,
+    <http://vocab.belgif.be/auth/refnis1995/21015>, <http://vocab.belgif.be/auth/refnis2025/21015> .
+
+<http://vocab.belgif.be/auth/refnis2019/21016> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/21000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "21016";
+  skos:prefLabel "Uccle"@de, "Uccle"@fr, "Ukkel"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2785124/>, <http://www.wikidata.org/entity/Q203312>,
+    <http://vocab.belgif.be/auth/refnis1995/21016>, <http://vocab.belgif.be/auth/refnis2025/21016> .
+
+<http://vocab.belgif.be/auth/refnis2019/21017> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/21000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "21017";
+  skos:prefLabel "Watermael-Boitsfort"@de, "Watermael-Boitsfort"@fr, "Watermaal-Bosvoorde"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2783980/>, <http://www.wikidata.org/entity/Q272262>,
+    <http://vocab.belgif.be/auth/refnis1995/21017>, <http://vocab.belgif.be/auth/refnis2025/21017> .
+
+<http://vocab.belgif.be/auth/refnis2019/21018> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/21000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "21018";
+  skos:prefLabel "Woluwe-Saint-Lambert"@de, "Woluwe-Saint-Lambert"@fr, "Sint-Lambrechts-Woluwe"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2783477/>, <http://www.wikidata.org/entity/Q211764>,
+    <http://vocab.belgif.be/auth/refnis1995/21018>, <http://vocab.belgif.be/auth/refnis2025/21018> .
+
+<http://vocab.belgif.be/auth/refnis2019/21019> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/21000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "21019";
+  skos:prefLabel "Woluwe-Saint-Pierre"@de, "Woluwe-Saint-Pierre"@fr, "Sint-Pieters-Woluwe"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2783475/>, <http://www.wikidata.org/entity/Q242393>,
+    <http://vocab.belgif.be/auth/refnis1995/21019>, <http://vocab.belgif.be/auth/refnis2025/21019> .
+
+<http://vocab.belgif.be/auth/refnis2019/23002> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/23000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "23002";
+  skos:prefLabel "Asse"@de, "Asse"@fr, "Asse"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2803035/>, <http://www.wikidata.org/entity/Q515710>,
+    <http://vocab.belgif.be/auth/refnis1995/23002>, <http://vocab.belgif.be/auth/refnis2025/23002> .
+
+<http://vocab.belgif.be/auth/refnis2019/23003> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/23000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "23003";
+  skos:prefLabel "Beersel"@de, "Beersel"@fr, "Beersel"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2802434/>, <http://www.wikidata.org/entity/Q692168>,
+    <http://vocab.belgif.be/auth/refnis1995/23003>, <http://vocab.belgif.be/auth/refnis2025/23003> .
+
+<http://vocab.belgif.be/auth/refnis2019/23009> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/23000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "23009";
+  skos:prefLabel "Bever"@de, "Biévène"@fr, "Bever"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2801951/>, <http://www.wikidata.org/entity/Q839017>,
+    <http://vocab.belgif.be/auth/refnis1995/23009>, <http://vocab.belgif.be/auth/refnis2025/23009> .
+
+<http://vocab.belgif.be/auth/refnis2019/23016> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/23000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "23016";
+  skos:prefLabel "Dilbeek"@de, "Dilbeek"@fr, "Dilbeek"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2799366/>, <http://www.wikidata.org/entity/Q641134>,
+    <http://vocab.belgif.be/auth/refnis1995/23016>, <http://vocab.belgif.be/auth/refnis2025/23016> .
+
+<http://vocab.belgif.be/auth/refnis2019/23023> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/23000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "23023";
+  skos:prefLabel "Galmaarden"@de, "Gammerages"@fr, "Galmaarden"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "2025-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2797852/>, <http://www.wikidata.org/entity/Q908554>,
+    <http://vocab.belgif.be/auth/refnis1995/23023>;
+  skos:broadMatch <http://vocab.belgif.be/auth/refnis2025/23106> .
+
+<http://vocab.belgif.be/auth/refnis2019/23024> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/23000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "23024";
+  skos:prefLabel "Gooik"@de, "Gooik"@fr, "Gooik"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "2025-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2797418/>, <http://www.wikidata.org/entity/Q912014>,
+    <http://vocab.belgif.be/auth/refnis1995/23024>;
+  skos:broadMatch <http://vocab.belgif.be/auth/refnis2025/23106> .
+
+<http://vocab.belgif.be/auth/refnis2019/23025> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/23000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "23025";
+  skos:prefLabel "Grimbergen"@de, "Grimbergen"@fr, "Grimbergen"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2797115/>, <http://www.wikidata.org/entity/Q633063>,
+    <http://vocab.belgif.be/auth/refnis1995/23025>, <http://vocab.belgif.be/auth/refnis2025/23025> .
+
+<http://vocab.belgif.be/auth/refnis2019/23027> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/23000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "23027";
+  skos:prefLabel "Halle"@de, "Hal"@fr, "Halle"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2796697/>, <http://www.wikidata.org/entity/Q210003>,
+    <http://vocab.belgif.be/auth/refnis1995/23027>, <http://vocab.belgif.be/auth/refnis2025/23027> .
+
+<http://vocab.belgif.be/auth/refnis2019/23032> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/23000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "23032";
+  skos:prefLabel "Herne"@de, "Herne"@fr, "Herne"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "2025-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2795957/>, <http://www.wikidata.org/entity/Q567808>,
+    <http://vocab.belgif.be/auth/refnis1995/23032>;
+  skos:broadMatch <http://vocab.belgif.be/auth/refnis2025/23106> .
+
+<http://vocab.belgif.be/auth/refnis2019/23033> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/23000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "23033";
+  skos:prefLabel "Hoeilaart"@de, "Hoeilaart"@fr, "Hoeilaart"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2795700/>, <http://www.wikidata.org/entity/Q641278>,
+    <http://vocab.belgif.be/auth/refnis1995/23033>, <http://vocab.belgif.be/auth/refnis2025/23033> .
+
+<http://vocab.belgif.be/auth/refnis2019/23038> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/23000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "23038";
+  skos:prefLabel "Kampenhout"@de, "Kampenhout"@fr, "Kampenhout"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2794764/>, <http://www.wikidata.org/entity/Q492453>,
+    <http://vocab.belgif.be/auth/refnis1995/23038>, <http://vocab.belgif.be/auth/refnis2025/23038> .
+
+<http://vocab.belgif.be/auth/refnis2019/23039> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/23000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "23039";
+  skos:prefLabel "Kapelle-op-den-Bos"@de, "Kapelle-op-den-Bos"@fr, "Kapelle-op-den-Bos"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2794725/>, <http://www.wikidata.org/entity/Q911995>,
+    <http://vocab.belgif.be/auth/refnis1995/23039>, <http://vocab.belgif.be/auth/refnis2025/23039> .
+
+<http://vocab.belgif.be/auth/refnis2019/23044> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/23000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "23044";
+  skos:prefLabel "Liedekerke"@de, "Liedekerke"@fr, "Liedekerke"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2792424/>, <http://www.wikidata.org/entity/Q818621>,
+    <http://vocab.belgif.be/auth/refnis1995/23044>, <http://vocab.belgif.be/auth/refnis2025/23044> .
+
+<http://vocab.belgif.be/auth/refnis2019/23045> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/23000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "23045";
+  skos:prefLabel "Londerzeel"@de, "Londerzeel"@fr, "Londerzeel"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2792166/>, <http://www.wikidata.org/entity/Q587819>,
+    <http://vocab.belgif.be/auth/refnis1995/23045>, <http://vocab.belgif.be/auth/refnis2025/23045> .
+
+<http://vocab.belgif.be/auth/refnis2019/23047> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/23000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "23047";
+  skos:prefLabel "Machelen"@de, "Machelen"@fr, "Machelen"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2791953/>, <http://www.wikidata.org/entity/Q752115>,
+    <http://vocab.belgif.be/auth/refnis1995/23047>, <http://vocab.belgif.be/auth/refnis2025/23047> .
+
+<http://vocab.belgif.be/auth/refnis2019/23050> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/23000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "23050";
+  skos:prefLabel "Meise"@de, "Meise"@fr, "Meise"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2791425/>, <http://www.wikidata.org/entity/Q922260>,
+    <http://vocab.belgif.be/auth/refnis1995/23050>, <http://vocab.belgif.be/auth/refnis2025/23050> .
+
+<http://vocab.belgif.be/auth/refnis2019/23052> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/23000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "23052";
+  skos:prefLabel "Merchtem"@de, "Merchtem"@fr, "Merchtem"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2791324/>, <http://www.wikidata.org/entity/Q912106>,
+    <http://vocab.belgif.be/auth/refnis1995/23052>, <http://vocab.belgif.be/auth/refnis2025/23052> .
+
+<http://vocab.belgif.be/auth/refnis2019/23060> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/23000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "23060";
+  skos:prefLabel "Opwijk"@de, "Opwijk"@fr, "Opwijk"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2789655/>, <http://www.wikidata.org/entity/Q930292>,
+    <http://vocab.belgif.be/auth/refnis1995/23060>, <http://vocab.belgif.be/auth/refnis2025/23060> .
+
+<http://vocab.belgif.be/auth/refnis2019/23062> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/23000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "23062";
+  skos:prefLabel "Overijse"@de, "Overijse"@fr, "Overijse"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2789414/>, <http://www.wikidata.org/entity/Q599127>,
+    <http://vocab.belgif.be/auth/refnis1995/23062>, <http://vocab.belgif.be/auth/refnis2025/23062> .
+
+<http://vocab.belgif.be/auth/refnis2019/23064> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/23000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "23064";
+  skos:prefLabel "Pepingen"@de, "Pepingen"@fr, "Pepingen"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2789193/>, <http://www.wikidata.org/entity/Q646037>,
+    <http://vocab.belgif.be/auth/refnis1995/23064>, <http://vocab.belgif.be/auth/refnis2025/23064> .
+
+<http://vocab.belgif.be/auth/refnis2019/23077> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/23000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "23077";
+  skos:prefLabel "Sint-Pieters-Leeuw"@de, "Sint-Pieters-Leeuw"@fr, "Sint-Pieters-Leeuw"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2786560/>, <http://www.wikidata.org/entity/Q688790>,
+    <http://vocab.belgif.be/auth/refnis1995/23077>, <http://vocab.belgif.be/auth/refnis2025/23077> .
+
+<http://vocab.belgif.be/auth/refnis2019/23081> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/23000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "23081";
+  skos:prefLabel "Steenokkerzeel"@de, "Steenokkerzeel"@fr, "Steenokkerzeel"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2786125/>, <http://www.wikidata.org/entity/Q984888>,
+    <http://vocab.belgif.be/auth/refnis1995/23081>, <http://vocab.belgif.be/auth/refnis2025/23081> .
+
+<http://vocab.belgif.be/auth/refnis2019/23086> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/23000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "23086";
+  skos:prefLabel "Ternat"@de, "Ternat"@fr, "Ternat"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2785656/>, <http://www.wikidata.org/entity/Q930249>,
+    <http://vocab.belgif.be/auth/refnis1995/23086>, <http://vocab.belgif.be/auth/refnis2025/23086> .
+
+<http://vocab.belgif.be/auth/refnis2019/23088> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/23000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "23088";
+  skos:prefLabel "Vilvoorde"@de, "Vilvorde"@fr, "Vilvoorde"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2784605/>, <http://www.wikidata.org/entity/Q318418>,
+    <http://vocab.belgif.be/auth/refnis1995/23088>, <http://vocab.belgif.be/auth/refnis2025/23088> .
+
+<http://vocab.belgif.be/auth/refnis2019/23094> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/23000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "23094";
+  skos:prefLabel "Zaventem"@de, "Zaventem"@fr, "Zaventem"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2783311/>, <http://www.wikidata.org/entity/Q28898>,
+    <http://vocab.belgif.be/auth/refnis1995/23094>, <http://vocab.belgif.be/auth/refnis2025/23094> .
+
+<http://vocab.belgif.be/auth/refnis2019/23096> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/23000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "23096";
+  skos:prefLabel "Zemst"@de, "Zemst"@fr, "Zemst"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2783275/>, <http://www.wikidata.org/entity/Q179249>,
+    <http://vocab.belgif.be/auth/refnis1995/23096>, <http://vocab.belgif.be/auth/refnis2025/23096> .
+
+<http://vocab.belgif.be/auth/refnis2019/23097> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/23000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "23097";
+  skos:prefLabel "Roosdaal"@de, "Roosdaal"@fr, "Roosdaal"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2789347/>, <http://www.wikidata.org/entity/Q936660>,
+    <http://vocab.belgif.be/auth/refnis1995/23097>, <http://vocab.belgif.be/auth/refnis2025/23097> .
+
+<http://vocab.belgif.be/auth/refnis2019/23098> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/23000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "23098";
+  skos:prefLabel "Drogenbos"@de, "Drogenbos"@fr, "Drogenbos"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2799115/>, <http://www.wikidata.org/entity/Q688377>,
+    <http://vocab.belgif.be/auth/refnis1995/23098>, <http://vocab.belgif.be/auth/refnis2025/23098> .
+
+<http://vocab.belgif.be/auth/refnis2019/23099> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/23000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "23099";
+  skos:prefLabel "Kraainem"@de, "Kraainem"@fr, "Kraainem"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2794017/>, <http://www.wikidata.org/entity/Q839023>,
+    <http://vocab.belgif.be/auth/refnis1995/23099>, <http://vocab.belgif.be/auth/refnis2025/23099> .
+
+<http://vocab.belgif.be/auth/refnis2019/23100> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/23000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "23100";
+  skos:prefLabel "Linkebeek"@de, "Linkebeek"@fr, "Linkebeek"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2792302/>, <http://www.wikidata.org/entity/Q631639>,
+    <http://vocab.belgif.be/auth/refnis1995/23100>, <http://vocab.belgif.be/auth/refnis2025/23100> .
+
+<http://vocab.belgif.be/auth/refnis2019/23101> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/23000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "23101";
+  skos:prefLabel "Sint-Genesius-Rode"@de, "Rhode-Saint-Genèse"@fr, "Sint-Genesius-Rode"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2786701/>, <http://www.wikidata.org/entity/Q841597>,
+    <http://vocab.belgif.be/auth/refnis1995/23101>, <http://vocab.belgif.be/auth/refnis2025/23101> .
+
+<http://vocab.belgif.be/auth/refnis2019/23102> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/23000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "23102";
+  skos:prefLabel "Wemmel"@de, "Wemmel"@fr, "Wemmel"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2783857/>, <http://www.wikidata.org/entity/Q913195>,
+    <http://vocab.belgif.be/auth/refnis1995/23102>, <http://vocab.belgif.be/auth/refnis2025/23102> .
+
+<http://vocab.belgif.be/auth/refnis2019/23103> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/23000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "23103";
+  skos:prefLabel "Wezembeek-Oppem"@de, "Wezembeek-Oppem"@fr, "Wezembeek-Oppem"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2783738/>, <http://www.wikidata.org/entity/Q912091>,
+    <http://vocab.belgif.be/auth/refnis1995/23103>, <http://vocab.belgif.be/auth/refnis2025/23103> .
+
+<http://vocab.belgif.be/auth/refnis2019/23104> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/23000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "23104";
+  skos:prefLabel "Lennik"@de, "Lennik"@fr, "Lennik"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2786588/>, <http://www.wikidata.org/entity/Q912022>,
+    <http://vocab.belgif.be/auth/refnis1995/23104>, <http://vocab.belgif.be/auth/refnis2025/23104> .
+
+<http://vocab.belgif.be/auth/refnis2019/23105> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/23000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "23105";
+  skos:prefLabel "Affligem"@de, "Affligem"@fr, "Affligem"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2798612/>, <http://www.wikidata.org/entity/Q382860>,
+    <http://vocab.belgif.be/auth/refnis1995/23105>, <http://vocab.belgif.be/auth/refnis2025/23105> .
+
+<http://vocab.belgif.be/auth/refnis2019/24001> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/24000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "24001";
+  skos:prefLabel "Aarschot"@de, "Aarschot"@fr, "Aarschot"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2803430/>, <http://www.wikidata.org/entity/Q273442>,
+    <http://vocab.belgif.be/auth/refnis1995/24001>, <http://vocab.belgif.be/auth/refnis2025/24001> .
+
+<http://vocab.belgif.be/auth/refnis2019/24007> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/24000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "24007";
+  skos:prefLabel "Begijnendijk"@de, "Begijnendijk"@fr, "Begijnendijk"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2802406/>, <http://www.wikidata.org/entity/Q432610>,
+    <http://vocab.belgif.be/auth/refnis1995/24007>, <http://vocab.belgif.be/auth/refnis2025/24007> .
+
+<http://vocab.belgif.be/auth/refnis2019/24008> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/24000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "24008";
+  skos:prefLabel "Bekkevoort"@de, "Bekkevoort"@fr, "Bekkevoort"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2802375/>, <http://www.wikidata.org/entity/Q815054>,
+    <http://vocab.belgif.be/auth/refnis1995/24008>, <http://vocab.belgif.be/auth/refnis2025/24008> .
+
+<http://vocab.belgif.be/auth/refnis2019/24009> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/24000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "24009";
+  skos:prefLabel "Bertem"@de, "Bertem"@fr, "Bertem"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2802124/>, <http://www.wikidata.org/entity/Q827665>,
+    <http://vocab.belgif.be/auth/refnis1995/24009>, <http://vocab.belgif.be/auth/refnis2025/24009> .
+
+<http://vocab.belgif.be/auth/refnis2019/24011> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/24000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "24011";
+  skos:prefLabel "Bierbeek"@de, "Bierbeek"@fr, "Bierbeek"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2801999/>, <http://www.wikidata.org/entity/Q729929>,
+    <http://vocab.belgif.be/auth/refnis1995/24011>, <http://vocab.belgif.be/auth/refnis2025/24011> .
+
+<http://vocab.belgif.be/auth/refnis2019/24014> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/24000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "24014";
+  skos:prefLabel "Boortmeerbeek"@de, "Boortmeerbeek"@fr, "Boortmeerbeek"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2801484/>, <http://www.wikidata.org/entity/Q746078>,
+    <http://vocab.belgif.be/auth/refnis1995/24014>, <http://vocab.belgif.be/auth/refnis2025/24014> .
+
+<http://vocab.belgif.be/auth/refnis2019/24016> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/24000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "24016";
+  skos:prefLabel "Boutersem"@de, "Boutersem"@fr, "Boutersem"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2801216/>, <http://www.wikidata.org/entity/Q895293>,
+    <http://vocab.belgif.be/auth/refnis1995/24016>, <http://vocab.belgif.be/auth/refnis2025/24016> .
+
+<http://vocab.belgif.be/auth/refnis2019/24020> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/24000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "24020";
+  skos:prefLabel "Diest"@de, "Diest"@fr, "Diest"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2799398/>, <http://www.wikidata.org/entity/Q743236>,
+    <http://vocab.belgif.be/auth/refnis1995/24020>, <http://vocab.belgif.be/auth/refnis2025/24020> .
+
+<http://vocab.belgif.be/auth/refnis2019/24028> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/24000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "24028";
+  skos:prefLabel "Geetbets"@de, "Geetbets"@fr, "Geetbets"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2797762/>, <http://www.wikidata.org/entity/Q984874>,
+    <http://vocab.belgif.be/auth/refnis1995/24028>, <http://vocab.belgif.be/auth/refnis2025/24028> .
+
+<http://vocab.belgif.be/auth/refnis2019/24033> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/24000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "24033";
+  skos:prefLabel "Haacht"@de, "Haacht"@fr, "Haacht"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2796845/>, <http://www.wikidata.org/entity/Q950129>,
+    <http://vocab.belgif.be/auth/refnis1995/24033>, <http://vocab.belgif.be/auth/refnis2025/24033> .
+
+<http://vocab.belgif.be/auth/refnis2019/24038> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/24000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "24038";
+  skos:prefLabel "Herent"@de, "Herent"@fr, "Herent"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2796013/>, <http://www.wikidata.org/entity/Q930269>,
+    <http://vocab.belgif.be/auth/refnis1995/24038>, <http://vocab.belgif.be/auth/refnis2025/24038> .
+
+<http://vocab.belgif.be/auth/refnis2019/24041> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/24000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "24041";
+  skos:prefLabel "Hoegaarden"@de, "Hoegaarden"@fr, "Hoegaarden"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2795704/>, <http://www.wikidata.org/entity/Q818787>,
+    <http://vocab.belgif.be/auth/refnis1995/24041>, <http://vocab.belgif.be/auth/refnis2025/24041> .
+
+<http://vocab.belgif.be/auth/refnis2019/24043> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/24000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "24043";
+  skos:prefLabel "Holsbeek"@de, "Holsbeek"@fr, "Holsbeek"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2795512/>, <http://www.wikidata.org/entity/Q676893>,
+    <http://vocab.belgif.be/auth/refnis1995/24043>, <http://vocab.belgif.be/auth/refnis2025/24043> .
+
+<http://vocab.belgif.be/auth/refnis2019/24045> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/24000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "24045";
+  skos:prefLabel "Huldenberg"@de, "Huldenberg"@fr, "Huldenberg"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2795185/>, <http://www.wikidata.org/entity/Q943472>,
+    <http://vocab.belgif.be/auth/refnis1995/24045>, <http://vocab.belgif.be/auth/refnis2025/24045> .
+
+<http://vocab.belgif.be/auth/refnis2019/24048> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/24000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "24048";
+  skos:prefLabel "Keerbergen"@de, "Keerbergen"@fr, "Keerbergen"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2794620/>, <http://www.wikidata.org/entity/Q984894>,
+    <http://vocab.belgif.be/auth/refnis1995/24048>, <http://vocab.belgif.be/auth/refnis2025/24048> .
+
+<http://vocab.belgif.be/auth/refnis2019/24054> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/24000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "24054";
+  skos:prefLabel "Kortenaken"@de, "Kortenaken"@fr, "Kortenaken"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2794073/>, <http://www.wikidata.org/entity/Q984877>,
+    <http://vocab.belgif.be/auth/refnis1995/24054>, <http://vocab.belgif.be/auth/refnis2025/24054> .
+
+<http://vocab.belgif.be/auth/refnis2019/24055> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/24000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "24055";
+  skos:prefLabel "Kortenberg"@de, "Kortenberg"@fr, "Kortenberg"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2794071/>, <http://www.wikidata.org/entity/Q929474>,
+    <http://vocab.belgif.be/auth/refnis1995/24055>, <http://vocab.belgif.be/auth/refnis2025/24055> .
+
+<http://vocab.belgif.be/auth/refnis2019/24059> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/24000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "24059";
+  skos:prefLabel "Landen"@de, "Landen"@fr, "Landen"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2793430/>, <http://www.wikidata.org/entity/Q943502>,
+    <http://vocab.belgif.be/auth/refnis1995/24059>, <http://vocab.belgif.be/auth/refnis2025/24059> .
+
+<http://vocab.belgif.be/auth/refnis2019/24062> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/24000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "24062";
+  skos:prefLabel "Löwen"@de, "Louvain"@fr, "Leuven"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2792483/>, <http://www.wikidata.org/wiki/Q118958>,
+    <http://vocab.belgif.be/auth/refnis1995/24062>, <http://vocab.belgif.be/auth/refnis2025/24062> .
+
+<http://vocab.belgif.be/auth/refnis2019/24066> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/24000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "24066";
+  skos:prefLabel "Lubbeek"@de, "Lubbeek"@fr, "Lubbeek"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2792035/>, <http://www.wikidata.org/entity/Q929447>,
+    <http://vocab.belgif.be/auth/refnis1995/24066>, <http://vocab.belgif.be/auth/refnis2025/24066> .
+
+<http://vocab.belgif.be/auth/refnis2019/24086> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/24000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "24086";
+  skos:prefLabel "Oud-Heverlee"@de, "Oud-Heverlee"@fr, "Oud-Heverlee"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2789493/>, <http://www.wikidata.org/entity/Q746641>,
+    <http://vocab.belgif.be/auth/refnis1995/24086>, <http://vocab.belgif.be/auth/refnis2025/24086> .
+
+<http://vocab.belgif.be/auth/refnis2019/24094> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/24000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "24094";
+  skos:prefLabel "Rotselaar"@de, "Rotselaar"@fr, "Rotselaar"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2787663/>, <http://www.wikidata.org/entity/Q926139>,
+    <http://vocab.belgif.be/auth/refnis1995/24094>, <http://vocab.belgif.be/auth/refnis2025/24094> .
+
+<http://vocab.belgif.be/auth/refnis2019/24104> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/24000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "24104";
+  skos:prefLabel "Tervuren"@de, "Tervuren"@fr, "Tervuren"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2785623/>, <http://www.wikidata.org/entity/Q456544>,
+    <http://vocab.belgif.be/auth/refnis1995/24104>, <http://vocab.belgif.be/auth/refnis2025/24104> .
+
+<http://vocab.belgif.be/auth/refnis2019/24107> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/24000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "24107";
+  skos:prefLabel "Tienen"@de, "Tirlemont"@fr, "Tienen"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2785471/>, <http://www.wikidata.org/entity/Q456550>,
+    <http://vocab.belgif.be/auth/refnis1995/24107>, <http://vocab.belgif.be/auth/refnis2025/24107> .
+
+<http://vocab.belgif.be/auth/refnis2019/24109> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/24000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "24109";
+  skos:prefLabel "Tremelo"@de, "Tremelo"@fr, "Tremelo"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2785294/>, <http://www.wikidata.org/entity/Q926110>,
+    <http://vocab.belgif.be/auth/refnis1995/24109>, <http://vocab.belgif.be/auth/refnis2025/24109> .
+
+<http://vocab.belgif.be/auth/refnis2019/24130> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/24000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "24130";
+  skos:prefLabel "Zoutleeuw"@de, "Léau"@fr, "Zoutleeuw"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2783171/>, <http://www.wikidata.org/entity/Q227070>,
+    <http://vocab.belgif.be/auth/refnis1995/24130>, <http://vocab.belgif.be/auth/refnis2025/24130> .
+
+<http://vocab.belgif.be/auth/refnis2019/24133> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/24000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "24133";
+  skos:prefLabel "Linter"@de, "Linter"@fr, "Linter"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2791389/>, <http://www.wikidata.org/entity/Q984881>,
+    <http://vocab.belgif.be/auth/refnis1995/24133>, <http://vocab.belgif.be/auth/refnis2025/24133> .
+
+<http://vocab.belgif.be/auth/refnis2019/24134> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/24000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "24134";
+  skos:prefLabel "Scherpenheuvel-Zichem"@de, "Montaigu-Zichem"@fr, "Scherpenheuvel-Zichem"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2787061/>, <http://www.wikidata.org/entity/Q932020>,
+    <http://vocab.belgif.be/auth/refnis1995/24134>, <http://vocab.belgif.be/auth/refnis2025/24134> .
+
+<http://vocab.belgif.be/auth/refnis2019/24135> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/24000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "24135";
+  skos:prefLabel "Tielt-Winge"@de, "Tielt-Winge"@fr, "Tielt-Winge"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2785479/>, <http://www.wikidata.org/entity/Q984892>,
+    <http://vocab.belgif.be/auth/refnis1995/24135>, <http://vocab.belgif.be/auth/refnis2025/24135> .
+
+<http://vocab.belgif.be/auth/refnis2019/24137> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/24000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "24137";
+  skos:prefLabel "Glabbeek"@de, "Glabbeek"@fr, "Glabbeek"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2797501/>, <http://www.wikidata.org/entity/Q984868>,
+    <http://vocab.belgif.be/auth/refnis1995/24137>, <http://vocab.belgif.be/auth/refnis2025/24137> .
+
+<http://vocab.belgif.be/auth/refnis2019/25005> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/25000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "25005";
+  skos:prefLabel "Beauvechain"@de, "Beauvechain"@fr, "Bevekom"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2802484/>, <http://www.wikidata.org/entity/Q276266>,
+    <http://vocab.belgif.be/auth/refnis1995/25005>, <http://vocab.belgif.be/auth/refnis2025/25005> .
+
+<http://vocab.belgif.be/auth/refnis2019/25014> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/25000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "25014";
+  skos:prefLabel "Braine-l’Alleud"@de, "Braine-l’Alleud"@fr, "Eigenbrakel"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2801155/>, <http://www.wikidata.org/entity/Q497572>,
+    <http://vocab.belgif.be/auth/refnis1995/25014>, <http://vocab.belgif.be/auth/refnis2025/25014> .
+
+<http://vocab.belgif.be/auth/refnis2019/25015> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/25000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "25015";
+  skos:prefLabel "Braine-le-Château"@de, "Braine-le-Château"@fr, "Kasteelbrakel"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2801153/>, <http://www.wikidata.org/entity/Q497558>,
+    <http://vocab.belgif.be/auth/refnis1995/25015>, <http://vocab.belgif.be/auth/refnis2025/25015> .
+
+<http://vocab.belgif.be/auth/refnis2019/25018> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/25000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "25018";
+  skos:prefLabel "Chaumont-Gistoux"@de, "Chaumont-Gistoux"@fr, "Chaumont-Gistoux"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2800431/>, <http://www.wikidata.org/entity/Q670141>,
+    <http://vocab.belgif.be/auth/refnis1995/25018>, <http://vocab.belgif.be/auth/refnis2025/25018> .
+
+<http://vocab.belgif.be/auth/refnis2019/25023> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/25000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "25023";
+  skos:prefLabel "Court-Saint-Etienne"@de, "Court-Saint-Etienne"@fr, "Court-Saint-Etienne"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2800043/>, <http://www.wikidata.org/entity/Q670210>,
+    <http://vocab.belgif.be/auth/refnis1995/25023>, <http://vocab.belgif.be/auth/refnis2025/25023> .
+
+<http://vocab.belgif.be/auth/refnis2019/25031> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/25000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "25031";
+  skos:prefLabel "Genappe"@de, "Genappe"@fr, "Genepiën"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2797695/>, <http://www.wikidata.org/entity/Q517899>,
+    <http://vocab.belgif.be/auth/refnis1995/25031>, <http://vocab.belgif.be/auth/refnis2025/25031> .
+
+<http://vocab.belgif.be/auth/refnis2019/25037> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/25000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "25037";
+  skos:prefLabel "Grez-Doiceau"@de, "Grez-Doiceau"@fr, "Graven"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2797129/>, <http://www.wikidata.org/entity/Q670310>,
+    <http://vocab.belgif.be/auth/refnis1995/25037>, <http://vocab.belgif.be/auth/refnis2025/25037> .
+
+<http://vocab.belgif.be/auth/refnis2019/25043> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/25000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "25043";
+  skos:prefLabel "Incourt"@de, "Incourt"@fr, "Incourt"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2795064/>, <http://www.wikidata.org/entity/Q670455>,
+    <http://vocab.belgif.be/auth/refnis1995/25043>, <http://vocab.belgif.be/auth/refnis2025/25043> .
+
+<http://vocab.belgif.be/auth/refnis2019/25044> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/25000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "25044";
+  skos:prefLabel "Ittre"@de, "Ittre"@fr, "Itter"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2795018/>, <http://www.wikidata.org/entity/Q281080>,
+    <http://vocab.belgif.be/auth/refnis1995/25044>, <http://vocab.belgif.be/auth/refnis2025/25044> .
+
+<http://vocab.belgif.be/auth/refnis2019/25048> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/25000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "25048";
+  skos:prefLabel "Jodoigne"@de, "Jodoigne"@fr, "Geldenaken"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2794896/>, <http://www.wikidata.org/entity/Q670500>,
+    <http://vocab.belgif.be/auth/refnis1995/25048>, <http://vocab.belgif.be/auth/refnis2025/25048> .
+
+<http://vocab.belgif.be/auth/refnis2019/25050> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/25000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "25050";
+  skos:prefLabel "La Hulpe"@de, "La Hulpe"@fr, "Terhulpen"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2793549/>, <http://www.wikidata.org/entity/Q670407>,
+    <http://vocab.belgif.be/auth/refnis1995/25050>, <http://vocab.belgif.be/auth/refnis2025/25050> .
+
+<http://vocab.belgif.be/auth/refnis2019/25068> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/25000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "25068";
+  skos:prefLabel "Mont-Saint-Guibert"@de, "Mont-Saint-Guibert"@fr, "Mont-Saint-Guibert"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2790757/>, <http://www.wikidata.org/entity/Q650152>,
+    <http://vocab.belgif.be/auth/refnis1995/25068>, <http://vocab.belgif.be/auth/refnis2025/25068> .
+
+<http://vocab.belgif.be/auth/refnis2019/25072> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/25000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "25072";
+  skos:prefLabel "Nivelles"@de, "Nivelles"@fr, "Nijvel"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2790102/>, <http://www.wikidata.org/entity/Q319463>,
+    <http://vocab.belgif.be/auth/refnis1995/25072>, <http://vocab.belgif.be/auth/refnis2025/25072> .
+
+<http://vocab.belgif.be/auth/refnis2019/25084> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/25000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "25084";
+  skos:prefLabel "Perwez"@de, "Perwez"@fr, "Perwijs"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2789158/>, <http://www.wikidata.org/entity/Q678458>,
+    <http://vocab.belgif.be/auth/refnis1995/25084>, <http://vocab.belgif.be/auth/refnis2025/25084> .
+
+<http://vocab.belgif.be/auth/refnis2019/25091> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/25000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "25091";
+  skos:prefLabel "Rixensart"@de, "Rixensart"@fr, "Rixensart"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2787990/>, <http://www.wikidata.org/entity/Q630478>,
+    <http://vocab.belgif.be/auth/refnis1995/25091>, <http://vocab.belgif.be/auth/refnis2025/25091> .
+
+<http://vocab.belgif.be/auth/refnis2019/25105> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/25000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "25105";
+  skos:prefLabel "Tubize"@de, "Tubize"@fr, "Tubeke"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2785170/>, <http://www.wikidata.org/entity/Q497549>,
+    <http://vocab.belgif.be/auth/refnis1995/25105>, <http://vocab.belgif.be/auth/refnis2025/25105> .
+
+<http://vocab.belgif.be/auth/refnis2019/25107> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/25000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "25107";
+  skos:prefLabel "Villers-la-Ville"@de, "Villers-la-Ville"@fr, "Villers-la-Ville"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2784642/>, <http://www.wikidata.org/entity/Q678612>,
+    <http://vocab.belgif.be/auth/refnis1995/25107>, <http://vocab.belgif.be/auth/refnis2025/25107> .
+
+<http://vocab.belgif.be/auth/refnis2019/25110> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/25000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "25110";
+  skos:prefLabel "Waterloo"@de, "Waterloo"@fr, "Waterloo"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2783986/>, <http://www.wikidata.org/entity/Q179034>,
+    <http://vocab.belgif.be/auth/refnis1995/25110>, <http://vocab.belgif.be/auth/refnis2025/25110> .
+
+<http://vocab.belgif.be/auth/refnis2019/25112> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/25000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "25112";
+  skos:prefLabel "Wavre"@de, "Wavre"@fr, "Waver"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2783942/>, <http://www.wikidata.org/entity/Q181314>,
+    <http://vocab.belgif.be/auth/refnis1995/25112>, <http://vocab.belgif.be/auth/refnis2025/25112> .
+
+<http://vocab.belgif.be/auth/refnis2019/25117> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/25000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "25117";
+  skos:prefLabel "Chastre"@de, "Chastre"@fr, "Chastre"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2800458/>, <http://www.wikidata.org/entity/Q618054>,
+    <http://vocab.belgif.be/auth/refnis1995/25117>, <http://vocab.belgif.be/auth/refnis2025/25117> .
+
+<http://vocab.belgif.be/auth/refnis2019/25118> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/25000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "25118";
+  skos:prefLabel "Hélécine"@de, "Hélécine"@fr, "Hélécine"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2792297/>, <http://www.wikidata.org/entity/Q670355>,
+    <http://vocab.belgif.be/auth/refnis1995/25118>, <http://vocab.belgif.be/auth/refnis2025/25118> .
+
+<http://vocab.belgif.be/auth/refnis2019/25119> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/25000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "25119";
+  skos:prefLabel "Lasne"@de, "Lasne"@fr, "Lasne"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2793248/>, <http://www.wikidata.org/entity/Q678158>,
+    <http://vocab.belgif.be/auth/refnis1995/25119>, <http://vocab.belgif.be/auth/refnis2025/25119> .
+
+<http://vocab.belgif.be/auth/refnis2019/25120> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/25000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "25120";
+  skos:prefLabel "Orp-Jauche"@de, "Orp-Jauche"@fr, "Orp-Jauche"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2789622/>, <http://www.wikidata.org/entity/Q678218>,
+    <http://vocab.belgif.be/auth/refnis1995/25120>, <http://vocab.belgif.be/auth/refnis2025/25120> .
+
+<http://vocab.belgif.be/auth/refnis2019/25121> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/25000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "25121";
+  skos:prefLabel "Ottignies-Louvain-la-Neuve"@de, "Ottignies-Louvain-la-Neuve"@fr, "Ottignies-Louvain-la-Neuve"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2789571/>, <http://www.wikidata.org/entity/Q329642>,
+    <http://vocab.belgif.be/auth/refnis1995/25121>, <http://vocab.belgif.be/auth/refnis2025/25121> .
+
+<http://vocab.belgif.be/auth/refnis2019/25122> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/25000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "25122";
+  skos:prefLabel "Ramillies"@de, "Ramillies"@fr, "Ramillies"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2788382/>, <http://www.wikidata.org/entity/Q531456>,
+    <http://vocab.belgif.be/auth/refnis1995/25122>, <http://vocab.belgif.be/auth/refnis2025/25122> .
+
+<http://vocab.belgif.be/auth/refnis2019/25123> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/25000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "25123";
+  skos:prefLabel "Rebecq"@de, "Rebecq"@fr, "Rebecq"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2788300/>, <http://www.wikidata.org/entity/Q374861>,
+    <http://vocab.belgif.be/auth/refnis1995/25123>, <http://vocab.belgif.be/auth/refnis2025/25123> .
+
+<http://vocab.belgif.be/auth/refnis2019/25124> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/25000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "25124";
+  skos:prefLabel "Walhain"@de, "Walhain"@fr, "Walhain"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2784169/>, <http://www.wikidata.org/entity/Q650216>,
+    <http://vocab.belgif.be/auth/refnis1995/25124>, <http://vocab.belgif.be/auth/refnis2025/25124> .
+
+<http://vocab.belgif.be/auth/refnis2019/31003> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/31000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "31003";
+  skos:prefLabel "Beernem"@de, "Beernem"@fr, "Beernem"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2802438/>, <http://www.wikidata.org/entity/Q687921>,
+    <http://vocab.belgif.be/auth/refnis1995/31003>, <http://vocab.belgif.be/auth/refnis2025/31003> .
+
+<http://vocab.belgif.be/auth/refnis2019/31004> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/31000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "31004";
+  skos:prefLabel "Blankenberge"@de, "Blankenberge"@fr, "Blankenberge"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2801859/>, <http://www.wikidata.org/entity/Q328104>,
+    <http://vocab.belgif.be/auth/refnis1995/31004>, <http://vocab.belgif.be/auth/refnis2025/31004> .
+
+<http://vocab.belgif.be/auth/refnis2019/31005> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/31000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "31005";
+  skos:prefLabel "Brügge"@de, "Bruges"@fr, "Brugge"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2800935/>, <http://www.wikidata.org/entity/Q12994>,
+    <http://vocab.belgif.be/auth/refnis1995/31005>, <http://vocab.belgif.be/auth/refnis2025/31005> .
+
+<http://vocab.belgif.be/auth/refnis2019/31006> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/31000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "31006";
+  skos:prefLabel "Damme"@de, "Damme"@fr, "Damme"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2799886/>, <http://www.wikidata.org/entity/Q323408>,
+    <http://vocab.belgif.be/auth/refnis1995/31006>, <http://vocab.belgif.be/auth/refnis2025/31006> .
+
+<http://vocab.belgif.be/auth/refnis2019/31012> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/31000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "31012";
+  skos:prefLabel "Jabbeke"@de, "Jabbeke"@fr, "Jabbeke"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2795001/>, <http://www.wikidata.org/entity/Q465973>,
+    <http://vocab.belgif.be/auth/refnis1995/31012>, <http://vocab.belgif.be/auth/refnis2025/31012> .
+
+<http://vocab.belgif.be/auth/refnis2019/31022> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/31000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "31022";
+  skos:prefLabel "Oostkamp"@de, "Oostkamp"@fr, "Oostkamp"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2789752/>, <http://www.wikidata.org/entity/Q742892>,
+    <http://vocab.belgif.be/auth/refnis1995/31022>, <http://vocab.belgif.be/auth/refnis2025/31022> .
+
+<http://vocab.belgif.be/auth/refnis2019/31033> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/31000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "31033";
+  skos:prefLabel "Torhout"@de, "Torhout"@fr, "Torhout"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2785365/>, <http://www.wikidata.org/entity/Q270633>,
+    <http://vocab.belgif.be/auth/refnis1995/31033>, <http://vocab.belgif.be/auth/refnis2025/31033> .
+
+<http://vocab.belgif.be/auth/refnis2019/31040> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/31000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "31040";
+  skos:prefLabel "Zedelgem"@de, "Zedelgem"@fr, "Zedelgem"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2783309/>, <http://www.wikidata.org/entity/Q184287>,
+    <http://vocab.belgif.be/auth/refnis1995/31040>, <http://vocab.belgif.be/auth/refnis2025/31040> .
+
+<http://vocab.belgif.be/auth/refnis2019/31042> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/31000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "31042";
+  skos:prefLabel "Zuienkerke"@de, "Zuienkerke"@fr, "Zuienkerke"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2783154/>, <http://www.wikidata.org/entity/Q228685>,
+    <http://vocab.belgif.be/auth/refnis1995/31042>, <http://vocab.belgif.be/auth/refnis2025/31042> .
+
+<http://vocab.belgif.be/auth/refnis2019/31043> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/31000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "31043";
+  skos:prefLabel "Knokke-Heist"@de, "Knokke-Heist"@fr, "Knokke-Heist"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2794216/>, <http://www.wikidata.org/entity/Q12988>,
+    <http://vocab.belgif.be/auth/refnis1995/31043>, <http://vocab.belgif.be/auth/refnis2025/31043> .
+
+<http://vocab.belgif.be/auth/refnis2019/32003> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/32000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "32003";
+  skos:prefLabel "Diksmuide"@de, "Dixmude"@fr, "Diksmuide"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2799370/>, <http://www.wikidata.org/entity/Q215244>,
+    <http://vocab.belgif.be/auth/refnis1995/32003>, <http://vocab.belgif.be/auth/refnis2025/32003> .
+
+<http://vocab.belgif.be/auth/refnis2019/32006> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/32000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "32006";
+  skos:prefLabel "Houthulst"@de, "Houthulst"@fr, "Houthulst"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2795256/>, <http://www.wikidata.org/entity/Q696942>,
+    <http://vocab.belgif.be/auth/refnis1995/32006>, <http://vocab.belgif.be/auth/refnis2025/32006> .
+
+<http://vocab.belgif.be/auth/refnis2019/32010> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/32000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "32010";
+  skos:prefLabel "Koekelare"@de, "Koekelare"@fr, "Koekelare"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2794195/>, <http://www.wikidata.org/entity/Q822795>,
+    <http://vocab.belgif.be/auth/refnis1995/32010>, <http://vocab.belgif.be/auth/refnis2025/32010> .
+
+<http://vocab.belgif.be/auth/refnis2019/32011> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/32000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "32011";
+  skos:prefLabel "Kortemark"@de, "Kortemark"@fr, "Kortemark"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2794075/>, <http://www.wikidata.org/entity/Q822763>,
+    <http://vocab.belgif.be/auth/refnis1995/32011>, <http://vocab.belgif.be/auth/refnis2025/32011> .
+
+<http://vocab.belgif.be/auth/refnis2019/32030> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/32000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "32030";
+  skos:prefLabel "Lo-Reninge"@de, "Lo-Reninge"@fr, "Lo-Reninge"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2788179/>, <http://www.wikidata.org/entity/Q822790>,
+    <http://vocab.belgif.be/auth/refnis1995/32030>, <http://vocab.belgif.be/auth/refnis2025/32030> .
+
+<http://vocab.belgif.be/auth/refnis2019/33011> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/33000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "33011";
+  skos:prefLabel "Ypern"@de, "Ypres"@fr, "Ieper"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2795101/>, <http://www.wikidata.org/entity/Q102728>,
+    <http://vocab.belgif.be/auth/refnis1995/33011>, <http://vocab.belgif.be/auth/refnis2025/33011> .
+
+<http://vocab.belgif.be/auth/refnis2019/33016> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/33000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "33016";
+  skos:prefLabel "Mesen"@de, "Messines"@fr, "Mesen"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2791285/>, <http://www.wikidata.org/entity/Q737077>,
+    <http://vocab.belgif.be/auth/refnis1995/33016>, <http://vocab.belgif.be/auth/refnis2025/33016> .
+
+<http://vocab.belgif.be/auth/refnis2019/33021> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/33000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "33021";
+  skos:prefLabel "Poperinge"@de, "Poperinge"@fr, "Poperinge"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2788727/>, <http://www.wikidata.org/entity/Q499588>,
+    <http://vocab.belgif.be/auth/refnis1995/33021>, <http://vocab.belgif.be/auth/refnis2025/33021> .
+
+<http://vocab.belgif.be/auth/refnis2019/33029> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/33000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "33029";
+  skos:prefLabel "Wervik"@de, "Wervik"@fr, "Wervik"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2783821/>, <http://www.wikidata.org/entity/Q318532>,
+    <http://vocab.belgif.be/auth/refnis1995/33029>, <http://vocab.belgif.be/auth/refnis2025/33029> .
+
+<http://vocab.belgif.be/auth/refnis2019/33037> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/33000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "33037";
+  skos:prefLabel "Zonnebeke"@de, "Zonnebeke"@fr, "Zonnebeke"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2783185/>, <http://www.wikidata.org/entity/Q214154>,
+    <http://vocab.belgif.be/auth/refnis1995/33037>, <http://vocab.belgif.be/auth/refnis2025/33037> .
+
+<http://vocab.belgif.be/auth/refnis2019/33039> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/33000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "33039";
+  skos:prefLabel "Heuvelland"@de, "Heuvelland"@fr, "Heuvelland"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2794580/>, <http://www.wikidata.org/entity/Q822755>,
+    <http://vocab.belgif.be/auth/refnis1995/33039>, <http://vocab.belgif.be/auth/refnis2025/33039> .
+
+<http://vocab.belgif.be/auth/refnis2019/33040> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/33000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "33040";
+  skos:prefLabel "Langemark-Poelkapelle"@de, "Langemark-Poelkapelle"@fr, "Langemark-Poelkapelle"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2793393/>, <http://www.wikidata.org/entity/Q735865>,
+    <http://vocab.belgif.be/auth/refnis1995/33040>, <http://vocab.belgif.be/auth/refnis2025/33040> .
+
+<http://vocab.belgif.be/auth/refnis2019/33041> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/33000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "33041";
+  skos:prefLabel "Vleteren"@de, "Vleteren"@fr, "Vleteren"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2783769/>, <http://www.wikidata.org/entity/Q735813>,
+    <http://vocab.belgif.be/auth/refnis1995/33041>, <http://vocab.belgif.be/auth/refnis2025/33041> .
+
+<http://vocab.belgif.be/auth/refnis2019/34002> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/34000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "34002";
+  skos:prefLabel "Anzegem"@de, "Anzegem"@fr, "Anzegem"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2803131/>, <http://www.wikidata.org/entity/Q614274>,
+    <http://vocab.belgif.be/auth/refnis1995/34002>, <http://vocab.belgif.be/auth/refnis2025/34002> .
+
+<http://vocab.belgif.be/auth/refnis2019/34003> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/34000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "34003";
+  skos:prefLabel "Avelgem"@de, "Avelgem"@fr, "Avelgem"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2802872/>, <http://www.wikidata.org/entity/Q177133>,
+    <http://vocab.belgif.be/auth/refnis1995/34003>, <http://vocab.belgif.be/auth/refnis2025/34003> .
+
+<http://vocab.belgif.be/auth/refnis2019/34009> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/34000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "34009";
+  skos:prefLabel "Deerlijk"@de, "Deerlijk"@fr, "Deerlijk"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2799798/>, <http://www.wikidata.org/entity/Q822771>,
+    <http://vocab.belgif.be/auth/refnis1995/34009>, <http://vocab.belgif.be/auth/refnis2025/34009> .
+
+<http://vocab.belgif.be/auth/refnis2019/34013> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/34000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "34013";
+  skos:prefLabel "Harelbeke"@de, "Harelbeke"@fr, "Harelbeke"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2796543/>, <http://www.wikidata.org/entity/Q478797>,
+    <http://vocab.belgif.be/auth/refnis1995/34013>, <http://vocab.belgif.be/auth/refnis2025/34013> .
+
+<http://vocab.belgif.be/auth/refnis2019/34022> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/34000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "34022";
+  skos:prefLabel "Kortrijk"@de, "Courtrai"@fr, "Kortrijk"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2794056/>, <http://www.wikidata.org/entity/Q12995>,
+    <http://vocab.belgif.be/auth/refnis1995/34022>, <http://vocab.belgif.be/auth/refnis2025/34022> .
+
+<http://vocab.belgif.be/auth/refnis2019/34023> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/34000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "34023";
+  skos:prefLabel "Kuurne"@de, "Kuurne"@fr, "Kuurne"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2793858/>, <http://www.wikidata.org/entity/Q731501>,
+    <http://vocab.belgif.be/auth/refnis1995/34023>, <http://vocab.belgif.be/auth/refnis2025/34023> .
+
+<http://vocab.belgif.be/auth/refnis2019/34025> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/34000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "34025";
+  skos:prefLabel "Lendelede"@de, "Lendelede"@fr, "Lendelede"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2792880/>, <http://www.wikidata.org/entity/Q696887>,
+    <http://vocab.belgif.be/auth/refnis1995/34025>, <http://vocab.belgif.be/auth/refnis2025/34025> .
+
+<http://vocab.belgif.be/auth/refnis2019/34027> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/34000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "34027";
+  skos:prefLabel "Menen"@de, "Menin"@fr, "Menen"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2791344/>, <http://www.wikidata.org/entity/Q213224>,
+    <http://vocab.belgif.be/auth/refnis1995/34027>, <http://vocab.belgif.be/auth/refnis2025/34027> .
+
+<http://vocab.belgif.be/auth/refnis2019/34040> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/34000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "34040";
+  skos:prefLabel "Waregem"@de, "Waregem"@fr, "Waregem"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2784069/>, <http://www.wikidata.org/entity/Q204547>,
+    <http://vocab.belgif.be/auth/refnis1995/34040>, <http://vocab.belgif.be/auth/refnis2025/34040> .
+
+<http://vocab.belgif.be/auth/refnis2019/34041> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/34000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "34041";
+  skos:prefLabel "Wevelgem"@de, "Wevelgem"@fr, "Wevelgem"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2783760/>, <http://www.wikidata.org/entity/Q392343>,
+    <http://vocab.belgif.be/auth/refnis1995/34041>, <http://vocab.belgif.be/auth/refnis2025/34041> .
+
+<http://vocab.belgif.be/auth/refnis2019/34042> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/34000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "34042";
+  skos:prefLabel "Zwevegem"@de, "Zwevegem"@fr, "Zwevegem"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2783090/>, <http://www.wikidata.org/entity/Q244513>,
+    <http://vocab.belgif.be/auth/refnis1995/34042>, <http://vocab.belgif.be/auth/refnis2025/34042> .
+
+<http://vocab.belgif.be/auth/refnis2019/34043> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/34000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "34043";
+  skos:prefLabel "Spiere-Helkijn"@de, "Espierres-Helchin"@fr, "Spiere-Helkijn"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2798628/>, <http://www.wikidata.org/entity/Q846212>,
+    <http://vocab.belgif.be/auth/refnis1995/34043>, <http://vocab.belgif.be/auth/refnis2025/34043> .
+
+<http://vocab.belgif.be/auth/refnis2019/35002> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/35000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "35002";
+  skos:prefLabel "Bredene"@de, "Bredene"@fr, "Bredene"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2801104/>, <http://www.wikidata.org/entity/Q742920>,
+    <http://vocab.belgif.be/auth/refnis1995/35002>, <http://vocab.belgif.be/auth/refnis2025/35002> .
+
+<http://vocab.belgif.be/auth/refnis2019/35005> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/35000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "35005";
+  skos:prefLabel "Gistel"@de, "Gistel"@fr, "Gistel"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2797518/>, <http://www.wikidata.org/entity/Q815948>,
+    <http://vocab.belgif.be/auth/refnis1995/35005>, <http://vocab.belgif.be/auth/refnis2025/35005> .
+
+<http://vocab.belgif.be/auth/refnis2019/35006> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/35000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "35006";
+  skos:prefLabel "Ichtegem"@de, "Ichtegem"@fr, "Ichtegem"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2795107/>, <http://www.wikidata.org/entity/Q281181>,
+    <http://vocab.belgif.be/auth/refnis1995/35006>, <http://vocab.belgif.be/auth/refnis2025/35006> .
+
+<http://vocab.belgif.be/auth/refnis2019/35011> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/35000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "35011";
+  skos:prefLabel "Middelkerke"@de, "Middelkerke"@fr, "Middelkerke"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2791195/>, <http://www.wikidata.org/entity/Q492369>,
+    <http://vocab.belgif.be/auth/refnis1995/35011>, <http://vocab.belgif.be/auth/refnis2025/35011> .
+
+<http://vocab.belgif.be/auth/refnis2019/35013> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/35000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "35013";
+  skos:prefLabel "Ostende"@de, "Ostende"@fr, "Oostende"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2789788/>, <http://www.wikidata.org/entity/Q12996>,
+    <http://vocab.belgif.be/auth/refnis1995/35013>, <http://vocab.belgif.be/auth/refnis2025/35013> .
+
+<http://vocab.belgif.be/auth/refnis2019/35014> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/35000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "35014";
+  skos:prefLabel "Oudenburg"@de, "Oudenburg"@fr, "Oudenburg"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2789520/>, <http://www.wikidata.org/entity/Q835128>,
+    <http://vocab.belgif.be/auth/refnis1995/35014>, <http://vocab.belgif.be/auth/refnis2025/35014> .
+
+<http://vocab.belgif.be/auth/refnis2019/35029> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/35000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "35029";
+  skos:prefLabel "De Haan"@de, "De Haan"@fr, "De Haan"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2783855/>, <http://www.wikidata.org/entity/Q492351>,
+    <http://vocab.belgif.be/auth/refnis1995/35029>, <http://vocab.belgif.be/auth/refnis2025/35029> .
+
+<http://vocab.belgif.be/auth/refnis2019/36006> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/36000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "36006";
+  skos:prefLabel "Hooglede"@de, "Hooglede"@fr, "Hooglede"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2795424/>, <http://www.wikidata.org/entity/Q696907>,
+    <http://vocab.belgif.be/auth/refnis1995/36006>, <http://vocab.belgif.be/auth/refnis2025/36006> .
+
+<http://vocab.belgif.be/auth/refnis2019/36007> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/36000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "36007";
+  skos:prefLabel "Ingelmunster"@de, "Ingelmunster"@fr, "Ingelmunster"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2795057/>, <http://www.wikidata.org/entity/Q822748>,
+    <http://vocab.belgif.be/auth/refnis1995/36007>, <http://vocab.belgif.be/auth/refnis2025/36007> .
+
+<http://vocab.belgif.be/auth/refnis2019/36008> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/36000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "36008";
+  skos:prefLabel "Izegem"@de, "Izegem"@fr, "Izegem"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2795010/>, <http://www.wikidata.org/entity/Q392337>,
+    <http://vocab.belgif.be/auth/refnis1995/36008>, <http://vocab.belgif.be/auth/refnis2025/36008> .
+
+<http://vocab.belgif.be/auth/refnis2019/36010> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/36000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "36010";
+  skos:prefLabel "Ledegem"@de, "Ledegem"@fr, "Ledegem"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2793068/>, <http://www.wikidata.org/entity/Q735842>,
+    <http://vocab.belgif.be/auth/refnis1995/36010>, <http://vocab.belgif.be/auth/refnis2025/36010> .
+
+<http://vocab.belgif.be/auth/refnis2019/36011> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/36000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "36011";
+  skos:prefLabel "Lichtervelde"@de, "Lichtervelde"@fr, "Lichtervelde"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2792430/>, <http://www.wikidata.org/entity/Q696871>,
+    <http://vocab.belgif.be/auth/refnis1995/36011>, <http://vocab.belgif.be/auth/refnis2025/36011> .
+
+<http://vocab.belgif.be/auth/refnis2019/36012> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/36000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "36012";
+  skos:prefLabel "Moorslede"@de, "Moorslede"@fr, "Moorslede"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2790730/>, <http://www.wikidata.org/entity/Q628733>,
+    <http://vocab.belgif.be/auth/refnis1995/36012>, <http://vocab.belgif.be/auth/refnis2025/36012> .
+
+<http://vocab.belgif.be/auth/refnis2019/36015> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/36000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "36015";
+  skos:prefLabel "Roeselare"@de, "Roulers"@fr, "Roeselare"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2787891/>, <http://www.wikidata.org/entity/Q211037>,
+    <http://vocab.belgif.be/auth/refnis1995/36015>, <http://vocab.belgif.be/auth/refnis2025/36015> .
+
+<http://vocab.belgif.be/auth/refnis2019/36019> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/36000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "36019";
+  skos:prefLabel "Staden"@de, "Staden"@fr, "Staden"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2786227/>, <http://www.wikidata.org/entity/Q742876>,
+    <http://vocab.belgif.be/auth/refnis1995/36019>, <http://vocab.belgif.be/auth/refnis2025/36019> .
+
+<http://vocab.belgif.be/auth/refnis2019/37002> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/37000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "37002";
+  skos:prefLabel "Dentergem"@de, "Dentergem"@fr, "Dentergem"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2799587/>, <http://www.wikidata.org/entity/Q742906>,
+    <http://vocab.belgif.be/auth/refnis1995/37002>, <http://vocab.belgif.be/auth/refnis2025/37002> .
+
+<http://vocab.belgif.be/auth/refnis2019/37007> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/37000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "37007";
+  skos:prefLabel "Meulebeke"@de, "Meulebeke"@fr, "Meulebeke"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "2025-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2791256/>, <http://www.wikidata.org/entity/Q822783>,
+    <http://vocab.belgif.be/auth/refnis1995/37007>;
+  skos:broadMatch <http://vocab.belgif.be/auth/refnis2025/37022> .
+
+<http://vocab.belgif.be/auth/refnis2019/37010> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/37000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "37010";
+  skos:prefLabel "Oostrozebeke"@de, "Oostrozebeke"@fr, "Oostrozebeke"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2789738/>, <http://www.wikidata.org/entity/Q822777>,
+    <http://vocab.belgif.be/auth/refnis1995/37010>, <http://vocab.belgif.be/auth/refnis2025/37010> .
+
+<http://vocab.belgif.be/auth/refnis2019/37011> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/37000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "37011";
+  skos:prefLabel "Pittem"@de, "Pittem"@fr, "Pittem"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2788926/>, <http://www.wikidata.org/entity/Q651724>,
+    <http://vocab.belgif.be/auth/refnis1995/37011>, <http://vocab.belgif.be/auth/refnis2025/37011> .
+
+<http://vocab.belgif.be/auth/refnis2019/37012> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/37000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "37012";
+  skos:prefLabel "Ruiselede"@de, "Ruiselede"@fr, "Ruiselede"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "2025-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2787548/>, <http://www.wikidata.org/entity/Q696982>,
+    <http://vocab.belgif.be/auth/refnis1995/37012>;
+  skos:broadMatch <http://vocab.belgif.be/auth/refnis2025/37021> .
+
+<http://vocab.belgif.be/auth/refnis2019/37015> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/37000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "37015";
+  skos:prefLabel "Tielt"@de, "Tielt"@fr, "Tielt"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "2025-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2785478/>, <http://www.wikidata.org/entity/Q651811>,
+    <http://vocab.belgif.be/auth/refnis1995/37015>;
+  skos:broadMatch <http://vocab.belgif.be/auth/refnis2025/37022> .
+
+<http://vocab.belgif.be/auth/refnis2019/37017> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/37000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "37017";
+  skos:prefLabel "Wielsbeke"@de, "Wielsbeke"@fr, "Wielsbeke"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2783718/>, <http://www.wikidata.org/entity/Q339395>,
+    <http://vocab.belgif.be/auth/refnis1995/37017>, <http://vocab.belgif.be/auth/refnis2025/37017> .
+
+<http://vocab.belgif.be/auth/refnis2019/37018> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/37000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "37018";
+  skos:prefLabel "Wingene"@de, "Wingene"@fr, "Wingene"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "2025-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2783587/>, <http://www.wikidata.org/entity/Q735797>,
+    <http://vocab.belgif.be/auth/refnis1995/37018>;
+  skos:broadMatch <http://vocab.belgif.be/auth/refnis2025/37021> .
+
+<http://vocab.belgif.be/auth/refnis2019/37020> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/37000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "37020";
+  skos:prefLabel "Ardooie"@de, "Ardooie"@fr, "Ardooie"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2803092/>, <http://www.wikidata.org/entity/Q639974>,
+    <http://vocab.belgif.be/auth/refnis1995/37020>, <http://vocab.belgif.be/auth/refnis2025/37020> .
+
+<http://vocab.belgif.be/auth/refnis2019/38002> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/38000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "38002";
+  skos:prefLabel "Alveringem"@de, "Alveringem"@fr, "Alveringem"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2803253/>, <http://www.wikidata.org/entity/Q448840>,
+    <http://vocab.belgif.be/auth/refnis1995/38002>, <http://vocab.belgif.be/auth/refnis2025/38002> .
+
+<http://vocab.belgif.be/auth/refnis2019/38008> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/38000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "38008";
+  skos:prefLabel "De Panne"@de, "La Panne"@fr, "De Panne"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2799578/>, <http://www.wikidata.org/entity/Q674954>,
+    <http://vocab.belgif.be/auth/refnis1995/38008>, <http://vocab.belgif.be/auth/refnis2025/38008> .
+
+<http://vocab.belgif.be/auth/refnis2019/38014> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/38000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "38014";
+  skos:prefLabel "Koksijde"@de, "Koksijde"@fr, "Koksijde"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2794167/>, <http://www.wikidata.org/entity/Q465545>,
+    <http://vocab.belgif.be/auth/refnis1995/38014>, <http://vocab.belgif.be/auth/refnis2025/38014> .
+
+<http://vocab.belgif.be/auth/refnis2019/38016> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/38000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "38016";
+  skos:prefLabel "Nieuwpoort"@de, "Nieuport"@fr, "Nieuwpoort"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2790153/>, <http://www.wikidata.org/entity/Q623310>,
+    <http://vocab.belgif.be/auth/refnis1995/38016>, <http://vocab.belgif.be/auth/refnis2025/38016> .
+
+<http://vocab.belgif.be/auth/refnis2019/38025> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/38000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "38025";
+  skos:prefLabel "Veurne"@de, "Furnes"@fr, "Veurne"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2784805/>, <http://www.wikidata.org/entity/Q506707>,
+    <http://vocab.belgif.be/auth/refnis1995/38025>, <http://vocab.belgif.be/auth/refnis2025/38025> .
+
+<http://vocab.belgif.be/auth/refnis2019/41002> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/41000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "41002";
+  skos:prefLabel "Aalst"@de, "Alost"@fr, "Aalst"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2803451/>, <http://www.wikidata.org/entity/Q13121>,
+    <http://vocab.belgif.be/auth/refnis1995/41002>, <http://vocab.belgif.be/auth/refnis2025/41002> .
+
+<http://vocab.belgif.be/auth/refnis2019/41011> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/41000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "41011";
+  skos:prefLabel "Denderleeuw"@de, "Denderleeuw"@fr, "Denderleeuw"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2799648/>, <http://www.wikidata.org/entity/Q696825>,
+    <http://vocab.belgif.be/auth/refnis1995/41011>, <http://vocab.belgif.be/auth/refnis2025/41011> .
+
+<http://vocab.belgif.be/auth/refnis2019/41018> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/41000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "41018";
+  skos:prefLabel "Geraardsbergen"@de, "Grammont"@fr, "Geraardsbergen"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2797639/>, <http://www.wikidata.org/entity/Q499532>,
+    <http://vocab.belgif.be/auth/refnis1995/41018>, <http://vocab.belgif.be/auth/refnis2025/41018> .
+
+<http://vocab.belgif.be/auth/refnis2019/41024> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/41000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "41024";
+  skos:prefLabel "Haaltert"@de, "Haaltert"@fr, "Haaltert"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2796834/>, <http://www.wikidata.org/entity/Q911974>,
+    <http://vocab.belgif.be/auth/refnis1995/41024>, <http://vocab.belgif.be/auth/refnis2025/41024> .
+
+<http://vocab.belgif.be/auth/refnis2019/41027> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/41000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "41027";
+  skos:prefLabel "Herzele"@de, "Herzele"@fr, "Herzele"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2795909/>, <http://www.wikidata.org/entity/Q587979>,
+    <http://vocab.belgif.be/auth/refnis1995/41027>, <http://vocab.belgif.be/auth/refnis2025/41027> .
+
+<http://vocab.belgif.be/auth/refnis2019/41034> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/41000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "41034";
+  skos:prefLabel "Lede"@de, "Lede"@fr, "Lede"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2793079/>, <http://www.wikidata.org/entity/Q912113>,
+    <http://vocab.belgif.be/auth/refnis1995/41034>, <http://vocab.belgif.be/auth/refnis2025/41034> .
+
+<http://vocab.belgif.be/auth/refnis2019/41048> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/41000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "41048";
+  skos:prefLabel "Ninove"@de, "Ninove"@fr, "Ninove"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2790115/>, <http://www.wikidata.org/entity/Q385026>,
+    <http://vocab.belgif.be/auth/refnis1995/41048>, <http://vocab.belgif.be/auth/refnis2025/41048> .
+
+<http://vocab.belgif.be/auth/refnis2019/41063> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/41000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "41063";
+  skos:prefLabel "Sint-Lievens-Houtem"@de, "Sint-Lievens-Houtem"@fr, "Sint-Lievens-Houtem"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2786617/>, <http://www.wikidata.org/entity/Q817372>,
+    <http://vocab.belgif.be/auth/refnis1995/41063>, <http://vocab.belgif.be/auth/refnis2025/41063> .
+
+<http://vocab.belgif.be/auth/refnis2019/41081> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/41000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "41081";
+  skos:prefLabel "Zottegem"@de, "Zottegem"@fr, "Zottegem"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2783176/>, <http://www.wikidata.org/entity/Q226941>,
+    <http://vocab.belgif.be/auth/refnis1995/41081>, <http://vocab.belgif.be/auth/refnis2025/41081> .
+
+<http://vocab.belgif.be/auth/refnis2019/41082> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/41000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "41082";
+  skos:prefLabel "Erpe-Mere"@de, "Erpe-Mere"@fr, "Erpe-Mere"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2798679/>, <http://www.wikidata.org/entity/Q817458>,
+    <http://vocab.belgif.be/auth/refnis1995/41082>, <http://vocab.belgif.be/auth/refnis2025/41082> .
+
+<http://vocab.belgif.be/auth/refnis2019/42003> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/42000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "42003";
+  skos:prefLabel "Berlare"@de, "Berlare"@fr, "Berlare"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2802155/>, <http://www.wikidata.org/entity/Q793584>,
+    <http://vocab.belgif.be/auth/refnis1995/42003>, <http://vocab.belgif.be/auth/refnis2025/42003> .
+
+<http://vocab.belgif.be/auth/refnis2019/42004> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/42000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "42004";
+  skos:prefLabel "Buggenhout"@de, "Buggenhout"@fr, "Buggenhout"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2800817/>, <http://www.wikidata.org/entity/Q202309>,
+    <http://vocab.belgif.be/auth/refnis1995/42004>, <http://vocab.belgif.be/auth/refnis2025/42004> .
+
+<http://vocab.belgif.be/auth/refnis2019/42006> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/42000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "42006";
+  skos:prefLabel "Dendermonde"@de, "Termonde"@fr, "Dendermonde"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2799646/>, <http://www.wikidata.org/entity/Q13122>,
+    <http://vocab.belgif.be/auth/refnis1995/42006>, <http://vocab.belgif.be/auth/refnis2025/42006> .
+
+<http://vocab.belgif.be/auth/refnis2019/42008> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/42000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "42008";
+  skos:prefLabel "Hamme"@de, "Hamme"@fr, "Hamme"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2796640/>, <http://www.wikidata.org/entity/Q391294>,
+    <http://vocab.belgif.be/auth/refnis1995/42008>, <http://vocab.belgif.be/auth/refnis2025/42008> .
+
+<http://vocab.belgif.be/auth/refnis2019/42010> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/42000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "42010";
+  skos:prefLabel "Laarne"@de, "Laarne"@fr, "Laarne"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2793798/>, <http://www.wikidata.org/entity/Q730696>,
+    <http://vocab.belgif.be/auth/refnis1995/42010>, <http://vocab.belgif.be/auth/refnis2025/42010> .
+
+<http://vocab.belgif.be/auth/refnis2019/42011> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/42000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "42011";
+  skos:prefLabel "Lebbeke"@de, "Lebbeke"@fr, "Lebbeke"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2793145/>, <http://www.wikidata.org/entity/Q504653>,
+    <http://vocab.belgif.be/auth/refnis1995/42011>, <http://vocab.belgif.be/auth/refnis2025/42011> .
+
+<http://vocab.belgif.be/auth/refnis2019/42023> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/42000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "42023";
+  skos:prefLabel "Waasmunster"@de, "Waasmunster"@fr, "Waasmunster"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2784232/>, <http://www.wikidata.org/entity/Q587906>,
+    <http://vocab.belgif.be/auth/refnis1995/42023>, <http://vocab.belgif.be/auth/refnis2025/42023> .
+
+<http://vocab.belgif.be/auth/refnis2019/42025> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/42000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "42025";
+  skos:prefLabel "Wetteren"@de, "Wetteren"@fr, "Wetteren"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2783764/>, <http://www.wikidata.org/entity/Q643980>,
+    <http://vocab.belgif.be/auth/refnis1995/42025>, <http://vocab.belgif.be/auth/refnis2025/42025> .
+
+<http://vocab.belgif.be/auth/refnis2019/42026> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/42000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "42026";
+  skos:prefLabel "Wichelen"@de, "Wichelen"@fr, "Wichelen"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2783729/>, <http://www.wikidata.org/entity/Q730801>,
+    <http://vocab.belgif.be/auth/refnis1995/42026>, <http://vocab.belgif.be/auth/refnis2025/42026> .
+
+<http://vocab.belgif.be/auth/refnis2019/42028> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/42000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "42028";
+  skos:prefLabel "Zele"@de, "Zele"@fr, "Zele"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2783294/>, <http://www.wikidata.org/entity/Q388115>,
+    <http://vocab.belgif.be/auth/refnis1995/42028>, <http://vocab.belgif.be/auth/refnis2025/42028> .
+
+<http://vocab.belgif.be/auth/refnis2019/43002> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/43000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "43002";
+  skos:prefLabel "Assenede"@de, "Assenede"@fr, "Assenede"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2803027/>, <http://www.wikidata.org/entity/Q12901>,
+    <http://vocab.belgif.be/auth/refnis1995/43002>, <http://vocab.belgif.be/auth/refnis2025/43002> .
+
+<http://vocab.belgif.be/auth/refnis2019/43005> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/43000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "43005";
+  skos:prefLabel "Eeklo"@de, "Eeklo"@fr, "Eeklo"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2798988/>, <http://www.wikidata.org/entity/Q12440>,
+    <http://vocab.belgif.be/auth/refnis1995/43005>, <http://vocab.belgif.be/auth/refnis2025/43005> .
+
+<http://vocab.belgif.be/auth/refnis2019/43007> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/43000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "43007";
+  skos:prefLabel "Kaprijke"@de, "Kaprijke"@fr, "Kaprijke"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2794708/>, <http://www.wikidata.org/entity/Q12437>,
+    <http://vocab.belgif.be/auth/refnis1995/43007>, <http://vocab.belgif.be/auth/refnis2025/43007> .
+
+<http://vocab.belgif.be/auth/refnis2019/43010> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/43000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "43010";
+  skos:prefLabel "Maldegem"@de, "Maldegem"@fr, "Maldegem"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2791858/>, <http://www.wikidata.org/entity/Q12896>,
+    <http://vocab.belgif.be/auth/refnis1995/43010>, <http://vocab.belgif.be/auth/refnis2025/43010> .
+
+<http://vocab.belgif.be/auth/refnis2019/43014> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/43000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "43014";
+  skos:prefLabel "Sint-Laureins"@de, "Sint-Laureins"@fr, "Sint-Laureins"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2786627/>, <http://www.wikidata.org/entity/Q13126>,
+    <http://vocab.belgif.be/auth/refnis1995/43014>, <http://vocab.belgif.be/auth/refnis2025/43014> .
+
+<http://vocab.belgif.be/auth/refnis2019/43018> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/43000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "43018";
+  skos:prefLabel "Zelzate"@de, "Zelzate"@fr, "Zelzate"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2783279/>, <http://www.wikidata.org/entity/Q14062>,
+    <http://vocab.belgif.be/auth/refnis1995/43018>, <http://vocab.belgif.be/auth/refnis2025/43018> .
+
+<http://vocab.belgif.be/auth/refnis2019/44083> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/44000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "44083";
+  skos:prefLabel "Deinze"@de, "Deinze"@fr, "Deinze"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2799747/>, <http://www.wikidata.org/entity/Q499313>,
+    <http://vocab.belgif.be/auth/refnis2025/44083>;
+  skos:narrowMatch <http://vocab.belgif.be/auth/refnis1995/44011>, <https://sws.geonames.org/2790236/>,
+    <http://www.wikidata.org/entity/Q822651>, <http://vocab.belgif.be/auth/refnis1995/44049> .
+
+<http://vocab.belgif.be/auth/refnis2019/44012> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/44000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "44012";
+  skos:prefLabel "De Pinte"@de, "De Pinte"@fr, "De Pinte"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "2025-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2799571/>, <http://www.wikidata.org/entity/Q842454>,
+    <http://vocab.belgif.be/auth/refnis1995/44012>;
+  skos:broadMatch <http://vocab.belgif.be/auth/refnis2025/44086> .
+
+<http://vocab.belgif.be/auth/refnis2019/44013> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/44000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "44013";
+  skos:prefLabel "Destelbergen"@de, "Destelbergen"@fr, "Destelbergen"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2799497/>, <http://www.wikidata.org/entity/Q3177595>,
+    <http://vocab.belgif.be/auth/refnis1995/44013>, <http://vocab.belgif.be/auth/refnis2025/44013> .
+
+<http://vocab.belgif.be/auth/refnis2019/44019> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/44000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "44019";
+  skos:prefLabel "Evergem"@de, "Evergem"@fr, "Evergem"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2798553/>, <http://www.wikidata.org/entity/Q12997>,
+    <http://vocab.belgif.be/auth/refnis1995/44019>, <http://vocab.belgif.be/auth/refnis2025/44019> .
+
+<http://vocab.belgif.be/auth/refnis2019/44020> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/44000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "44020";
+  skos:prefLabel "Gavere"@de, "Gavere"@fr, "Gavere"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2797799/>, <http://www.wikidata.org/entity/Q690611>,
+    <http://vocab.belgif.be/auth/refnis1995/44020>, <http://vocab.belgif.be/auth/refnis2025/44020> .
+
+<http://vocab.belgif.be/auth/refnis2019/44021> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/44000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "44021";
+  skos:prefLabel "Gent"@de, "Gand"@fr, "Gent"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2797657/>, <http://www.wikidata.org/entity/Q1296>,
+    <http://vocab.belgif.be/auth/refnis1995/44021>, <http://vocab.belgif.be/auth/refnis2025/44021> .
+
+<http://vocab.belgif.be/auth/refnis2019/44034> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/44000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "44034";
+  skos:prefLabel "Lochristi"@de, "Lochristi"@fr, "Lochristi"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "2025-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2792236/>, <http://www.wikidata.org/entity/Q735827>,
+    <http://vocab.belgif.be/auth/refnis1995/44034>;
+  skos:broadMatch <http://vocab.belgif.be/auth/refnis2025/44087> .
+
+<http://vocab.belgif.be/auth/refnis2019/44040> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/44000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "44040";
+  skos:prefLabel "Melle"@de, "Melle"@fr, "Melle"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "2025-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2791386/>, <http://www.wikidata.org/entity/Q696355>,
+    <http://vocab.belgif.be/auth/refnis1995/44040>;
+  skos:broadMatch <http://vocab.belgif.be/auth/refnis2025/44088> .
+
+<http://vocab.belgif.be/auth/refnis2019/44043> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/44000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "44043";
+  skos:prefLabel "Merelbeke"@de, "Merelbeke"@fr, "Merelbeke"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "2025-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2791316/>, <http://www.wikidata.org/entity/Q187755>,
+    <http://vocab.belgif.be/auth/refnis1995/44043>;
+  skos:broadMatch <http://vocab.belgif.be/auth/refnis2025/44088> .
+
+<http://vocab.belgif.be/auth/refnis2019/44045> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/44000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "44045";
+  skos:prefLabel "Moerbeke"@de, "Moerbeke"@fr, "Moerbeke"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "2025-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2791122/>, <http://www.wikidata.org/entity/Q397705>,
+    <http://vocab.belgif.be/auth/refnis1995/44045>;
+  skos:broadMatch <http://vocab.belgif.be/auth/refnis2025/46029> .
+
+<http://vocab.belgif.be/auth/refnis2019/44048> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/44000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "44048";
+  skos:prefLabel "Nazareth"@de, "Nazareth"@fr, "Nazareth"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "2025-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2790435/>, <http://www.wikidata.org/entity/Q580315>,
+    <http://vocab.belgif.be/auth/refnis1995/44048>;
+  skos:broadMatch <http://vocab.belgif.be/auth/refnis2025/44086> .
+
+<http://vocab.belgif.be/auth/refnis2019/44052> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/44000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "44052";
+  skos:prefLabel "Oosterzele"@de, "Oosterzele"@fr, "Oosterzele"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2789772/>, <http://www.wikidata.org/entity/Q842477>,
+    <http://vocab.belgif.be/auth/refnis1995/44052>, <http://vocab.belgif.be/auth/refnis2025/44052> .
+
+<http://vocab.belgif.be/auth/refnis2019/44064> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/44000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "44064";
+  skos:prefLabel "Sint-Martens-Latem"@de, "Sint-Martens-Latem"@fr, "Sint-Martens-Latem"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2786592/>, <http://www.wikidata.org/entity/Q737538>,
+    <http://vocab.belgif.be/auth/refnis1995/44064>, <http://vocab.belgif.be/auth/refnis2025/44064> .
+
+<http://vocab.belgif.be/auth/refnis2019/44073> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/44000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "44073";
+  skos:prefLabel "Wachtebeke"@de, "Wachtebeke"@fr, "Wachtebeke"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "2025-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2784228/>, <http://www.wikidata.org/entity/Q696349>,
+    <http://vocab.belgif.be/auth/refnis1995/44073>;
+  skos:broadMatch <http://vocab.belgif.be/auth/refnis2025/44087> .
+
+<http://vocab.belgif.be/auth/refnis2019/44081> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/44000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "44081";
+  skos:prefLabel "Zulte"@de, "Zulte"@fr, "Zulte"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2783152/>, <http://www.wikidata.org/entity/Q228863>,
+    <http://vocab.belgif.be/auth/refnis1995/44081>, <http://vocab.belgif.be/auth/refnis2025/44081> .
+
+<http://vocab.belgif.be/auth/refnis2019/44084> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/44000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "44084";
+  skos:prefLabel "Aalter"@de, "Aalter"@fr, "Aalter"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2803444/>, <http://www.wikidata.org/entity/Q300970>,
+    <http://vocab.belgif.be/auth/refnis2025/44084>;
+  skos:narrowMatch <http://vocab.belgif.be/auth/refnis1995/44001>, <https://sws.geonames.org/2794224/>,
+    <http://www.wikidata.org/entity/Q912069>, <http://vocab.belgif.be/auth/refnis1995/44029> .
+
+<http://vocab.belgif.be/auth/refnis2019/44085> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/44000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "44085";
+  skos:prefLabel "Lievegem"@de, "Lievegem"@fr, "Lievegem"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/11994860/>, <https://www.wikidata.org/entity/Q46865167>,
+    <http://vocab.belgif.be/auth/refnis2025/44085>;
+  skos:narrowMatch <https://sws.geonames.org/2784238/>, <http://www.wikidata.org/entity/Q911983>,
+    <http://vocab.belgif.be/auth/refnis1995/44072>, <https://sws.geonames.org/2792058/>,
+    <http://www.wikidata.org/entity/Q840968>, <http://vocab.belgif.be/auth/refnis1995/44036>,
+    <https://sws.geonames.org/2783196/>, <http://www.wikidata.org/entity/Q219827>, <http://vocab.belgif.be/auth/refnis1995/44080> .
+
+<http://vocab.belgif.be/auth/refnis2019/45035> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/45000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "45035";
+  skos:prefLabel "Oudenaarde"@de, "Audenarde"@fr, "Oudenaarde"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2789530/>, <http://www.wikidata.org/entity/Q12992>,
+    <http://vocab.belgif.be/auth/refnis1995/45035>, <http://vocab.belgif.be/auth/refnis2025/45035> .
+
+<http://vocab.belgif.be/auth/refnis2019/45041> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/45000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "45041";
+  skos:prefLabel "Ronse"@de, "Renaix"@fr, "Ronse"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2787770/>, <http://www.wikidata.org/entity/Q268219>,
+    <http://vocab.belgif.be/auth/refnis1995/45041>, <http://vocab.belgif.be/auth/refnis2025/45041> .
+
+<http://vocab.belgif.be/auth/refnis2019/45059> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/45000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "45059";
+  skos:prefLabel "Brakel"@de, "Brakel"@fr, "Brakel"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2790422/>, <http://www.wikidata.org/entity/Q845980>,
+    <http://vocab.belgif.be/auth/refnis1995/45059>, <http://vocab.belgif.be/auth/refnis2025/45059> .
+
+<http://vocab.belgif.be/auth/refnis2019/45060> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/45000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "45060";
+  skos:prefLabel "Kluisbergen"@de, "Kluisbergen"@fr, "Kluisbergen"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2794234/>, <http://www.wikidata.org/entity/Q840517>,
+    <http://vocab.belgif.be/auth/refnis1995/45060>, <http://vocab.belgif.be/auth/refnis2025/45060> .
+
+<http://vocab.belgif.be/auth/refnis2019/45061> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/45000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "45061";
+  skos:prefLabel "Wortegem-Petegem"@de, "Wortegem-Petegem"@fr, "Wortegem-Petegem"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2783450/>, <http://www.wikidata.org/entity/Q840935>,
+    <http://vocab.belgif.be/auth/refnis1995/45061>, <http://vocab.belgif.be/auth/refnis2025/45061> .
+
+<http://vocab.belgif.be/auth/refnis2019/45062> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/45000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "45062";
+  skos:prefLabel "Horebeke"@de, "Horebeke"@fr, "Horebeke"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2786637/>, <http://www.wikidata.org/entity/Q912076>,
+    <http://vocab.belgif.be/auth/refnis1995/45062>, <http://vocab.belgif.be/auth/refnis2025/45062> .
+
+<http://vocab.belgif.be/auth/refnis2019/45063> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/45000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "45063";
+  skos:prefLabel "Lierde"@de, "Lierde"@fr, "Lierde"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2786604/>, <http://www.wikidata.org/entity/Q648509>,
+    <http://vocab.belgif.be/auth/refnis1995/45063>, <http://vocab.belgif.be/auth/refnis2025/45063> .
+
+<http://vocab.belgif.be/auth/refnis2019/45064> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/45000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "45064";
+  skos:prefLabel "Maarkedal"@de, "Maarkedal"@fr, "Maarkedal"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2791971/>, <http://www.wikidata.org/entity/Q912099>,
+    <http://vocab.belgif.be/auth/refnis1995/45064>, <http://vocab.belgif.be/auth/refnis2025/45064> .
+
+<http://vocab.belgif.be/auth/refnis2019/45065> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/45000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "45065";
+  skos:prefLabel "Zwalm"@de, "Zwalin"@fr, "Zwalm"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2790540/>, <http://www.wikidata.org/entity/Q231568>,
+    <http://vocab.belgif.be/auth/refnis1995/45065>, <http://vocab.belgif.be/auth/refnis2025/45065> .
+
+<http://vocab.belgif.be/auth/refnis2019/45068> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/45000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "45068";
+  skos:prefLabel "Kruisem"@de, "Kruisem"@fr, "Kruisem"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/11994886/>, <http://www.wikidata.org/entity/Q46865464>,
+    <http://vocab.belgif.be/auth/refnis2025/45068>;
+  skos:narrowMatch <https://sws.geonames.org/2793908/>, <http://www.wikidata.org/entity/Q817375>,
+    <http://vocab.belgif.be/auth/refnis1995/45017>, <https://sws.geonames.org/2783216/>,
+    <http://www.wikidata.org/entity/Q204477>, <http://vocab.belgif.be/auth/refnis1995/45057> .
+
+<http://vocab.belgif.be/auth/refnis2019/46003> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/46000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "46003";
+  skos:prefLabel "Beveren"@de, "Beveren"@fr, "Beveren"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "2025-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2802035/>, <http://www.wikidata.org/entity/Q270644>,
+    <http://vocab.belgif.be/auth/refnis1995/46003>;
+  skos:broadMatch <http://vocab.belgif.be/auth/refnis2025/46030> .
+
+<http://vocab.belgif.be/auth/refnis2019/46013> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/46000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "46013";
+  skos:prefLabel "Kruibeke"@de, "Kruibeke"@fr, "Kruibeke"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "2025-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2793941/>, <http://www.wikidata.org/entity/Q916980>,
+    <http://vocab.belgif.be/auth/refnis1995/46013>;
+  skos:broadMatch <http://vocab.belgif.be/auth/refnis2025/46030> .
+
+<http://vocab.belgif.be/auth/refnis2019/46014> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/46000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "46014";
+  skos:prefLabel "Lokeren"@de, "Lokeren"@fr, "Lokeren"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "2025-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2792197/>, <http://www.wikidata.org/entity/Q12910>,
+    <http://vocab.belgif.be/auth/refnis1995/46014>;
+  skos:broadMatch <http://vocab.belgif.be/auth/refnis2025/46029> .
+
+<http://vocab.belgif.be/auth/refnis2019/46020> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/46000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "46020";
+  skos:prefLabel "Sint-Gillis-Waas"@de, "Sint-Gillis-Waas"@fr, "Sint-Gillis-Waas"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2786695/>, <http://www.wikidata.org/entity/Q430510>,
+    <http://vocab.belgif.be/auth/refnis1995/46020>, <http://vocab.belgif.be/auth/refnis2025/46020> .
+
+<http://vocab.belgif.be/auth/refnis2019/46021> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/46000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "46021";
+  skos:prefLabel "Sint-Niklaas"@de, "Saint-Nicolas"@fr, "Sint-Niklaas"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2786579/>, <http://www.wikidata.org/wiki/Q13127>,
+    <http://vocab.belgif.be/auth/refnis1995/46021>, <http://vocab.belgif.be/auth/refnis2025/46021> .
+
+<http://vocab.belgif.be/auth/refnis2019/46024> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/46000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "46024";
+  skos:prefLabel "Stekene"@de, "Stekene"@fr, "Stekene"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2786088/>, <http://www.wikidata.org/entity/Q735851>,
+    <http://vocab.belgif.be/auth/refnis1995/46024>, <http://vocab.belgif.be/auth/refnis2025/46024> .
+
+<http://vocab.belgif.be/auth/refnis2019/46025> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/46000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "46025";
+  skos:prefLabel "Temse"@de, "Tamise"@fr, "Temse"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2785779/>, <http://www.wikidata.org/entity/Q823623>,
+    <http://vocab.belgif.be/auth/refnis1995/46025>, <http://vocab.belgif.be/auth/refnis2025/46025> .
+
+<http://vocab.belgif.be/auth/refnis2019/51004> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/51000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "51004";
+  skos:prefLabel "Ath"@de, "Ath"@fr, "Aat"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2803011/>, <http://www.wikidata.org/entity/Q95096>,
+    <http://vocab.belgif.be/auth/refnis1995/51004>, <http://vocab.belgif.be/auth/refnis2025/51004> .
+
+<http://vocab.belgif.be/auth/refnis2019/51008> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/51000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "51008";
+  skos:prefLabel "Beloeil"@de, "Beloeil"@fr, "Beloeil"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2802294/>, <http://www.wikidata.org/entity/Q95105>,
+    <http://vocab.belgif.be/auth/refnis1995/51008>, <http://vocab.belgif.be/auth/refnis2025/51008> .
+
+<http://vocab.belgif.be/auth/refnis2019/51009> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/51000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "51009";
+  skos:prefLabel "Bernissart"@de, "Bernissart"@fr, "Bernissart"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2802136/>, <http://www.wikidata.org/entity/Q95112>,
+    <http://vocab.belgif.be/auth/refnis1995/51009>, <http://vocab.belgif.be/auth/refnis2025/51009> .
+
+<http://vocab.belgif.be/auth/refnis2019/51012> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/51000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "51012";
+  skos:prefLabel "Brugelette"@de, "Brugelette"@fr, "Brugelette"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2800937/>, <http://www.wikidata.org/entity/Q95130>,
+    <http://vocab.belgif.be/auth/refnis1995/51012>, <http://vocab.belgif.be/auth/refnis2025/51012> .
+
+<http://vocab.belgif.be/auth/refnis2019/51014> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/51000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "51014";
+  skos:prefLabel "Chièvres"@de, "Chièvres"@fr, "Chièvres"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2800329/>, <http://www.wikidata.org/entity/Q95318>,
+    <http://vocab.belgif.be/auth/refnis1995/51014>, <http://vocab.belgif.be/auth/refnis2025/51014> .
+
+<http://vocab.belgif.be/auth/refnis2019/51017> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/51000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "51017";
+  skos:prefLabel "Ellezelles"@de, "Ellezelles"@fr, "Elzele"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2798837/>, <http://www.wikidata.org/entity/Q665992>,
+    <http://vocab.belgif.be/auth/refnis1995/51017>, <http://vocab.belgif.be/auth/refnis2025/51017> .
+
+<http://vocab.belgif.be/auth/refnis2019/51019> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/51000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "51019";
+  skos:prefLabel "Flobecq"@de, "Flobecq"@fr, "Vloesberg"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2798291/>, <http://www.wikidata.org/entity/Q666559>,
+    <http://vocab.belgif.be/auth/refnis1995/51019>, <http://vocab.belgif.be/auth/refnis2025/51019> .
+
+<http://vocab.belgif.be/auth/refnis2019/51065> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/51000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "51065";
+  skos:prefLabel "Frasnes-lez-Anvaing"@de, "Frasnes-lez-Anvaing"@fr, "Frasnes-lez-Anvaing"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2797980/>, <http://www.wikidata.org/entity/Q666813>,
+    <http://vocab.belgif.be/auth/refnis1995/51065>, <http://vocab.belgif.be/auth/refnis2025/51065> .
+
+<http://vocab.belgif.be/auth/refnis2019/51067> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/51000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "51067";
+  skos:prefLabel "Enghien"@de, "Enghien"@fr, "Edingen"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2798748/>, <http://www.wikidata.org/entity/Q666238>,
+    <http://vocab.belgif.be/auth/refnis1995/55010>, <http://vocab.belgif.be/auth/refnis2025/51067> .
+
+<http://vocab.belgif.be/auth/refnis2019/51068> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/51000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "51068";
+  skos:prefLabel "Silly"@de, "Silly"@fr, "Opzullik"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2786770/>, <http://www.wikidata.org/entity/Q669088>,
+    <http://vocab.belgif.be/auth/refnis1995/55039>, <http://vocab.belgif.be/auth/refnis2025/51068> .
+
+<http://vocab.belgif.be/auth/refnis2019/51069> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/51000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "51069";
+  skos:prefLabel "Lessines"@de, "Lessines"@fr, "Lessen"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2792568/>, <http://www.wikidata.org/entity/Q667790>,
+    <http://vocab.belgif.be/auth/refnis1995/55023>, <http://vocab.belgif.be/auth/refnis2025/51069> .
+
+<http://vocab.belgif.be/auth/refnis2019/52010> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/52000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "52010";
+  skos:prefLabel "Chapelle-lez-Herlaimont"@de, "Chapelle-lez-Herlaimont"@fr, "Chapelle-lez-Herlaimont"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2800501/>, <http://www.wikidata.org/entity/Q95140>,
+    <http://vocab.belgif.be/auth/refnis1995/52010>, <http://vocab.belgif.be/auth/refnis2025/52010> .
+
+<http://vocab.belgif.be/auth/refnis2019/52011> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/52000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "52011";
+  skos:prefLabel "Charleroi"@de, "Charleroi"@fr, "Charleroi"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2800482/>, <http://www.wikidata.org/entity/Q81046>,
+    <http://vocab.belgif.be/auth/refnis1995/52011>, <http://vocab.belgif.be/auth/refnis2025/52011> .
+
+<http://vocab.belgif.be/auth/refnis2019/52012> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/52000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "52012";
+  skos:prefLabel "Châtelet"@de, "Châtelet"@fr, "Châtelet"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2800449/>, <http://www.wikidata.org/entity/Q95144>,
+    <http://vocab.belgif.be/auth/refnis1995/52012>, <http://vocab.belgif.be/auth/refnis2025/52012> .
+
+<http://vocab.belgif.be/auth/refnis2019/52015> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/52000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "52015";
+  skos:prefLabel "Courcelles"@de, "Courcelles"@fr, "Courcelles"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2800064/>, <http://www.wikidata.org/entity/Q665860>,
+    <http://vocab.belgif.be/auth/refnis1995/52015>, <http://vocab.belgif.be/auth/refnis2025/52015> .
+
+<http://vocab.belgif.be/auth/refnis2019/52018> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/52000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "52018";
+  skos:prefLabel "Farciennes"@de, "Farciennes"@fr, "Farciennes"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2798471/>, <http://www.wikidata.org/entity/Q666503>,
+    <http://vocab.belgif.be/auth/refnis1995/52018>, <http://vocab.belgif.be/auth/refnis2025/52018> .
+
+<http://vocab.belgif.be/auth/refnis2019/52021> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/52000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "52021";
+  skos:prefLabel "Fleurus"@de, "Fleurus"@fr, "Fleurus"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2798298/>, <http://www.wikidata.org/entity/Q314922>,
+    <http://vocab.belgif.be/auth/refnis1995/52021>, <http://vocab.belgif.be/auth/refnis2025/52021> .
+
+<http://vocab.belgif.be/auth/refnis2019/52022> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/52000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "52022";
+  skos:prefLabel "Fontaine-l’Evêque"@de, "Fontaine-l’Evêque"@fr, "Fontaine-l’Evêque"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2798185/>, <http://www.wikidata.org/entity/Q666696>,
+    <http://vocab.belgif.be/auth/refnis1995/52022>, <http://vocab.belgif.be/auth/refnis2025/52022> .
+
+<http://vocab.belgif.be/auth/refnis2019/52025> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/52000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "52025";
+  skos:prefLabel "Gerpinnes"@de, "Gerpinnes"@fr, "Gerpinnes"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2797599/>, <http://www.wikidata.org/entity/Q666902>,
+    <http://vocab.belgif.be/auth/refnis1995/52025>, <http://vocab.belgif.be/auth/refnis2025/52025> .
+
+<http://vocab.belgif.be/auth/refnis2019/52048> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/52000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "52048";
+  skos:prefLabel "Montigny-le-Tilleul"@de, "Montigny-le-Tilleul"@fr, "Montigny-le-Tilleul"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2790805/>, <http://www.wikidata.org/entity/Q668437>,
+    <http://vocab.belgif.be/auth/refnis1995/52048>, <http://vocab.belgif.be/auth/refnis2025/52048> .
+
+<http://vocab.belgif.be/auth/refnis2019/52055> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/52000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "52055";
+  skos:prefLabel "Pont-à-Celles"@de, "Pont-à-Celles"@fr, "Pont-à-Celles"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2788766/>, <http://www.wikidata.org/entity/Q607182>,
+    <http://vocab.belgif.be/auth/refnis1995/52055>, <http://vocab.belgif.be/auth/refnis2025/52055> .
+
+<http://vocab.belgif.be/auth/refnis2019/55085> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/55000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "55085";
+  skos:prefLabel "Seneffe"@de, "Seneffe"@fr, "Seneffe"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2786853/>, <http://www.wikidata.org/entity/Q669051>,
+    <http://vocab.belgif.be/auth/refnis1995/52063>, <http://vocab.belgif.be/auth/refnis2025/55085> .
+
+<http://vocab.belgif.be/auth/refnis2019/55086> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/55000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "55086";
+  skos:prefLabel "Manage"@de, "Manage"@fr, "Manage"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2791815/>, <http://www.wikidata.org/entity/Q667987>,
+    <http://vocab.belgif.be/auth/refnis1995/52043>, <http://vocab.belgif.be/auth/refnis2025/55086> .
+
+<http://vocab.belgif.be/auth/refnis2019/52074> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/52000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "52074";
+  skos:prefLabel "Aiseau-Presles"@de, "Aiseau-Presles"@fr, "Aiseau-Presles"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2803324/>, <http://www.wikidata.org/entity/Q95004>,
+    <http://vocab.belgif.be/auth/refnis1995/52074>, <http://vocab.belgif.be/auth/refnis2025/52074> .
+
+<http://vocab.belgif.be/auth/refnis2019/52075> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/52000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "52075";
+  skos:prefLabel "Les Bons Villers"@de, "Les Bons Villers"@fr, "Les Bons Villers"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2784626/>, <http://www.wikidata.org/entity/Q95123>,
+    <http://vocab.belgif.be/auth/refnis1995/52075>, <http://vocab.belgif.be/auth/refnis2025/52075> .
+
+<http://vocab.belgif.be/auth/refnis2019/53014> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/53000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "53014";
+  skos:prefLabel "Boussu"@de, "Boussu"@fr, "Boussu"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2801227/>, <http://www.wikidata.org/entity/Q95126>,
+    <http://vocab.belgif.be/auth/refnis1995/53014>, <http://vocab.belgif.be/auth/refnis2025/53014> .
+
+<http://vocab.belgif.be/auth/refnis2019/53020> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/53000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "53020";
+  skos:prefLabel "Dour"@de, "Dour"@fr, "Dour"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2799227/>, <http://www.wikidata.org/entity/Q665938>,
+    <http://vocab.belgif.be/auth/refnis1995/53020>, <http://vocab.belgif.be/auth/refnis2025/53020> .
+
+<http://vocab.belgif.be/auth/refnis2019/53028> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/53000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "53028";
+  skos:prefLabel "Frameries"@de, "Frameries"@fr, "Frameries"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2798024/>, <http://www.wikidata.org/entity/Q666751>,
+    <http://vocab.belgif.be/auth/refnis1995/53028>, <http://vocab.belgif.be/auth/refnis2025/53028> .
+
+<http://vocab.belgif.be/auth/refnis2019/53039> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/53000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "53039";
+  skos:prefLabel "Hensies"@de, "Hensies"@fr, "Hensies"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2796057/>, <http://www.wikidata.org/entity/Q666983>,
+    <http://vocab.belgif.be/auth/refnis1995/53039>, <http://vocab.belgif.be/auth/refnis2025/53039> .
+
+<http://vocab.belgif.be/auth/refnis2019/53044> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/53000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "53044";
+  skos:prefLabel "Jurbise"@de, "Jurbise"@fr, "Jurbeke"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2794853/>, <http://www.wikidata.org/entity/Q377152>,
+    <http://vocab.belgif.be/auth/refnis1995/53044>, <http://vocab.belgif.be/auth/refnis2025/53044> .
+
+<http://vocab.belgif.be/auth/refnis2019/53046> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/53000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "53046";
+  skos:prefLabel "Lens"@de, "Lens"@fr, "Lens"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2792872/>, <http://www.wikidata.org/entity/Q667158>,
+    <http://vocab.belgif.be/auth/refnis1995/53046>, <http://vocab.belgif.be/auth/refnis2025/53046> .
+
+<http://vocab.belgif.be/auth/refnis2019/53053> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/53000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "53053";
+  skos:prefLabel "Mons"@de, "Mons"@fr, "Bergen"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2790871/>, <http://www.wikidata.org/entity/Q83407>,
+    <http://vocab.belgif.be/auth/refnis1995/53053>, <http://vocab.belgif.be/auth/refnis2025/53053> .
+
+<http://vocab.belgif.be/auth/refnis2019/53065> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/53000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "53065";
+  skos:prefLabel "Quaregnon"@de, "Quaregnon"@fr, "Quaregnon"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2788500/>, <http://www.wikidata.org/entity/Q538735>,
+    <http://vocab.belgif.be/auth/refnis1995/53065>, <http://vocab.belgif.be/auth/refnis2025/53065> .
+
+<http://vocab.belgif.be/auth/refnis2019/53068> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/53000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "53068";
+  skos:prefLabel "Quiévrain"@de, "Quiévrain"@fr, "Quiévrain"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2788445/>, <http://www.wikidata.org/entity/Q668815>,
+    <http://vocab.belgif.be/auth/refnis1995/53068>, <http://vocab.belgif.be/auth/refnis2025/53068> .
+
+<http://vocab.belgif.be/auth/refnis2019/53070> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/53000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "53070";
+  skos:prefLabel "Saint-Ghislain"@de, "Saint-Ghislain"@fr, "Saint-Ghislain"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2787417/>, <http://www.wikidata.org/entity/Q668950>,
+    <http://vocab.belgif.be/auth/refnis1995/53070>, <http://vocab.belgif.be/auth/refnis2025/53070> .
+
+<http://vocab.belgif.be/auth/refnis2019/53082> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/53000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "53082";
+  skos:prefLabel "Colfontaine"@de, "Colfontaine"@fr, "Colfontaine"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2800221/>, <http://www.wikidata.org/entity/Q665573>,
+    <http://vocab.belgif.be/auth/refnis1995/53082>, <http://vocab.belgif.be/auth/refnis2025/53082> .
+
+<http://vocab.belgif.be/auth/refnis2019/53083> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/53000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "53083";
+  skos:prefLabel "Honnelles"@de, "Honnelles"@fr, "Honnelles"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2802909/>, <http://www.wikidata.org/entity/Q667091>,
+    <http://vocab.belgif.be/auth/refnis1995/53083>, <http://vocab.belgif.be/auth/refnis2025/53083> .
+
+<http://vocab.belgif.be/auth/refnis2019/53084> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/53000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "53084";
+  skos:prefLabel "Quévy"@de, "Quévy"@fr, "Quévy"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2788448/>, <http://www.wikidata.org/entity/Q668702>,
+    <http://vocab.belgif.be/auth/refnis1995/53084>, <http://vocab.belgif.be/auth/refnis2025/53084> .
+
+<http://vocab.belgif.be/auth/refnis2019/55004> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/55000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "55004";
+  skos:prefLabel "Braine-le-Comte"@de, "Braine-le-Comte"@fr, "’s Gravenbrakel"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2801151/>, <http://www.wikidata.org/entity/Q95129>,
+    <http://vocab.belgif.be/auth/refnis1995/55004>, <http://vocab.belgif.be/auth/refnis2025/55004> .
+
+<http://vocab.belgif.be/auth/refnis2019/55035> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/55000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "55035";
+  skos:prefLabel "Le Roeulx"@de, "Le Roeulx"@fr, "Le Roeulx"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2787879/>, <http://www.wikidata.org/entity/Q668861>,
+    <http://vocab.belgif.be/auth/refnis1995/55035>, <http://vocab.belgif.be/auth/refnis2025/55035> .
+
+<http://vocab.belgif.be/auth/refnis2019/55040> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/55000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "55040";
+  skos:prefLabel "Soignies"@de, "Soignies"@fr, "Zinnik"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2786421/>, <http://www.wikidata.org/entity/Q462985>,
+    <http://vocab.belgif.be/auth/refnis1995/55040>, <http://vocab.belgif.be/auth/refnis2025/55040> .
+
+<http://vocab.belgif.be/auth/refnis2019/55050> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/55000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "55050";
+  skos:prefLabel "Ecaussinnes"@de, "Ecaussinnes"@fr, "Ecaussinnes"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2791740/>, <http://www.wikidata.org/entity/Q273316>,
+    <http://vocab.belgif.be/auth/refnis1995/55050>, <http://vocab.belgif.be/auth/refnis2025/55050> .
+
+<http://vocab.belgif.be/auth/refnis2019/56001> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/56000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "56001";
+  skos:prefLabel "Anderlues"@de, "Anderlues"@fr, "Anderlues"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2803200/>, <http://www.wikidata.org/entity/Q95005>,
+    <http://vocab.belgif.be/auth/refnis1995/56001>, <http://vocab.belgif.be/auth/refnis2025/56001> .
+
+<http://vocab.belgif.be/auth/refnis2019/56005> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/56000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "56005";
+  skos:prefLabel "Beaumont"@de, "Beaumont"@fr, "Beaumont"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2802511/>, <http://www.wikidata.org/entity/Q95100>,
+    <http://vocab.belgif.be/auth/refnis1995/56005>, <http://vocab.belgif.be/auth/refnis2025/56005> .
+
+<http://vocab.belgif.be/auth/refnis2019/56016> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/56000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "56016";
+  skos:prefLabel "Chimay"@de, "Chimay"@fr, "Chimay"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2800326/>, <http://www.wikidata.org/entity/Q95380>,
+    <http://vocab.belgif.be/auth/refnis1995/56016>, <http://vocab.belgif.be/auth/refnis2025/56016> .
+
+<http://vocab.belgif.be/auth/refnis2019/56022> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/56000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "56022";
+  skos:prefLabel "Erquelinnes"@de, "Erquelinnes"@fr, "Erquelinnes"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2798667/>, <http://www.wikidata.org/entity/Q666335>,
+    <http://vocab.belgif.be/auth/refnis1995/56022>, <http://vocab.belgif.be/auth/refnis2025/56022> .
+
+<http://vocab.belgif.be/auth/refnis2019/56029> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/56000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "56029";
+  skos:prefLabel "Froidchapelle"@de, "Froidchapelle"@fr, "Froidchapelle"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2797938/>, <http://www.wikidata.org/entity/Q666853>,
+    <http://vocab.belgif.be/auth/refnis1995/56029>, <http://vocab.belgif.be/auth/refnis2025/56029> .
+
+<http://vocab.belgif.be/auth/refnis2019/56044> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/56000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "56044";
+  skos:prefLabel "Lobbes"@de, "Lobbes"@fr, "Lobbes"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2792246/>, <http://www.wikidata.org/entity/Q667936>,
+    <http://vocab.belgif.be/auth/refnis1995/56044>, <http://vocab.belgif.be/auth/refnis2025/56044> .
+
+<http://vocab.belgif.be/auth/refnis2019/56049> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/56000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "56049";
+  skos:prefLabel "Merbes-le-Château"@de, "Merbes-le-Château"@fr, "Merbes-le-Château"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2791330/>, <http://www.wikidata.org/entity/Q668139>,
+    <http://vocab.belgif.be/auth/refnis1995/56049>, <http://vocab.belgif.be/auth/refnis2025/56049> .
+
+<http://vocab.belgif.be/auth/refnis2019/56051> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/56000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "56051";
+  skos:prefLabel "Momignies"@de, "Momignies"@fr, "Momignies"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2790907/>, <http://www.wikidata.org/entity/Q668187>,
+    <http://vocab.belgif.be/auth/refnis1995/56051>, <http://vocab.belgif.be/auth/refnis2025/56051> .
+
+<http://vocab.belgif.be/auth/refnis2019/56078> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/56000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "56078";
+  skos:prefLabel "Thuin"@de, "Thuin"@fr, "Thuin"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2785518/>, <http://www.wikidata.org/entity/Q669186>,
+    <http://vocab.belgif.be/auth/refnis1995/56078>, <http://vocab.belgif.be/auth/refnis2025/56078> .
+
+<http://vocab.belgif.be/auth/refnis2019/56086> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/56000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "56086";
+  skos:prefLabel "Ham-sur-Heure-Nalinnes"@de, "Ham-sur-Heure-Nalinnes"@fr, "Ham-sur-Heure-Nalinnes"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2796617/>, <http://www.wikidata.org/entity/Q666952>,
+    <http://vocab.belgif.be/auth/refnis1995/56086>, <http://vocab.belgif.be/auth/refnis2025/56086> .
+
+<http://vocab.belgif.be/auth/refnis2019/56088> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/56000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "56088";
+  skos:prefLabel "Sivry-Rance"@de, "Sivry-Rance"@fr, "Sivry-Rance"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2786531/>, <http://www.wikidata.org/entity/Q669136>,
+    <http://vocab.belgif.be/auth/refnis1995/56088>, <http://vocab.belgif.be/auth/refnis2025/56088> .
+
+<http://vocab.belgif.be/auth/refnis2019/57003> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/57000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "57003";
+  skos:prefLabel "Antoing"@de, "Antoing"@fr, "Antoing"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2803145/>, <http://www.wikidata.org/entity/Q95011>,
+    <http://vocab.belgif.be/auth/refnis1995/57003>, <http://vocab.belgif.be/auth/refnis2025/57003> .
+
+<http://vocab.belgif.be/auth/refnis2019/57018> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/57000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "57018";
+  skos:prefLabel "Celles"@de, "Celles"@fr, "Celles"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2800608/>, <http://www.wikidata.org/entity/Q95136>,
+    <http://vocab.belgif.be/auth/refnis1995/57018>, <http://vocab.belgif.be/auth/refnis2025/57018> .
+
+<http://vocab.belgif.be/auth/refnis2019/57027> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/57000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "57027";
+  skos:prefLabel "Estaimpuis"@de, "Estaimpuis"@fr, "Estaimpuis"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2798605/>, <http://www.wikidata.org/entity/Q666393>,
+    <http://vocab.belgif.be/auth/refnis1995/57027>, <http://vocab.belgif.be/auth/refnis2025/57027> .
+
+<http://vocab.belgif.be/auth/refnis2019/57062> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/57000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "57062";
+  skos:prefLabel "Pecq"@de, "Pecq"@fr, "Pecq"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2789237/>, <http://www.wikidata.org/entity/Q668540>,
+    <http://vocab.belgif.be/auth/refnis1995/57062>, <http://vocab.belgif.be/auth/refnis2025/57062> .
+
+<http://vocab.belgif.be/auth/refnis2019/57064> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/57000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "57064";
+  skos:prefLabel "Péruwelz"@de, "Péruwelz"@fr, "Péruwelz"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2789163/>, <http://www.wikidata.org/entity/Q668630>,
+    <http://vocab.belgif.be/auth/refnis1995/57064>, <http://vocab.belgif.be/auth/refnis2025/57064> .
+
+<http://vocab.belgif.be/auth/refnis2019/57072> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/57000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "57072";
+  skos:prefLabel "Rumes"@de, "Rumes"@fr, "Rumes"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2787531/>, <http://www.wikidata.org/entity/Q668903>,
+    <http://vocab.belgif.be/auth/refnis1995/57072>, <http://vocab.belgif.be/auth/refnis2025/57072> .
+
+<http://vocab.belgif.be/auth/refnis2019/57081> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/57000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "57081";
+  skos:prefLabel "Tournai"@de, "Tournai"@fr, "Doornik"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2785342/>, <http://www.wikidata.org/entity/Q173219>,
+    <http://vocab.belgif.be/auth/refnis1995/57081>, <http://vocab.belgif.be/auth/refnis2025/57081> .
+
+<http://vocab.belgif.be/auth/refnis2019/57093> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/57000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "57093";
+  skos:prefLabel "Brunehaut"@de, "Brunehaut"@fr, "Brunehaut"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2801819/>, <http://www.wikidata.org/entity/Q95132>,
+    <http://vocab.belgif.be/auth/refnis1995/57093>, <http://vocab.belgif.be/auth/refnis2025/57093> .
+
+<http://vocab.belgif.be/auth/refnis2019/57094> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/57000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "57094";
+  skos:prefLabel "Leuze-en-Hainaut"@de, "Leuze-en-Hainaut"@fr, "Leuze-en-Hainaut"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2792477/>, <http://www.wikidata.org/entity/Q667862>,
+    <http://vocab.belgif.be/auth/refnis1995/57094>, <http://vocab.belgif.be/auth/refnis2025/57094> .
+
+<http://vocab.belgif.be/auth/refnis2019/57095> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/57000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "57095";
+  skos:prefLabel "Mont-de-l’Enclus"@de, "Mont-de-l’Enclus"@fr, "Mont-de-l’Enclus"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2803156/>, <http://www.wikidata.org/entity/Q668295>,
+    <http://vocab.belgif.be/auth/refnis1995/57095>, <http://vocab.belgif.be/auth/refnis2025/57095> .
+
+<http://vocab.belgif.be/auth/refnis2019/57096> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/57000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "57096";
+  skos:prefLabel "Mouscron"@de, "Mouscron"@fr, "Moeskroen"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2795937/>, <http://www.wikidata.org/entity/Q220145>,
+    <http://vocab.belgif.be/auth/refnis1995/54007>, <http://vocab.belgif.be/auth/refnis2025/57096> .
+
+<http://vocab.belgif.be/auth/refnis2019/57097> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/57000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "57097";
+  skos:prefLabel "Comines-Warneton"@de, "Comines-Warneton"@fr, "Komen-Waasten"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2800196/>, <http://www.wikidata.org/entity/Q665761>,
+    <http://vocab.belgif.be/auth/refnis1995/54010>, <http://vocab.belgif.be/auth/refnis2025/57097> .
+
+<http://vocab.belgif.be/auth/refnis2019/58001> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/58000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "55022";
+  skos:prefLabel "La Louvière"@de, "La Louvière"@fr, "La Louvière"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2793509/>, <http://www.wikidata.org/entity/Q211572>,
+    <http://vocab.belgif.be/auth/refnis1995/55022>, <http://vocab.belgif.be/auth/refnis2025/58001> .
+
+<http://vocab.belgif.be/auth/refnis2019/58002> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/58000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "58002";
+  skos:prefLabel "Binche"@de, "Binche"@fr, "Binche"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2801923/>, <http://www.wikidata.org/entity/Q95121>,
+    <http://vocab.belgif.be/auth/refnis1995/56011>, <http://vocab.belgif.be/auth/refnis2025/58002> .
+
+<http://vocab.belgif.be/auth/refnis2019/58003> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/58000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "58003";
+  skos:prefLabel "Estinnes"@de, "Estinnes"@fr, "Estinnes"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2798598/>, <http://www.wikidata.org/entity/Q666446>,
+    <http://vocab.belgif.be/auth/refnis1995/56085>, <http://vocab.belgif.be/auth/refnis2025/58003> .
+
+<http://vocab.belgif.be/auth/refnis2019/58004> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/58000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "58004";
+  skos:prefLabel "Morlanwelz"@de, "Morlanwelz"@fr, "Morlanwelz"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2790698/>, <http://www.wikidata.org/entity/Q668493>,
+    <http://vocab.belgif.be/auth/refnis1995/56087>, <http://vocab.belgif.be/auth/refnis2025/58004> .
+
+<http://vocab.belgif.be/auth/refnis2019/61003> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/61000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "61003";
+  skos:prefLabel "Amay"@de, "Amay"@fr, "Amay"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2803247/>, <http://www.wikidata.org/entity/Q455969>,
+    <http://vocab.belgif.be/auth/refnis1995/61003>, <http://vocab.belgif.be/auth/refnis2025/61003> .
+
+<http://vocab.belgif.be/auth/refnis2019/61010> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/61000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "61010";
+  skos:prefLabel "Burdinne"@de, "Burdinne"@fr, "Burdinne"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2800762/>, <http://www.wikidata.org/entity/Q681368>,
+    <http://vocab.belgif.be/auth/refnis1995/61010>, <http://vocab.belgif.be/auth/refnis2025/61010> .
+
+<http://vocab.belgif.be/auth/refnis2019/61012> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/61000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "61012";
+  skos:prefLabel "Clavier"@de, "Clavier"@fr, "Clavier"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2800270/>, <http://www.wikidata.org/entity/Q681854>,
+    <http://vocab.belgif.be/auth/refnis1995/61012>, <http://vocab.belgif.be/auth/refnis2025/61012> .
+
+<http://vocab.belgif.be/auth/refnis2019/61019> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/61000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "61019";
+  skos:prefLabel "Ferrières"@de, "Ferrières"@fr, "Ferrières"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2798367/>, <http://www.wikidata.org/entity/Q682570>,
+    <http://vocab.belgif.be/auth/refnis1995/61019>, <http://vocab.belgif.be/auth/refnis2025/61019> .
+
+<http://vocab.belgif.be/auth/refnis2019/61024> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/61000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "61024";
+  skos:prefLabel "Hamoir"@de, "Hamoir"@fr, "Hamoir"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2796630/>, <http://www.wikidata.org/entity/Q683083>,
+    <http://vocab.belgif.be/auth/refnis1995/61024>, <http://vocab.belgif.be/auth/refnis2025/61024> .
+
+<http://vocab.belgif.be/auth/refnis2019/61028> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/61000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "61028";
+  skos:prefLabel "Héron"@de, "Héron"@fr, "Héron"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2795950/>, <http://www.wikidata.org/entity/Q683321>,
+    <http://vocab.belgif.be/auth/refnis1995/61028>, <http://vocab.belgif.be/auth/refnis2025/61028> .
+
+<http://vocab.belgif.be/auth/refnis2019/61031> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/61000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "61031";
+  skos:prefLabel "Huy"@de, "Huy"@fr, "Hoei"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2795114/>, <http://www.wikidata.org/entity/Q207095>,
+    <http://vocab.belgif.be/auth/refnis1995/61031>, <http://vocab.belgif.be/auth/refnis2025/61031> .
+
+<http://vocab.belgif.be/auth/refnis2019/61039> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/61000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "61039";
+  skos:prefLabel "Marchin"@de, "Marchin"@fr, "Marchin"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2791734/>, <http://www.wikidata.org/entity/Q710190>,
+    <http://vocab.belgif.be/auth/refnis1995/61039>, <http://vocab.belgif.be/auth/refnis2025/61039> .
+
+<http://vocab.belgif.be/auth/refnis2019/61041> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/61000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "61041";
+  skos:prefLabel "Modave"@de, "Modave"@fr, "Modave"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2791133/>, <http://www.wikidata.org/entity/Q710237>,
+    <http://vocab.belgif.be/auth/refnis1995/61041>, <http://vocab.belgif.be/auth/refnis2025/61041> .
+
+<http://vocab.belgif.be/auth/refnis2019/61043> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/61000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "61043";
+  skos:prefLabel "Nandrin"@de, "Nandrin"@fr, "Nandrin"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2790468/>, <http://www.wikidata.org/entity/Q710280>,
+    <http://vocab.belgif.be/auth/refnis1995/61043>, <http://vocab.belgif.be/auth/refnis2025/61043> .
+
+<http://vocab.belgif.be/auth/refnis2019/61048> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/61000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "61048";
+  skos:prefLabel "Ouffet"@de, "Ouffet"@fr, "Ouffet"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2789480/>, <http://www.wikidata.org/entity/Q222233>,
+    <http://vocab.belgif.be/auth/refnis1995/61048>, <http://vocab.belgif.be/auth/refnis2025/61048> .
+
+<http://vocab.belgif.be/auth/refnis2019/61063> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/61000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "61063";
+  skos:prefLabel "Verlaine"@de, "Verlaine"@fr, "Verlaine"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2784859/>, <http://www.wikidata.org/entity/Q711292>,
+    <http://vocab.belgif.be/auth/refnis1995/61063>, <http://vocab.belgif.be/auth/refnis2025/61063> .
+
+<http://vocab.belgif.be/auth/refnis2019/61068> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/61000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "61068";
+  skos:prefLabel "Villers-Le-Bouillet"@de, "Villers-Le-Bouillet"@fr, "Villers-Le-Bouillet"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2784640/>, <http://www.wikidata.org/entity/Q711373>,
+    <http://vocab.belgif.be/auth/refnis1995/61068>, <http://vocab.belgif.be/auth/refnis2025/61068> .
+
+<http://vocab.belgif.be/auth/refnis2019/61072> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/61000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "61072";
+  skos:prefLabel "Wanze"@de, "Wanze"@fr, "Wanze"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2784093/>, <http://www.wikidata.org/entity/Q711443>,
+    <http://vocab.belgif.be/auth/refnis1995/61072>, <http://vocab.belgif.be/auth/refnis2025/61072> .
+
+<http://vocab.belgif.be/auth/refnis2019/61079> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/61000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "61079";
+  skos:prefLabel "Anthisnes"@de, "Anthisnes"@fr, "Anthisnes"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2803149/>, <http://www.wikidata.org/entity/Q572472>,
+    <http://vocab.belgif.be/auth/refnis1995/61079>, <http://vocab.belgif.be/auth/refnis2025/61079> .
+
+<http://vocab.belgif.be/auth/refnis2019/61080> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/61000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "61080";
+  skos:prefLabel "Engis"@de, "Engis"@fr, "Engis"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2798744/>, <http://www.wikidata.org/entity/Q682223>,
+    <http://vocab.belgif.be/auth/refnis1995/61080>, <http://vocab.belgif.be/auth/refnis2025/61080> .
+
+<http://vocab.belgif.be/auth/refnis2019/61081> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/61000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "61081";
+  skos:prefLabel "Tinlot"@de, "Tinlot"@fr, "Tinlot"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2786426/>, <http://www.wikidata.org/entity/Q711152>,
+    <http://vocab.belgif.be/auth/refnis1995/61081>, <http://vocab.belgif.be/auth/refnis2025/61081> .
+
+<http://vocab.belgif.be/auth/refnis2019/62003> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/62000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "62003";
+  skos:prefLabel "Ans"@de, "Ans"@fr, "Ans"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2803161/>, <http://www.wikidata.org/entity/Q499594>,
+    <http://vocab.belgif.be/auth/refnis1995/62003>, <http://vocab.belgif.be/auth/refnis2025/62003> .
+
+<http://vocab.belgif.be/auth/refnis2019/62006> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/62000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "62006";
+  skos:prefLabel "Awans"@de, "Awans"@fr, "Awans"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2802851/>, <http://www.wikidata.org/entity/Q680564>,
+    <http://vocab.belgif.be/auth/refnis1995/62006>, <http://vocab.belgif.be/auth/refnis2025/62006> .
+
+<http://vocab.belgif.be/auth/refnis2019/62009> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/62000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "62009";
+  skos:prefLabel "Aywaille"@de, "Aywaille"@fr, "Aywaille"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2802838/>, <http://www.wikidata.org/entity/Q793396>,
+    <http://vocab.belgif.be/auth/refnis1995/62009>, <http://vocab.belgif.be/auth/refnis2025/62009> .
+
+<http://vocab.belgif.be/auth/refnis2019/62011> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/62000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "62011";
+  skos:prefLabel "Bassenge"@de, "Bassenge"@fr, "Bitsingen"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2802607/>, <http://www.wikidata.org/entity/Q680918>,
+    <http://vocab.belgif.be/auth/refnis1995/62011>, <http://vocab.belgif.be/auth/refnis2025/62011> .
+
+<http://vocab.belgif.be/auth/refnis2019/62015> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/62000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "62015";
+  skos:prefLabel "Beyne-Heusay"@de, "Beyne-Heusay"@fr, "Beyne-Heusay"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2802016/>, <http://www.wikidata.org/entity/Q681039>,
+    <http://vocab.belgif.be/auth/refnis1995/62015>, <http://vocab.belgif.be/auth/refnis2025/62015> .
+
+<http://vocab.belgif.be/auth/refnis2019/62022> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/62000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "62022";
+  skos:prefLabel "Chaudfontaine"@de, "Chaudfontaine"@fr, "Chaudfontaine"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2800439/>, <http://www.wikidata.org/entity/Q503363>,
+    <http://vocab.belgif.be/auth/refnis1995/62022>, <http://vocab.belgif.be/auth/refnis2025/62022> .
+
+<http://vocab.belgif.be/auth/refnis2019/62026> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/62000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "62026";
+  skos:prefLabel "Comblain-au-Pont"@de, "Comblain-au-Pont"@fr, "Comblain-au-Pont"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2800205/>, <http://www.wikidata.org/entity/Q681909>,
+    <http://vocab.belgif.be/auth/refnis1995/62026>, <http://vocab.belgif.be/auth/refnis2025/62026> .
+
+<http://vocab.belgif.be/auth/refnis2019/62027> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/62000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "62027";
+  skos:prefLabel "Dalhem"@de, "Dalhem"@fr, "Dalhem"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2799898/>, <http://www.wikidata.org/entity/Q846182>,
+    <http://vocab.belgif.be/auth/refnis1995/62027>, <http://vocab.belgif.be/auth/refnis2025/62027> .
+
+<http://vocab.belgif.be/auth/refnis2019/62032> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/62000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "62032";
+  skos:prefLabel "Esneux"@de, "Esneux"@fr, "Esneux"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2798637/>, <http://www.wikidata.org/entity/Q682271>,
+    <http://vocab.belgif.be/auth/refnis1995/62032>, <http://vocab.belgif.be/auth/refnis2025/62032> .
+
+<http://vocab.belgif.be/auth/refnis2019/62038> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/62000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "62038";
+  skos:prefLabel "Fléron"@de, "Fléron"@fr, "Fléron"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2798302/>, <http://www.wikidata.org/entity/Q682811>,
+    <http://vocab.belgif.be/auth/refnis1995/62038>, <http://vocab.belgif.be/auth/refnis2025/62038> .
+
+<http://vocab.belgif.be/auth/refnis2019/62051> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/62000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "62051";
+  skos:prefLabel "Herstal"@de, "Herstal"@fr, "Herstal"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2795931/>, <http://www.wikidata.org/entity/Q211033>,
+    <http://vocab.belgif.be/auth/refnis1995/62051>, <http://vocab.belgif.be/auth/refnis2025/62051> .
+
+<http://vocab.belgif.be/auth/refnis2019/62060> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/62000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "62060";
+  skos:prefLabel "Juprelle"@de, "Juprelle"@fr, "Juprelle"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2794855/>, <http://www.wikidata.org/entity/Q914102>,
+    <http://vocab.belgif.be/auth/refnis1995/62060>, <http://vocab.belgif.be/auth/refnis2025/62060> .
+
+<http://vocab.belgif.be/auth/refnis2019/62063> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/62000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "62063";
+  skos:prefLabel "Lüttich"@de, "Liège"@fr, "Luik"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2792414/>, <http://www.wikidata.org/entity/Q3992>,
+    <http://vocab.belgif.be/auth/refnis1995/62063>, <http://vocab.belgif.be/auth/refnis2025/62063> .
+
+<http://vocab.belgif.be/auth/refnis2019/62079> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/62000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "62079";
+  skos:prefLabel "Oupeye"@de, "Oupeye"@fr, "Oupeye"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2789472/>, <http://www.wikidata.org/entity/Q286215>,
+    <http://vocab.belgif.be/auth/refnis1995/62079>, <http://vocab.belgif.be/auth/refnis2025/62079> .
+
+<http://vocab.belgif.be/auth/refnis2019/62093> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/62000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "62093";
+  skos:prefLabel "Saint-Nicolas"@de, "Saint-Nicolas"@fr, "Saint-Nicolas"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2787357/>, <http://www.wikidata.org/entity/Q65062>,
+    <http://vocab.belgif.be/auth/refnis1995/62093>, <http://vocab.belgif.be/auth/refnis2025/62093> .
+
+<http://vocab.belgif.be/auth/refnis2019/62096> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/62000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "62096";
+  skos:prefLabel "Seraing"@de, "Seraing"@fr, "Seraing"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2786825/>, <http://www.wikidata.org/entity/Q194037>,
+    <http://vocab.belgif.be/auth/refnis1995/62096>, <http://vocab.belgif.be/auth/refnis2025/62096> .
+
+<http://vocab.belgif.be/auth/refnis2019/62099> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/62000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "62099";
+  skos:prefLabel "Soumagne"@de, "Soumagne"@fr, "Soumagne"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2786345/>, <http://www.wikidata.org/entity/Q696099>,
+    <http://vocab.belgif.be/auth/refnis1995/62099>, <http://vocab.belgif.be/auth/refnis2025/62099> .
+
+<http://vocab.belgif.be/auth/refnis2019/62100> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/62000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "62100";
+  skos:prefLabel "Sprimont"@de, "Sprimont"@fr, "Sprimont"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2786244/>, <http://www.wikidata.org/entity/Q696110>,
+    <http://vocab.belgif.be/auth/refnis1995/62100>, <http://vocab.belgif.be/auth/refnis2025/62100> .
+
+<http://vocab.belgif.be/auth/refnis2019/62108> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/62000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "62108";
+  skos:prefLabel "Visé"@de, "Visé"@fr, "Wezet"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2784549/>, <http://www.wikidata.org/entity/Q49743>,
+    <http://vocab.belgif.be/auth/refnis1995/62108>, <http://vocab.belgif.be/auth/refnis2025/62108> .
+
+<http://vocab.belgif.be/auth/refnis2019/62118> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/62000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "62118";
+  skos:prefLabel "Grâce-Hollogne"@de, "Grâce-Hollogne"@fr, "Grâce-Hollogne"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2797337/>, <http://www.wikidata.org/entity/Q683034>,
+    <http://vocab.belgif.be/auth/refnis1995/62118>, <http://vocab.belgif.be/auth/refnis2025/62118> .
+
+<http://vocab.belgif.be/auth/refnis2019/62119> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/62000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "62119";
+  skos:prefLabel "Blegny"@de, "Blegny"@fr, "Blegny"@nl;
+  skos:altLabel "Blégny"@de, "Blégny"@fr, "Blégny"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2802681/>, <http://www.wikidata.org/entity/Q681109>,
+    <http://vocab.belgif.be/auth/refnis1995/62119>, <http://vocab.belgif.be/auth/refnis2025/62119> .
+
+<http://vocab.belgif.be/auth/refnis2019/62120> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/62000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "62120";
+  skos:prefLabel "Flémalle"@de, "Flémalle"@fr, "Flémalle"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2798310/>, <http://www.wikidata.org/entity/Q175322>,
+    <http://vocab.belgif.be/auth/refnis1995/62120>, <http://vocab.belgif.be/auth/refnis2025/62120> .
+
+<http://vocab.belgif.be/auth/refnis2019/62121> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/62000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "62121";
+  skos:prefLabel "Neupré"@de, "Neupré"@fr, "Neupré"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2790241/>, <http://www.wikidata.org/entity/Q710316>,
+    <http://vocab.belgif.be/auth/refnis1995/62121>, <http://vocab.belgif.be/auth/refnis2025/62121> .
+
+<http://vocab.belgif.be/auth/refnis2019/62122> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/62000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "62122";
+  skos:prefLabel "Trooz"@de, "Trooz"@fr, "Trooz"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2798035/>, <http://www.wikidata.org/entity/Q711205>,
+    <http://vocab.belgif.be/auth/refnis1995/62122>, <http://vocab.belgif.be/auth/refnis2025/62122> .
+
+<http://vocab.belgif.be/auth/refnis2019/63001> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/63000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "63001";
+  skos:prefLabel "Amel"@de, "Amblève"@fr, "Amel"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2803243/>, <http://www.wikidata.org/entity/Q159868>,
+    <http://vocab.belgif.be/auth/refnis1995/63001>, <http://vocab.belgif.be/auth/refnis2025/63001> .
+
+<http://vocab.belgif.be/auth/refnis2019/63003> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/63000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "63003";
+  skos:prefLabel "Aubel"@de, "Aubel"@fr, "Aubel"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2802986/>, <http://www.wikidata.org/entity/Q678920>,
+    <http://vocab.belgif.be/auth/refnis1995/63003>, <http://vocab.belgif.be/auth/refnis2025/63003> .
+
+<http://vocab.belgif.be/auth/refnis2019/63004> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/63000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "63004";
+  skos:prefLabel "Baelen"@de, "Baelen"@fr, "Baelen"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2802788/>, <http://www.wikidata.org/entity/Q680845>,
+    <http://vocab.belgif.be/auth/refnis1995/63004>, <http://vocab.belgif.be/auth/refnis2025/63004> .
+
+<http://vocab.belgif.be/auth/refnis2019/63012> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/63000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "63012";
+  skos:prefLabel "Büllingen"@de, "Bullange"@fr, "Büllingen"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2800783/>, <http://www.wikidata.org/entity/Q152737>,
+    <http://vocab.belgif.be/auth/refnis1995/63012>, <http://vocab.belgif.be/auth/refnis2025/63012> .
+
+<http://vocab.belgif.be/auth/refnis2019/63013> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/63000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "63013";
+  skos:prefLabel "Bütgenbach"@de, "Butgenbach"@fr, "Bütgenbach"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2800712/>, <http://www.wikidata.org/entity/Q160005>,
+    <http://vocab.belgif.be/auth/refnis1995/63013>, <http://vocab.belgif.be/auth/refnis2025/63013> .
+
+<http://vocab.belgif.be/auth/refnis2019/63020> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/63000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "63020";
+  skos:prefLabel "Dison"@de, "Dison"@fr, "Dison"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2799348/>, <http://www.wikidata.org/entity/Q682105>,
+    <http://vocab.belgif.be/auth/refnis1995/63020>, <http://vocab.belgif.be/auth/refnis2025/63020> .
+
+<http://vocab.belgif.be/auth/refnis2019/63023> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/63000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "63023";
+  skos:prefLabel "Eupen"@de, "Eupen"@fr, "Eupen"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2798574/>, <http://www.wikidata.org/entity/Q151831>,
+    <http://vocab.belgif.be/auth/refnis1995/63023>, <http://vocab.belgif.be/auth/refnis2025/63023> .
+
+<http://vocab.belgif.be/auth/refnis2019/63035> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/63000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "63035";
+  skos:prefLabel "Herve"@de, "Herve"@fr, "Herve"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2795913/>, <http://www.wikidata.org/entity/Q683465>,
+    <http://vocab.belgif.be/auth/refnis1995/63035>, <http://vocab.belgif.be/auth/refnis2025/63035> .
+
+<http://vocab.belgif.be/auth/refnis2019/63038> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/63000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "63038";
+  skos:prefLabel "Jalhay"@de, "Jalhay"@fr, "Jalhay"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2794990/>, <http://www.wikidata.org/entity/Q683634>,
+    <http://vocab.belgif.be/auth/refnis1995/63038>, <http://vocab.belgif.be/auth/refnis2025/63038> .
+
+<http://vocab.belgif.be/auth/refnis2019/63040> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/63000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "63040";
+  skos:prefLabel "Kelmis"@de, "La Calamine"@fr, "Kelmis"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2793723/>, <http://www.wikidata.org/entity/Q159864>,
+    <http://vocab.belgif.be/auth/refnis1995/63040>, <http://vocab.belgif.be/auth/refnis2025/63040> .
+
+<http://vocab.belgif.be/auth/refnis2019/63045> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/63000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "63045";
+  skos:prefLabel "Lierneux"@de, "Lierneux"@fr, "Lierneux"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2792401/>, <http://www.wikidata.org/entity/Q710022>,
+    <http://vocab.belgif.be/auth/refnis1995/63045>, <http://vocab.belgif.be/auth/refnis2025/63045> .
+
+<http://vocab.belgif.be/auth/refnis2019/63046> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/63000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "63046";
+  skos:prefLabel "Limbourg"@de, "Limbourg"@fr, "Limburg"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2792349/>, <http://www.wikidata.org/entity/Q506739>,
+    <http://vocab.belgif.be/auth/refnis1995/63046>, <http://vocab.belgif.be/auth/refnis2025/63046> .
+
+<http://vocab.belgif.be/auth/refnis2019/63048> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/63000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "63048";
+  skos:prefLabel "Lontzen"@de, "Lontzen"@fr, "Lontzen"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2792120/>, <http://www.wikidata.org/entity/Q159958>,
+    <http://vocab.belgif.be/auth/refnis1995/63048>, <http://vocab.belgif.be/auth/refnis2025/63048> .
+
+<http://vocab.belgif.be/auth/refnis2019/63049> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/63000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "63049";
+  skos:prefLabel "Malmedy"@de, "Malmedy"@fr, "Malmedy"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2791835/>, <http://www.wikidata.org/entity/Q159838>,
+    <http://vocab.belgif.be/auth/refnis1995/63049>, <http://vocab.belgif.be/auth/refnis2025/63049> .
+
+<http://vocab.belgif.be/auth/refnis2019/63057> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/63000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "63057";
+  skos:prefLabel "Olne"@de, "Olne"@fr, "Olne"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2789870/>, <http://www.wikidata.org/entity/Q710358>,
+    <http://vocab.belgif.be/auth/refnis1995/63057>, <http://vocab.belgif.be/auth/refnis2025/63057> .
+
+<http://vocab.belgif.be/auth/refnis2019/63058> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/63000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "63058";
+  skos:prefLabel "Pepinster"@de, "Pepinster"@fr, "Pepinster"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2789191/>, <http://www.wikidata.org/entity/Q710522>,
+    <http://vocab.belgif.be/auth/refnis1995/63058>, <http://vocab.belgif.be/auth/refnis2025/63058> .
+
+<http://vocab.belgif.be/auth/refnis2019/63061> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/63000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "63061";
+  skos:prefLabel "Raeren"@de, "Raeren"@fr, "Raeren"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2788411/>, <http://www.wikidata.org/entity/Q152734>,
+    <http://vocab.belgif.be/auth/refnis1995/63061>, <http://vocab.belgif.be/auth/refnis2025/63061> .
+
+<http://vocab.belgif.be/auth/refnis2019/63067> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/63000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "63067";
+  skos:prefLabel "Sankt Vith"@de, "Saint-Vith"@fr, "Sankt Vith"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2787316/>, <http://www.wikidata.org/entity/Q152748>,
+    <http://vocab.belgif.be/auth/refnis1995/63067>, <http://vocab.belgif.be/auth/refnis2025/63067> .
+
+<http://vocab.belgif.be/auth/refnis2019/63072> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/63000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "63072";
+  skos:prefLabel "Spa"@de, "Spa"@fr, "Spa"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2786319/>, <http://www.wikidata.org/entity/Q39865>,
+    <http://vocab.belgif.be/auth/refnis1995/63072>, <http://vocab.belgif.be/auth/refnis2025/63072> .
+
+<http://vocab.belgif.be/auth/refnis2019/63073> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/63000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "63073";
+  skos:prefLabel "Stavelot"@de, "Stavelot"@fr, "Stavelot"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2786186/>, <http://www.wikidata.org/entity/Q468920>,
+    <http://vocab.belgif.be/auth/refnis1995/63073>, <http://vocab.belgif.be/auth/refnis2025/63073> .
+
+<http://vocab.belgif.be/auth/refnis2019/63075> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/63000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "63075";
+  skos:prefLabel "Stoumont"@de, "Stoumont"@fr, "Stoumont"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2785990/>, <http://www.wikidata.org/entity/Q711046>,
+    <http://vocab.belgif.be/auth/refnis1995/63075>, <http://vocab.belgif.be/auth/refnis2025/63075> .
+
+<http://vocab.belgif.be/auth/refnis2019/63076> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/63000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "63076";
+  skos:prefLabel "Theux"@de, "Theux"@fr, "Theux"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2785594/>, <http://www.wikidata.org/entity/Q711079>,
+    <http://vocab.belgif.be/auth/refnis1995/63076>, <http://vocab.belgif.be/auth/refnis2025/63076> .
+
+<http://vocab.belgif.be/auth/refnis2019/63079> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/63000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "63079";
+  skos:prefLabel "Verviers"@de, "Verviers"@fr, "Verviers"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2784822/>, <http://www.wikidata.org/entity/Q202954>,
+    <http://vocab.belgif.be/auth/refnis1995/63079>, <http://vocab.belgif.be/auth/refnis2025/63079> .
+
+<http://vocab.belgif.be/auth/refnis2019/63080> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/63000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "63080";
+  skos:prefLabel "Weismes"@de, "Waimes"@fr, "Weismes"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2784200/>, <http://www.wikidata.org/entity/Q159961>,
+    <http://vocab.belgif.be/auth/refnis1995/63080>, <http://vocab.belgif.be/auth/refnis2025/63080> .
+
+<http://vocab.belgif.be/auth/refnis2019/63084> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/63000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "63084";
+  skos:prefLabel "Welkenraedt"@de, "Welkenraedt"@fr, "Welkenraedt"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2783871/>, <http://www.wikidata.org/entity/Q152743>,
+    <http://vocab.belgif.be/auth/refnis1995/63084>, <http://vocab.belgif.be/auth/refnis2025/63084> .
+
+<http://vocab.belgif.be/auth/refnis2019/63086> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/63000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "63086";
+  skos:prefLabel "Trois-Ponts"@de, "Trois-Ponts"@fr, "Trois-Ponts"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2784103/>, <http://www.wikidata.org/entity/Q711183>,
+    <http://vocab.belgif.be/auth/refnis1995/63086>, <http://vocab.belgif.be/auth/refnis2025/63086> .
+
+<http://vocab.belgif.be/auth/refnis2019/63087> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/63000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "63087";
+  skos:prefLabel "Burg-Reuland"@de, "Burg-Reuland"@fr, "Burg-Reuland"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2788132/>, <http://www.wikidata.org/entity/Q159981>,
+    <http://vocab.belgif.be/auth/refnis1995/63087>, <http://vocab.belgif.be/auth/refnis2025/63087> .
+
+<http://vocab.belgif.be/auth/refnis2019/63088> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/63000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "63088";
+  skos:prefLabel "Plombières"@de, "Plombières"@fr, "Plombières"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2797697/>, <http://www.wikidata.org/entity/Q710606>,
+    <http://vocab.belgif.be/auth/refnis1995/63088>, <http://vocab.belgif.be/auth/refnis2025/63088> .
+
+<http://vocab.belgif.be/auth/refnis2019/63089> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/63000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "63089";
+  skos:prefLabel "Thimister-Clermont"@de, "Thimister-Clermont"@fr, "Thimister-Clermont"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2785563/>, <http://www.wikidata.org/entity/Q711115>,
+    <http://vocab.belgif.be/auth/refnis1995/63089>, <http://vocab.belgif.be/auth/refnis2025/63089> .
+
+<http://vocab.belgif.be/auth/refnis2019/64008> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/64000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "64008";
+  skos:prefLabel "Berloz"@de, "Berloz"@fr, "Berloz"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2802144/>, <http://www.wikidata.org/entity/Q680978>,
+    <http://vocab.belgif.be/auth/refnis1995/64008>, <http://vocab.belgif.be/auth/refnis2025/64008> .
+
+<http://vocab.belgif.be/auth/refnis2019/64015> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/64000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "64015";
+  skos:prefLabel "Braives"@de, "Braives"@fr, "Braives"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2801148/>, <http://www.wikidata.org/entity/Q681153>,
+    <http://vocab.belgif.be/auth/refnis1995/64015>, <http://vocab.belgif.be/auth/refnis2025/64015> .
+
+<http://vocab.belgif.be/auth/refnis2019/64021> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/64000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "64021";
+  skos:prefLabel "Crisnée"@de, "Crisnée"@fr, "Crisnée"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2799998/>, <http://www.wikidata.org/entity/Q929415>,
+    <http://vocab.belgif.be/auth/refnis1995/64021>, <http://vocab.belgif.be/auth/refnis2025/64021> .
+
+<http://vocab.belgif.be/auth/refnis2019/64023> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/64000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "64023";
+  skos:prefLabel "Donceel"@de, "Donceel"@fr, "Donceel"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2799318/>, <http://www.wikidata.org/entity/Q682163>,
+    <http://vocab.belgif.be/auth/refnis1995/64023>, <http://vocab.belgif.be/auth/refnis2025/64023> .
+
+<http://vocab.belgif.be/auth/refnis2019/64025> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/64000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "64025";
+  skos:prefLabel "Fexhe-le-Haut-Clocher"@de, "Fexhe-le-Haut-Clocher"@fr, "Fexhe-le-Haut-Clocher"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2798358/>, <http://www.wikidata.org/entity/Q379113>,
+    <http://vocab.belgif.be/auth/refnis1995/64025>, <http://vocab.belgif.be/auth/refnis2025/64025> .
+
+<http://vocab.belgif.be/auth/refnis2019/64029> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/64000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "64029";
+  skos:prefLabel "Geer"@de, "Geer"@fr, "Geer"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2797771/>, <http://www.wikidata.org/entity/Q682982>,
+    <http://vocab.belgif.be/auth/refnis1995/64029>, <http://vocab.belgif.be/auth/refnis2025/64029> .
+
+<http://vocab.belgif.be/auth/refnis2019/64034> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/64000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "64034";
+  skos:prefLabel "Hannut"@de, "Hannut"@fr, "Hannuit"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2796584/>, <http://www.wikidata.org/entity/Q683141>,
+    <http://vocab.belgif.be/auth/refnis1995/64034>, <http://vocab.belgif.be/auth/refnis2025/64034> .
+
+<http://vocab.belgif.be/auth/refnis2019/64047> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/64000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "64047";
+  skos:prefLabel "Lincent"@de, "Lincent"@fr, "Lijsem"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2792333/>, <http://www.wikidata.org/entity/Q509457>,
+    <http://vocab.belgif.be/auth/refnis1995/64047>, <http://vocab.belgif.be/auth/refnis2025/64047> .
+
+<http://vocab.belgif.be/auth/refnis2019/64056> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/64000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "64056";
+  skos:prefLabel "Oreye"@de, "Oreye"@fr, "Oerle"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2789636/>, <http://www.wikidata.org/entity/Q710409>,
+    <http://vocab.belgif.be/auth/refnis1995/64056>, <http://vocab.belgif.be/auth/refnis2025/64056> .
+
+<http://vocab.belgif.be/auth/refnis2019/64063> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/64000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "64063";
+  skos:prefLabel "Remicourt"@de, "Remicourt"@fr, "Remicourt"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2788212/>, <http://www.wikidata.org/entity/Q710690>,
+    <http://vocab.belgif.be/auth/refnis1995/64063>, <http://vocab.belgif.be/auth/refnis2025/64063> .
+
+<http://vocab.belgif.be/auth/refnis2019/64065> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/64000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "64065";
+  skos:prefLabel "Saint-Georges-sur-Meuse"@de, "Saint-Georges-sur-Meuse"@fr, "Saint-Georges-sur-Meuse"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2787426/>, <http://www.wikidata.org/entity/Q710718>,
+    <http://vocab.belgif.be/auth/refnis1995/64065>, <http://vocab.belgif.be/auth/refnis2025/64065> .
+
+<http://vocab.belgif.be/auth/refnis2019/64074> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/64000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "64074";
+  skos:prefLabel "Waremme"@de, "Waremme"@fr, "Borgworm"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2797322/>, <http://www.wikidata.org/entity/Q711474>,
+    <http://vocab.belgif.be/auth/refnis1995/64074>, <http://vocab.belgif.be/auth/refnis2025/64074> .
+
+<http://vocab.belgif.be/auth/refnis2019/64075> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/64000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "64075";
+  skos:prefLabel "Wasseiges"@de, "Wasseiges"@fr, "Wasseiges"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2784011/>, <http://www.wikidata.org/entity/Q711502>,
+    <http://vocab.belgif.be/auth/refnis1995/64075>, <http://vocab.belgif.be/auth/refnis2025/64075> .
+
+<http://vocab.belgif.be/auth/refnis2019/64076> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/64000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "64076";
+  skos:prefLabel "Faimes"@de, "Faimes"@fr, "Faimes"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2800609/>, <http://www.wikidata.org/entity/Q682441>,
+    <http://vocab.belgif.be/auth/refnis1995/64076>, <http://vocab.belgif.be/auth/refnis2025/64076> .
+
+<http://vocab.belgif.be/auth/refnis2019/71002> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/71000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "71002";
+  skos:prefLabel "As"@de, "As"@fr, "As"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2803054/>, <http://www.wikidata.org/entity/Q696591>,
+    <http://vocab.belgif.be/auth/refnis1995/71002>, <http://vocab.belgif.be/auth/refnis2025/71002> .
+
+<http://vocab.belgif.be/auth/refnis2019/71004> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/71000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "71004";
+  skos:prefLabel "Beringen"@de, "Beringen"@fr, "Beringen"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2802172/>, <http://www.wikidata.org/entity/Q242407>,
+    <http://vocab.belgif.be/auth/refnis1995/71004>, <http://vocab.belgif.be/auth/refnis2025/71004> .
+
+<http://vocab.belgif.be/auth/refnis2019/71011> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/71000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "71011";
+  skos:prefLabel "Diepenbeek"@de, "Diepenbeek"@fr, "Diepenbeek"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2799413/>, <http://www.wikidata.org/entity/Q651826>,
+    <http://vocab.belgif.be/auth/refnis1995/71011>, <http://vocab.belgif.be/auth/refnis2025/71011> .
+
+<http://vocab.belgif.be/auth/refnis2019/71016> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/71000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "71016";
+  skos:prefLabel "Genk"@de, "Genk"@fr, "Genk"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2797671/>, <http://www.wikidata.org/entity/Q189692>,
+    <http://vocab.belgif.be/auth/refnis1995/71016>, <http://vocab.belgif.be/auth/refnis2025/71016> .
+
+<http://vocab.belgif.be/auth/refnis2019/71017> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/71000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "71017";
+  skos:prefLabel "Gingelom"@de, "Gingelom"@fr, "Gingelom"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2797524/>, <http://www.wikidata.org/entity/Q651837>,
+    <http://vocab.belgif.be/auth/refnis1995/71017>, <http://vocab.belgif.be/auth/refnis2025/71017> .
+
+<http://vocab.belgif.be/auth/refnis2019/71020> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/71000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "71020";
+  skos:prefLabel "Halen"@de, "Halen"@fr, "Halen"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2796716/>, <http://www.wikidata.org/entity/Q461436>,
+    <http://vocab.belgif.be/auth/refnis1995/71020>, <http://vocab.belgif.be/auth/refnis2025/71020> .
+
+<http://vocab.belgif.be/auth/refnis2019/71022> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/71000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "71022";
+  skos:prefLabel "Hasselt"@de, "Hasselt"@fr, "Hasselt"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "2025-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2796492/>, <http://www.wikidata.org/entity/Q58780>,
+    <http://vocab.belgif.be/auth/refnis1995/71022>;
+  skos:broadMatch <http://vocab.belgif.be/auth/refnis2025/71072> .
+
+<http://vocab.belgif.be/auth/refnis2019/71024> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/71000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "71024";
+  skos:prefLabel "Herk-de-Stad"@de, "Herck-la-Ville"@fr, "Herk-de-Stad"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2795986/>, <http://www.wikidata.org/entity/Q696585>,
+    <http://vocab.belgif.be/auth/refnis1995/71024>, <http://vocab.belgif.be/auth/refnis2025/71024> .
+
+<http://vocab.belgif.be/auth/refnis2019/71034> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/71000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "71034";
+  skos:prefLabel "Leopoldsburg"@de, "Bourg-Léopold"@fr, "Leopoldsburg"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2792857/>, <http://www.wikidata.org/entity/Q736120>,
+    <http://vocab.belgif.be/auth/refnis1995/71034>, <http://vocab.belgif.be/auth/refnis2025/71034> .
+
+<http://vocab.belgif.be/auth/refnis2019/71037> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/71000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "71037";
+  skos:prefLabel "Lummen"@de, "Lummen"@fr, "Lummen"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2792008/>, <http://www.wikidata.org/entity/Q329628>,
+    <http://vocab.belgif.be/auth/refnis1995/71037>, <http://vocab.belgif.be/auth/refnis2025/71037> .
+
+<http://vocab.belgif.be/auth/refnis2019/71045> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/71000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "71045";
+  skos:prefLabel "Nieuwerkerken"@de, "Nieuwerkerken"@fr, "Nieuwerkerken"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2790181/>, <http://www.wikidata.org/entity/Q696740>,
+    <http://vocab.belgif.be/auth/refnis1995/71045>, <http://vocab.belgif.be/auth/refnis2025/71045> .
+
+<http://vocab.belgif.be/auth/refnis2019/71053> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/71000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "71053";
+  skos:prefLabel "Sint-Truiden"@de, "Saint-Trond"@fr, "Sint-Truiden"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2786546/>, <http://www.wikidata.org/entity/Q37792>,
+    <http://vocab.belgif.be/auth/refnis1995/71053>, <http://vocab.belgif.be/auth/refnis2025/71053> .
+
+<http://vocab.belgif.be/auth/refnis2019/71057> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/71000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "71057";
+  skos:prefLabel "Tessenderlo"@de, "Tessenderlo"@fr, "Tessenderlo"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "2025-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2785613/>, <http://www.wikidata.org/entity/Q740852>,
+    <http://vocab.belgif.be/auth/refnis1995/71057>;
+  skos:broadMatch <http://vocab.belgif.be/auth/refnis2025/71071> .
+
+<http://vocab.belgif.be/auth/refnis2019/71066> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/71000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "71066";
+  skos:prefLabel "Zonhoven"@de, "Zonhoven"@fr, "Zonhoven"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2783189/>, <http://www.wikidata.org/entity/Q133769>,
+    <http://vocab.belgif.be/auth/refnis1995/71066>, <http://vocab.belgif.be/auth/refnis2025/71066> .
+
+<http://vocab.belgif.be/auth/refnis2019/71067> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/71000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "71067";
+  skos:prefLabel "Zutendaal"@de, "Zutendaal"@fr, "Zutendaal"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2783144/>, <http://www.wikidata.org/entity/Q231090>,
+    <http://vocab.belgif.be/auth/refnis1995/71067>, <http://vocab.belgif.be/auth/refnis2025/71067> .
+
+<http://vocab.belgif.be/auth/refnis2019/71069> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/71000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "71069";
+  skos:prefLabel "Ham"@de, "Ham"@fr, "Ham"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "2025-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2789770/>, <http://www.wikidata.org/entity/Q695354>,
+    <http://vocab.belgif.be/auth/refnis1995/71069>;
+  skos:broadMatch <http://vocab.belgif.be/auth/refnis2025/71071> .
+
+<http://vocab.belgif.be/auth/refnis2019/71070> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/71000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "71070";
+  skos:prefLabel "Heusden-Zolder"@de, "Heusden-Zolder"@fr, "Heusden-Zolder"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2795802/>, <http://www.wikidata.org/entity/Q319792>,
+    <http://vocab.belgif.be/auth/refnis1995/71070>, <http://vocab.belgif.be/auth/refnis2025/71070> .
+
+<http://vocab.belgif.be/auth/refnis2019/72003> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/72000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "72003";
+  skos:prefLabel "Bocholt"@de, "Bocholt"@fr, "Bocholt"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2801755/>, <http://www.wikidata.org/entity/Q889044>,
+    <http://vocab.belgif.be/auth/refnis1995/72003>, <http://vocab.belgif.be/auth/refnis2025/72003> .
+
+<http://vocab.belgif.be/auth/refnis2019/72004> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/72000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "72004";
+  skos:prefLabel "Bree"@de, "Bree"@fr, "Bree"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2801094/>, <http://www.wikidata.org/entity/Q275863>,
+    <http://vocab.belgif.be/auth/refnis1995/72004>, <http://vocab.belgif.be/auth/refnis2025/72004> .
+
+<http://vocab.belgif.be/auth/refnis2019/72018> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/72000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "72018";
+  skos:prefLabel "Kinrooi"@de, "Kinrooi"@fr, "Kinrooi"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2794446/>, <http://www.wikidata.org/entity/Q819133>,
+    <http://vocab.belgif.be/auth/refnis1995/72018>, <http://vocab.belgif.be/auth/refnis2025/72018> .
+
+<http://vocab.belgif.be/auth/refnis2019/72020> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/72000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "72020";
+  skos:prefLabel "Lommel"@de, "Lommel"@fr, "Lommel"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2792180/>, <http://www.wikidata.org/entity/Q194366>,
+    <http://vocab.belgif.be/auth/refnis1995/72020>, <http://vocab.belgif.be/auth/refnis2025/72020> .
+
+<http://vocab.belgif.be/auth/refnis2019/72021> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/72000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "72021";
+  skos:prefLabel "Maaseik"@de, "Maaseik"@fr, "Maaseik"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2791965/>, <http://www.wikidata.org/entity/Q110989>,
+    <http://vocab.belgif.be/auth/refnis1995/72021>, <http://vocab.belgif.be/auth/refnis2025/72021> .
+
+<http://vocab.belgif.be/auth/refnis2019/72030> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/72000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "72030";
+  skos:prefLabel "Peer"@de, "Peer"@fr, "Peer"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2789233/>, <http://www.wikidata.org/entity/Q736085>,
+    <http://vocab.belgif.be/auth/refnis1995/72030>, <http://vocab.belgif.be/auth/refnis2025/72030> .
+
+<http://vocab.belgif.be/auth/refnis2019/72037> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/72000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "72037";
+  skos:prefLabel "Hamont-Achel"@de, "Hamont-Achel"@fr, "Hamont-Achel"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2796626/>, <http://www.wikidata.org/entity/Q499599>,
+    <http://vocab.belgif.be/auth/refnis1995/72037>, <http://vocab.belgif.be/auth/refnis2025/72037> .
+
+<http://vocab.belgif.be/auth/refnis2019/72038> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/72000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "72038";
+  skos:prefLabel "Hechtel-Eksel"@de, "Hechtel-Eksel"@fr, "Hechtel-Eksel"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2796320/>, <http://www.wikidata.org/entity/Q819164>,
+    <http://vocab.belgif.be/auth/refnis1995/72038>, <http://vocab.belgif.be/auth/refnis2025/72038> .
+
+<http://vocab.belgif.be/auth/refnis2019/72039> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/72000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "72039";
+  skos:prefLabel "Houthalen-Helchteren"@de, "Houthalen-Helchteren"@fr, "Houthalen-Helchteren"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2795262/>, <http://www.wikidata.org/entity/Q478795>,
+    <http://vocab.belgif.be/auth/refnis1995/72039>, <http://vocab.belgif.be/auth/refnis2025/72039> .
+
+<http://vocab.belgif.be/auth/refnis2019/72041> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/72000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "72041";
+  skos:prefLabel "Dilsen-Stokkem"@de, "Dilsen-Stokkem"@fr, "Dilsen-Stokkem"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2799363/>, <http://www.wikidata.org/entity/Q581246>,
+    <http://vocab.belgif.be/auth/refnis1995/72041>, <http://vocab.belgif.be/auth/refnis2025/72041> .
+
+<http://vocab.belgif.be/auth/refnis2019/72042> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/72000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "72042";
+  skos:prefLabel "Oudsbergen"@de, "Oudsbergen"@fr, "Oudsbergen"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/11995083/>, <https://www.wikidata.org/entity/Q41795471>,
+    <http://vocab.belgif.be/auth/refnis2025/72042>;
+  skos:narrowMatch <https://sws.geonames.org/2791461/>, <http://www.wikidata.org/entity/Q125979>,
+    <http://vocab.belgif.be/auth/refnis1995/72040>, <https://sws.geonames.org/2789715/>,
+    <http://www.wikidata.org/entity/Q651801>, <http://vocab.belgif.be/auth/refnis1995/71047> .
+
+<http://vocab.belgif.be/auth/refnis2019/72043> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/72000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "72043";
+  skos:prefLabel "Pelt"@de, "Pelt"@fr, "Pelt"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/11995106/>, <http://www.wikidata.org/entity/Q42878311>,
+    <https://sws.geonames.org/2789404/>, <http://www.wikidata.org/entity/Q651736>, <http://vocab.belgif.be/auth/refnis1995/72029>,
+    <http://vocab.belgif.be/auth/refnis2025/72043>;
+  skos:narrowMatch <https://sws.geonames.org/2790358/>, <http://www.wikidata.org/entity/Q651751>,
+    <http://vocab.belgif.be/auth/refnis1995/72025> .
+
+<http://vocab.belgif.be/auth/refnis2019/73001> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/73000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "73001";
+  skos:prefLabel "Alken"@de, "Alken"@fr, "Alken"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2803286/>, <http://www.wikidata.org/entity/Q499604>,
+    <http://vocab.belgif.be/auth/refnis1995/73001>, <http://vocab.belgif.be/auth/refnis2025/73001> .
+
+<http://vocab.belgif.be/auth/refnis2019/73006> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/73000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "73006";
+  skos:prefLabel "Bilzen"@de, "Bilzen"@fr, "Bilzen"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "2025-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2801925/>, <http://www.wikidata.org/entity/Q241898>,
+    <http://vocab.belgif.be/auth/refnis1995/73006>;
+  skos:broadMatch <http://vocab.belgif.be/auth/refnis2025/73110> .
+
+<http://vocab.belgif.be/auth/refnis2019/73009> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/73000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "73009";
+  skos:prefLabel "Borgloon"@de, "Looz"@fr, "Borgloon"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "2025-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2801468/>, <http://www.wikidata.org/entity/Q499609>,
+    <http://vocab.belgif.be/auth/refnis1995/73009>;
+  skos:broadMatch <http://vocab.belgif.be/auth/refnis2025/73111> .
+
+<http://vocab.belgif.be/auth/refnis2019/73022> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/73000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "73022";
+  skos:prefLabel "Heers"@de, "Heers"@fr, "Heers"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2796298/>, <http://www.wikidata.org/entity/Q819162>,
+    <http://vocab.belgif.be/auth/refnis1995/73022>, <http://vocab.belgif.be/auth/refnis2025/73022> .
+
+<http://vocab.belgif.be/auth/refnis2019/73028> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/73000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "73028";
+  skos:prefLabel "Herstappe"@de, "Herstappe"@fr, "Herstappe"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2795929/>, <http://www.wikidata.org/entity/Q499584>,
+    <http://vocab.belgif.be/auth/refnis1995/73028>, <http://vocab.belgif.be/auth/refnis2025/73028> .
+
+<http://vocab.belgif.be/auth/refnis2019/73032> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/73000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "73032";
+  skos:prefLabel "Hoeselt"@de, "Hoeselt"@fr, "Hoeselt"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "2025-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2795649/>, <http://www.wikidata.org/entity/Q819152>,
+    <http://vocab.belgif.be/auth/refnis1995/73032>;
+  skos:broadMatch <http://vocab.belgif.be/auth/refnis2025/73110> .
+
+<http://vocab.belgif.be/auth/refnis2019/73040> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/73000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "73040";
+  skos:prefLabel "Kortessem"@de, "Kortessem"@fr, "Kortessem"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "2025-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2794064/>, <http://www.wikidata.org/entity/Q819139>,
+    <http://vocab.belgif.be/auth/refnis1995/73040>;
+  skos:broadMatch <http://vocab.belgif.be/auth/refnis2025/71072> .
+
+<http://vocab.belgif.be/auth/refnis2019/73042> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/73000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "73042";
+  skos:prefLabel "Lanaken"@de, "Lanaken"@fr, "Lanaken"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2793447/>, <http://www.wikidata.org/entity/Q695315>,
+    <http://vocab.belgif.be/auth/refnis1995/73042>, <http://vocab.belgif.be/auth/refnis2025/73042> .
+
+<http://vocab.belgif.be/auth/refnis2019/73066> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/73000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "73066";
+  skos:prefLabel "Riemst"@de, "Riemst"@fr, "Riemst"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2788089/>, <http://www.wikidata.org/entity/Q736097>,
+    <http://vocab.belgif.be/auth/refnis1995/73066>, <http://vocab.belgif.be/auth/refnis2025/73066> .
+
+<http://vocab.belgif.be/auth/refnis2019/73083> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/73000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "73083";
+  skos:prefLabel "Tongeren"@de, "Tongres"@fr, "Tongeren"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "2025-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2785390/>, <http://www.wikidata.org/entity/Q190113>,
+    <http://vocab.belgif.be/auth/refnis1995/73083>;
+  skos:broadMatch <http://vocab.belgif.be/auth/refnis2025/73111> .
+
+<http://vocab.belgif.be/auth/refnis2019/73098> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/73000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "73098";
+  skos:prefLabel "Wellen"@de, "Wellen"@fr, "Wellen"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2783865/>, <http://www.wikidata.org/entity/Q119331>,
+    <http://vocab.belgif.be/auth/refnis1995/73098>, <http://vocab.belgif.be/auth/refnis2025/73098> .
+
+<http://vocab.belgif.be/auth/refnis2019/73107> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/73000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "73107";
+  skos:prefLabel "Maasmechelen"@de, "Maasmechelen"@fr, "Maasmechelen"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2791535/>, <http://www.wikidata.org/entity/Q329633>,
+    <http://vocab.belgif.be/auth/refnis1995/73107>, <http://vocab.belgif.be/auth/refnis2025/73107> .
+
+<http://vocab.belgif.be/auth/refnis2019/73109> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/73000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "73109";
+  skos:prefLabel "Voeren"@de, "Fourons"@fr, "Voeren"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2786584/>, <http://www.wikidata.org/entity/Q460479>,
+    <http://vocab.belgif.be/auth/refnis1995/73109>, <http://vocab.belgif.be/auth/refnis2025/73109> .
+
+<http://vocab.belgif.be/auth/refnis2019/81001> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/81000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "81001";
+  skos:prefLabel "Arlon"@de, "Arlon"@fr, "Aarlen"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2803074/>, <http://www.wikidata.org/entity/Q675960>,
+    <http://vocab.belgif.be/auth/refnis1995/81001>, <http://vocab.belgif.be/auth/refnis2025/81001> .
+
+<http://vocab.belgif.be/auth/refnis2019/81003> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/81000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "81003";
+  skos:prefLabel "Attert"@de, "Attert"@fr, "Attert"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2802997/>, <http://www.wikidata.org/entity/Q690926>,
+    <http://vocab.belgif.be/auth/refnis1995/81003>, <http://vocab.belgif.be/auth/refnis2025/81003> .
+
+<http://vocab.belgif.be/auth/refnis2019/81004> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/81000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "81004";
+  skos:prefLabel "Aubange"@de, "Aubange"@fr, "Aubange"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2802991/>, <http://www.wikidata.org/entity/Q713088>,
+    <http://vocab.belgif.be/auth/refnis1995/81004>, <http://vocab.belgif.be/auth/refnis2025/81004> .
+
+<http://vocab.belgif.be/auth/refnis2019/81013> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/81000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "81013";
+  skos:prefLabel "Martelange"@de, "Martelange"@fr, "Martelange"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2791643/>, <http://www.wikidata.org/entity/Q713498>,
+    <http://vocab.belgif.be/auth/refnis1995/81013>, <http://vocab.belgif.be/auth/refnis2025/81013> .
+
+<http://vocab.belgif.be/auth/refnis2019/81015> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/81000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "81015";
+  skos:prefLabel "Messancy"@de, "Messancy"@fr, "Messancy"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2791273/>, <http://www.wikidata.org/entity/Q692243>,
+    <http://vocab.belgif.be/auth/refnis1995/81015>, <http://vocab.belgif.be/auth/refnis2025/81015> .
+
+<http://vocab.belgif.be/auth/refnis2019/82003> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/82000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "82003";
+  skos:prefLabel "Bastnach"@de, "Bastogne"@fr, "Bastenaken"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "2024-12-02T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2802584/>, <http://www.wikidata.org/entity/Q34021>,
+    <http://vocab.belgif.be/auth/refnis1995/82003>;
+  skos:broadMatch <http://vocab.belgif.be/auth/refnis2025/82039> .
+
+<http://vocab.belgif.be/auth/refnis2019/82005> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/82000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "82005";
+  skos:prefLabel "Bertogne"@de, "Bertogne"@fr, "Bertogne"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "2024-12-02T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2802114/>, <http://www.wikidata.org/entity/Q713118>,
+    <http://vocab.belgif.be/auth/refnis1995/82005>;
+  skos:broadMatch <http://vocab.belgif.be/auth/refnis2025/82039> .
+
+<http://vocab.belgif.be/auth/refnis2019/82009> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/82000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "82009";
+  skos:prefLabel "Fauvillers"@de, "Fauvillers"@fr, "Fauvillers"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2798439/>, <http://www.wikidata.org/entity/Q713282>,
+    <http://vocab.belgif.be/auth/refnis1995/82009>, <http://vocab.belgif.be/auth/refnis2025/82009> .
+
+<http://vocab.belgif.be/auth/refnis2019/82014> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/82000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "82014";
+  skos:prefLabel "Houffalize"@de, "Houffalize"@fr, "Houffalize"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2795323/>, <http://www.wikidata.org/entity/Q650274>,
+    <http://vocab.belgif.be/auth/refnis1995/82014>, <http://vocab.belgif.be/auth/refnis2025/82014> .
+
+<http://vocab.belgif.be/auth/refnis2019/82032> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/82000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "82032";
+  skos:prefLabel "Vielsalm"@de, "Vielsalm"@fr, "Vielsalm"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2784776/>, <http://www.wikidata.org/entity/Q650172>,
+    <http://vocab.belgif.be/auth/refnis1995/82032>, <http://vocab.belgif.be/auth/refnis2025/82032> .
+
+<http://vocab.belgif.be/auth/refnis2019/82036> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/82000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "82036";
+  skos:prefLabel "Vaux-sur-Sûre"@de, "Vaux-sur-Sûre"@fr, "Vaux-sur-Sûre"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2784999/>, <http://www.wikidata.org/entity/Q713864>,
+    <http://vocab.belgif.be/auth/refnis1995/82036>, <http://vocab.belgif.be/auth/refnis2025/82036> .
+
+<http://vocab.belgif.be/auth/refnis2019/82037> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/82000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "82037";
+  skos:prefLabel "Gouvy"@de, "Gouvy"@fr, "Gouvy"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2792344/>, <http://www.wikidata.org/entity/Q713319>,
+    <http://vocab.belgif.be/auth/refnis1995/82037>, <http://vocab.belgif.be/auth/refnis2025/82037> .
+
+<http://vocab.belgif.be/auth/refnis2019/82038> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/82000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "82038";
+  skos:prefLabel "Sainte-Ode"@de, "Sainte-Ode"@fr, "Sainte-Ode"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2803245/>, <http://www.wikidata.org/entity/Q713708>,
+    <http://vocab.belgif.be/auth/refnis1995/82038>, <http://vocab.belgif.be/auth/refnis2025/82038> .
+
+<http://vocab.belgif.be/auth/refnis2019/83012> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/83000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "83012";
+  skos:prefLabel "Durbuy"@de, "Durbuy"@fr, "Durbuy"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2799048/>, <http://www.wikidata.org/entity/Q497697>,
+    <http://vocab.belgif.be/auth/refnis1995/83012>, <http://vocab.belgif.be/auth/refnis2025/83012> .
+
+<http://vocab.belgif.be/auth/refnis2019/83013> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/83000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "83013";
+  skos:prefLabel "Erezée"@de, "Erezée"@fr, "Erezée"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2798699/>, <http://www.wikidata.org/entity/Q287813>,
+    <http://vocab.belgif.be/auth/refnis1995/83013>, <http://vocab.belgif.be/auth/refnis2025/83013> .
+
+<http://vocab.belgif.be/auth/refnis2019/83028> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/83000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "83028";
+  skos:prefLabel "Hotton"@de, "Hotton"@fr, "Hotton"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2795338/>, <http://www.wikidata.org/entity/Q160709>,
+    <http://vocab.belgif.be/auth/refnis1995/83028>, <http://vocab.belgif.be/auth/refnis2025/83028> .
+
+<http://vocab.belgif.be/auth/refnis2019/83031> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/83000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "83031";
+  skos:prefLabel "La Roche-en-Ardenne"@de, "La Roche-en-Ardenne"@fr, "La Roche-en-Ardenne"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2793280/>, <http://www.wikidata.org/entity/Q159974>,
+    <http://vocab.belgif.be/auth/refnis1995/83031>, <http://vocab.belgif.be/auth/refnis2025/83031> .
+
+<http://vocab.belgif.be/auth/refnis2019/83034> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/83000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "83034";
+  skos:prefLabel "Marche-en-Famenne"@de, "Marche-en-Famenne"@fr, "Marche-en-Famenne"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2791745/>, <http://www.wikidata.org/entity/Q269908>,
+    <http://vocab.belgif.be/auth/refnis1995/83034>, <http://vocab.belgif.be/auth/refnis2025/83034> .
+
+<http://vocab.belgif.be/auth/refnis2019/83040> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/83000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "83040";
+  skos:prefLabel "Nassogne"@de, "Nassogne"@fr, "Nassogne"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2790452/>, <http://www.wikidata.org/entity/Q429794>,
+    <http://vocab.belgif.be/auth/refnis1995/83040>, <http://vocab.belgif.be/auth/refnis2025/83040> .
+
+<http://vocab.belgif.be/auth/refnis2019/83044> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/83000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "83044";
+  skos:prefLabel "Rendeux"@de, "Rendeux"@fr, "Rendeux"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2788187/>, <http://www.wikidata.org/entity/Q713615>,
+    <http://vocab.belgif.be/auth/refnis1995/83044>, <http://vocab.belgif.be/auth/refnis2025/83044> .
+
+<http://vocab.belgif.be/auth/refnis2019/83049> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/83000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "83049";
+  skos:prefLabel "Tenneville"@de, "Tenneville"@fr, "Tenneville"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2785746/>, <http://www.wikidata.org/entity/Q511239>,
+    <http://vocab.belgif.be/auth/refnis1995/83049>, <http://vocab.belgif.be/auth/refnis2025/83049> .
+
+<http://vocab.belgif.be/auth/refnis2019/83055> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/83000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "83055";
+  skos:prefLabel "Manhay"@de, "Manhay"@fr, "Manhay"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2797227/>, <http://www.wikidata.org/entity/Q713458>,
+    <http://vocab.belgif.be/auth/refnis1995/83055>, <http://vocab.belgif.be/auth/refnis2025/83055> .
+
+<http://vocab.belgif.be/auth/refnis2019/84009> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/84000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "84009";
+  skos:prefLabel "Bertrix"@de, "Bertrix"@fr, "Bertrix"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2802107/>, <http://www.wikidata.org/entity/Q713135>,
+    <http://vocab.belgif.be/auth/refnis1995/84009>, <http://vocab.belgif.be/auth/refnis2025/84009> .
+
+<http://vocab.belgif.be/auth/refnis2019/84010> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/84000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "84010";
+  skos:prefLabel "Bouillon"@de, "Bouillon"@fr, "Bouillon"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2801284/>, <http://www.wikidata.org/entity/Q217216>,
+    <http://vocab.belgif.be/auth/refnis1995/84010>, <http://vocab.belgif.be/auth/refnis2025/84010> .
+
+<http://vocab.belgif.be/auth/refnis2019/84016> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/84000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "84016";
+  skos:prefLabel "Daverdisse"@de, "Daverdisse"@fr, "Daverdisse"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2799852/>, <http://www.wikidata.org/entity/Q713189>,
+    <http://vocab.belgif.be/auth/refnis1995/84016>, <http://vocab.belgif.be/auth/refnis2025/84016> .
+
+<http://vocab.belgif.be/auth/refnis2019/84029> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/84000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "84029";
+  skos:prefLabel "Herbeumont"@de, "Herbeumont"@fr, "Herbeumont"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2796038/>, <http://www.wikidata.org/entity/Q713353>,
+    <http://vocab.belgif.be/auth/refnis1995/84029>, <http://vocab.belgif.be/auth/refnis2025/84029> .
+
+<http://vocab.belgif.be/auth/refnis2019/84033> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/84000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "84033";
+  skos:prefLabel "Léglise"@de, "Léglise"@fr, "Léglise"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2792986/>, <http://www.wikidata.org/entity/Q713404>,
+    <http://vocab.belgif.be/auth/refnis1995/84033>, <http://vocab.belgif.be/auth/refnis2025/84033> .
+
+<http://vocab.belgif.be/auth/refnis2019/84035> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/84000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "84035";
+  skos:prefLabel "Libin"@de, "Libin"@fr, "Libin"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2792443/>, <http://www.wikidata.org/entity/Q713433>,
+    <http://vocab.belgif.be/auth/refnis1995/84035>, <http://vocab.belgif.be/auth/refnis2025/84035> .
+
+<http://vocab.belgif.be/auth/refnis2019/84043> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/84000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "84043";
+  skos:prefLabel "Neufchâteau"@de, "Neufchâteau"@fr, "Neufchâteau"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2790288/>, <http://www.wikidata.org/entity/Q650135>,
+    <http://vocab.belgif.be/auth/refnis1995/84043>, <http://vocab.belgif.be/auth/refnis2025/84043> .
+
+<http://vocab.belgif.be/auth/refnis2019/84050> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/84000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "84050";
+  skos:prefLabel "Paliseul"@de, "Paliseul"@fr, "Paliseul"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2789355/>, <http://www.wikidata.org/entity/Q696127>,
+    <http://vocab.belgif.be/auth/refnis1995/84050>, <http://vocab.belgif.be/auth/refnis2025/84050> .
+
+<http://vocab.belgif.be/auth/refnis2019/84059> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/84000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "84059";
+  skos:prefLabel "Saint-Hubert"@de, "Saint-Hubert"@fr, "Saint-Hubert"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2787409/>, <http://www.wikidata.org/entity/Q713740>,
+    <http://vocab.belgif.be/auth/refnis1995/84059>, <http://vocab.belgif.be/auth/refnis2025/84059> .
+
+<http://vocab.belgif.be/auth/refnis2019/84068> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/84000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "84068";
+  skos:prefLabel "Tellin"@de, "Tellin"@fr, "Tellin"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2785794/>, <http://www.wikidata.org/entity/Q713812>,
+    <http://vocab.belgif.be/auth/refnis1995/84068>, <http://vocab.belgif.be/auth/refnis2025/84068> .
+
+<http://vocab.belgif.be/auth/refnis2019/84075> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/84000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "84075";
+  skos:prefLabel "Wellin"@de, "Wellin"@fr, "Wellin"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2783863/>, <http://www.wikidata.org/entity/Q713911>,
+    <http://vocab.belgif.be/auth/refnis1995/84075>, <http://vocab.belgif.be/auth/refnis2025/84075> .
+
+<http://vocab.belgif.be/auth/refnis2019/84077> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/84000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "84077";
+  skos:prefLabel "Libramont-Chevigny"@de, "Libramont-Chevigny"@fr, "Libramont-Chevigny"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2792438/>, <http://www.wikidata.org/entity/Q612267>,
+    <http://vocab.belgif.be/auth/refnis1995/84077>, <http://vocab.belgif.be/auth/refnis2025/84077> .
+
+<http://vocab.belgif.be/auth/refnis2019/85007> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/85000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "85007";
+  skos:prefLabel "Chiny"@de, "Chiny"@fr, "Chiny"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2800321/>, <http://www.wikidata.org/entity/Q713170>,
+    <http://vocab.belgif.be/auth/refnis1995/85007>, <http://vocab.belgif.be/auth/refnis2025/85007> .
+
+<http://vocab.belgif.be/auth/refnis2019/85009> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/85000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "85009";
+  skos:prefLabel "Etalle"@de, "Etalle"@fr, "Etalle"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2798594/>, <http://www.wikidata.org/entity/Q288872>,
+    <http://vocab.belgif.be/auth/refnis1995/85009>, <http://vocab.belgif.be/auth/refnis2025/85009> .
+
+<http://vocab.belgif.be/auth/refnis2019/85011> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/85000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "85011";
+  skos:prefLabel "Florenville"@de, "Florenville"@fr, "Florenville"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2798273/>, <http://www.wikidata.org/entity/Q713300>,
+    <http://vocab.belgif.be/auth/refnis1995/85011>, <http://vocab.belgif.be/auth/refnis2025/85011> .
+
+<http://vocab.belgif.be/auth/refnis2019/85024> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/85000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "85024";
+  skos:prefLabel "Meix-devant-Virton"@de, "Meix-devant-Virton"@fr, "Meix-devant-Virton"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2791420/>, <http://www.wikidata.org/entity/Q669134>,
+    <http://vocab.belgif.be/auth/refnis1995/85024>, <http://vocab.belgif.be/auth/refnis2025/85024> .
+
+<http://vocab.belgif.be/auth/refnis2019/85026> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/85000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "85026";
+  skos:prefLabel "Musson"@de, "Musson"@fr, "Musson"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2790516/>, <http://www.wikidata.org/entity/Q713538>,
+    <http://vocab.belgif.be/auth/refnis1995/85026>, <http://vocab.belgif.be/auth/refnis2025/85026> .
+
+<http://vocab.belgif.be/auth/refnis2019/85034> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/85000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "85034";
+  skos:prefLabel "Saint-Léger"@de, "Saint-Léger"@fr, "Saint-Léger"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2787380/>, <http://www.wikidata.org/entity/Q713786>,
+    <http://vocab.belgif.be/auth/refnis1995/85034>, <http://vocab.belgif.be/auth/refnis2025/85034> .
+
+<http://vocab.belgif.be/auth/refnis2019/85039> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/85000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "85039";
+  skos:prefLabel "Tintigny"@de, "Tintigny"@fr, "Tintigny"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2785423/>, <http://www.wikidata.org/entity/Q713845>,
+    <http://vocab.belgif.be/auth/refnis1995/85039>, <http://vocab.belgif.be/auth/refnis2025/85039> .
+
+<http://vocab.belgif.be/auth/refnis2019/85045> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/85000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "85045";
+  skos:prefLabel "Virton"@de, "Virton"@fr, "Virton"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2784556/>, <http://www.wikidata.org/entity/Q456495>,
+    <http://vocab.belgif.be/auth/refnis1995/85045>, <http://vocab.belgif.be/auth/refnis2025/85045> .
+
+<http://vocab.belgif.be/auth/refnis2019/85046> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/85000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "85046";
+  skos:prefLabel "Habay"@de, "Habay"@fr, "Habay"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2796810/>, <http://www.wikidata.org/entity/Q713334>,
+    <http://vocab.belgif.be/auth/refnis1995/85046>, <http://vocab.belgif.be/auth/refnis2025/85046> .
+
+<http://vocab.belgif.be/auth/refnis2019/85047> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/85000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "85047";
+  skos:prefLabel "Rouvroy"@de, "Rouvroy"@fr, "Rouvroy"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2793464/>, <http://www.wikidata.org/entity/Q713677>,
+    <http://vocab.belgif.be/auth/refnis1995/85047>, <http://vocab.belgif.be/auth/refnis2025/85047> .
+
+<http://vocab.belgif.be/auth/refnis2019/91005> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/91000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "91005";
+  skos:prefLabel "Anhée"@de, "Anhée"@fr, "Anhée"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2803175/>, <http://www.wikidata.org/entity/Q545889>,
+    <http://vocab.belgif.be/auth/refnis1995/91005>, <http://vocab.belgif.be/auth/refnis2025/91005> .
+
+<http://vocab.belgif.be/auth/refnis2019/91013> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/91000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "91013";
+  skos:prefLabel "Beauraing"@de, "Beauraing"@fr, "Beauraing"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2802502/>, <http://www.wikidata.org/entity/Q329621>,
+    <http://vocab.belgif.be/auth/refnis1995/91013>, <http://vocab.belgif.be/auth/refnis2025/91013> .
+
+<http://vocab.belgif.be/auth/refnis2019/91015> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/91000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "91015";
+  skos:prefLabel "Bièvre"@de, "Bièvre"@fr, "Bièvre"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2801950/>, <http://www.wikidata.org/entity/Q715371>,
+    <http://vocab.belgif.be/auth/refnis1995/91015>, <http://vocab.belgif.be/auth/refnis2025/91015> .
+
+<http://vocab.belgif.be/auth/refnis2019/91030> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/91000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "91030";
+  skos:prefLabel "Ciney"@de, "Ciney"@fr, "Ciney"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2800299/>, <http://www.wikidata.org/entity/Q456490>,
+    <http://vocab.belgif.be/auth/refnis1995/91030>, <http://vocab.belgif.be/auth/refnis2025/91030> .
+
+<http://vocab.belgif.be/auth/refnis2019/91034> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/91000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "91034";
+  skos:prefLabel "Dinant"@de, "Dinant"@fr, "Dinant"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2799359/>, <http://www.wikidata.org/entity/Q108247>,
+    <http://vocab.belgif.be/auth/refnis1995/91034>, <http://vocab.belgif.be/auth/refnis2025/91034> .
+
+<http://vocab.belgif.be/auth/refnis2019/91054> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/91000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "91054";
+  skos:prefLabel "Gedinne"@de, "Gedinne"@fr, "Gedinne"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2797782/>, <http://www.wikidata.org/entity/Q241069>,
+    <http://vocab.belgif.be/auth/refnis1995/91054>, <http://vocab.belgif.be/auth/refnis2025/91054> .
+
+<http://vocab.belgif.be/auth/refnis2019/91059> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/91000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "91059";
+  skos:prefLabel "Hamois"@de, "Hamois"@fr, "Hamois"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2796628/>, <http://www.wikidata.org/entity/Q696133>,
+    <http://vocab.belgif.be/auth/refnis1995/91059>, <http://vocab.belgif.be/auth/refnis2025/91059> .
+
+<http://vocab.belgif.be/auth/refnis2019/91064> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/91000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "91064";
+  skos:prefLabel "Havelange"@de, "Havelange"@fr, "Havelange"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2796370/>, <http://www.wikidata.org/entity/Q720709>,
+    <http://vocab.belgif.be/auth/refnis1995/91064>, <http://vocab.belgif.be/auth/refnis2025/91064> .
+
+<http://vocab.belgif.be/auth/refnis2019/91072> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/91000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "91072";
+  skos:prefLabel "Houyet"@de, "Houyet"@fr, "Houyet"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2795239/>, <http://www.wikidata.org/entity/Q695390>,
+    <http://vocab.belgif.be/auth/refnis1995/91072>, <http://vocab.belgif.be/auth/refnis2025/91072> .
+
+<http://vocab.belgif.be/auth/refnis2019/91103> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/91000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "91103";
+  skos:prefLabel "Onhaye"@de, "Onhaye"@fr, "Onhaye"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2789835/>, <http://www.wikidata.org/entity/Q695349>,
+    <http://vocab.belgif.be/auth/refnis1995/91103>, <http://vocab.belgif.be/auth/refnis2025/91103> .
+
+<http://vocab.belgif.be/auth/refnis2019/91114> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/91000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "91114";
+  skos:prefLabel "Rochefort"@de, "Rochefort"@fr, "Rochefort"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2787949/>, <http://www.wikidata.org/entity/Q497764>,
+    <http://vocab.belgif.be/auth/refnis1995/91114>, <http://vocab.belgif.be/auth/refnis2025/91114> .
+
+<http://vocab.belgif.be/auth/refnis2019/91120> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/91000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "91120";
+  skos:prefLabel "Somme-Leuze"@de, "Somme-Leuze"@fr, "Somme-Leuze"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2786388/>, <http://www.wikidata.org/entity/Q721342>,
+    <http://vocab.belgif.be/auth/refnis1995/91120>, <http://vocab.belgif.be/auth/refnis2025/91120> .
+
+<http://vocab.belgif.be/auth/refnis2019/91141> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/91000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "91141";
+  skos:prefLabel "Yvoir"@de, "Yvoir"@fr, "Yvoir"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2783386/>, <http://www.wikidata.org/entity/Q650163>,
+    <http://vocab.belgif.be/auth/refnis1995/91141>, <http://vocab.belgif.be/auth/refnis2025/91141> .
+
+<http://vocab.belgif.be/auth/refnis2019/91142> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/91000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "91142";
+  skos:prefLabel "Hastière"@de, "Hastière"@fr, "Hastière"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2796483/>, <http://www.wikidata.org/entity/Q514641>,
+    <http://vocab.belgif.be/auth/refnis1995/91142>, <http://vocab.belgif.be/auth/refnis2025/91142> .
+
+<http://vocab.belgif.be/auth/refnis2019/91143> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/91000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "91143";
+  skos:prefLabel "Vresse-sur-Semois"@de, "Vresse-sur-Semois"@fr, "Vresse-sur-Semois"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2784312/>, <http://www.wikidata.org/entity/Q650206>,
+    <http://vocab.belgif.be/auth/refnis1995/91143>, <http://vocab.belgif.be/auth/refnis2025/91143> .
+
+<http://vocab.belgif.be/auth/refnis2019/92003> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/92000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "92003";
+  skos:prefLabel "Andenne"@de, "Andenne"@fr, "Andenne"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2803205/>, <http://www.wikidata.org/entity/Q333466>,
+    <http://vocab.belgif.be/auth/refnis1995/92003>, <http://vocab.belgif.be/auth/refnis2025/92003> .
+
+<http://vocab.belgif.be/auth/refnis2019/92006> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/92000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "92006";
+  skos:prefLabel "Assesse"@de, "Assesse"@fr, "Assesse"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2803019/>, <http://www.wikidata.org/entity/Q715246>,
+    <http://vocab.belgif.be/auth/refnis1995/92006>, <http://vocab.belgif.be/auth/refnis2025/92006> .
+
+<http://vocab.belgif.be/auth/refnis2019/92035> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/92000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "92035";
+  skos:prefLabel "Eghezée"@de, "Eghezée"@fr, "Eghezée"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2798950/>, <http://www.wikidata.org/entity/Q274522>,
+    <http://vocab.belgif.be/auth/refnis1995/92035>, <http://vocab.belgif.be/auth/refnis2025/92035> .
+
+<http://vocab.belgif.be/auth/refnis2019/92045> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/92000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "92045";
+  skos:prefLabel "Floreffe"@de, "Floreffe"@fr, "Floreffe"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2798280/>, <http://www.wikidata.org/entity/Q578583>,
+    <http://vocab.belgif.be/auth/refnis1995/92045>, <http://vocab.belgif.be/auth/refnis2025/92045> .
+
+<http://vocab.belgif.be/auth/refnis2019/92048> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/92000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "92048";
+  skos:prefLabel "Fosses-la-Ville"@de, "Fosses-la-Ville"@fr, "Fosses-la-Ville"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2798101/>, <http://www.wikidata.org/entity/Q720478>,
+    <http://vocab.belgif.be/auth/refnis1995/92048>, <http://vocab.belgif.be/auth/refnis2025/92048> .
+
+<http://vocab.belgif.be/auth/refnis2019/92054> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/92000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "92054";
+  skos:prefLabel "Gesves"@de, "Gesves"@fr, "Gesves"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2797582/>, <http://www.wikidata.org/entity/Q388879>,
+    <http://vocab.belgif.be/auth/refnis1995/92054>, <http://vocab.belgif.be/auth/refnis2025/92054> .
+
+<http://vocab.belgif.be/auth/refnis2019/92087> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/92000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "92087";
+  skos:prefLabel "Mettet"@de, "Mettet"@fr, "Mettet"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2791262/>, <http://www.wikidata.org/entity/Q118769>,
+    <http://vocab.belgif.be/auth/refnis1995/92087>, <http://vocab.belgif.be/auth/refnis2025/92087> .
+
+<http://vocab.belgif.be/auth/refnis2019/92094> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/92000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "92094";
+  skos:prefLabel "Namur"@de, "Namur"@fr, "Namen"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2790472/>, <http://www.wikidata.org/entity/Q134121>,
+    <http://vocab.belgif.be/auth/refnis1995/92094>, <http://vocab.belgif.be/auth/refnis2025/92094> .
+
+<http://vocab.belgif.be/auth/refnis2019/92097> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/92000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "92097";
+  skos:prefLabel "Ohey"@de, "Ohey"@fr, "Ohey"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2789909/>, <http://www.wikidata.org/entity/Q721090>,
+    <http://vocab.belgif.be/auth/refnis1995/92097>, <http://vocab.belgif.be/auth/refnis2025/92097> .
+
+<http://vocab.belgif.be/auth/refnis2019/92101> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/92000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "92101";
+  skos:prefLabel "Profondeville"@de, "Profondeville"@fr, "Profondeville"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2788578/>, <http://www.wikidata.org/entity/Q696940>,
+    <http://vocab.belgif.be/auth/refnis1995/92101>, <http://vocab.belgif.be/auth/refnis2025/92101> .
+
+<http://vocab.belgif.be/auth/refnis2019/92114> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/92000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "92114";
+  skos:prefLabel "Sombreffe"@de, "Sombreffe"@fr, "Sombreffe"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2786391/>, <http://www.wikidata.org/entity/Q650226>,
+    <http://vocab.belgif.be/auth/refnis1995/92114>, <http://vocab.belgif.be/auth/refnis2025/92114> .
+
+<http://vocab.belgif.be/auth/refnis2019/92137> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/92000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "92137";
+  skos:prefLabel "Sambreville"@de, "Sambreville"@fr, "Sambreville"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2802903/>, <http://www.wikidata.org/entity/Q650185>,
+    <http://vocab.belgif.be/auth/refnis1995/92137>, <http://vocab.belgif.be/auth/refnis2025/92137> .
+
+<http://vocab.belgif.be/auth/refnis2019/92138> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/92000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "92138";
+  skos:prefLabel "Fernelmont"@de, "Fernelmont"@fr, "Fernelmont"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2788742/>, <http://www.wikidata.org/entity/Q696104>,
+    <http://vocab.belgif.be/auth/refnis1995/92138>, <http://vocab.belgif.be/auth/refnis2025/92138> .
+
+<http://vocab.belgif.be/auth/refnis2019/92140> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/92000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "92140";
+  skos:prefLabel "Jemeppe-sur-Sambre"@de, "Jemeppe-sur-Sambre"@fr, "Jemeppe-sur-Sambre"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2794933/>, <http://www.wikidata.org/entity/Q720791>,
+    <http://vocab.belgif.be/auth/refnis1995/92140>, <http://vocab.belgif.be/auth/refnis2025/92140> .
+
+<http://vocab.belgif.be/auth/refnis2019/92141> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/92000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "92141";
+  skos:prefLabel "La Bruyère"@de, "La Bruyère"@fr, "La Bruyère"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2788112/>, <http://www.wikidata.org/entity/Q715422>,
+    <http://vocab.belgif.be/auth/refnis1995/92141>, <http://vocab.belgif.be/auth/refnis2025/92141> .
+
+<http://vocab.belgif.be/auth/refnis2019/92142> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/92000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "92142";
+  skos:prefLabel "Gembloux"@de, "Gembloux"@fr, "Gembloux"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2797714/>, <http://www.wikidata.org/entity/Q223927>,
+    <http://vocab.belgif.be/auth/refnis1995/92142>, <http://vocab.belgif.be/auth/refnis2025/92142> .
+
+<http://vocab.belgif.be/auth/refnis2019/93010> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/93000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "93010";
+  skos:prefLabel "Cerfontaine"@de, "Cerfontaine"@fr, "Cerfontaine"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2800592/>, <http://www.wikidata.org/entity/Q715474>,
+    <http://vocab.belgif.be/auth/refnis1995/93010>, <http://vocab.belgif.be/auth/refnis2025/93010> .
+
+<http://vocab.belgif.be/auth/refnis2019/93014> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/93000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "93014";
+  skos:prefLabel "Couvin"@de, "Couvin"@fr, "Couvin"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2800026/>, <http://www.wikidata.org/entity/Q326771>,
+    <http://vocab.belgif.be/auth/refnis1995/93014>, <http://vocab.belgif.be/auth/refnis2025/93014> .
+
+<http://vocab.belgif.be/auth/refnis2019/93018> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/93000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "93018";
+  skos:prefLabel "Doische"@de, "Doische"@fr, "Doische"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2799329/>, <http://www.wikidata.org/entity/Q720275>,
+    <http://vocab.belgif.be/auth/refnis1995/93018>, <http://vocab.belgif.be/auth/refnis2025/93018> .
+
+<http://vocab.belgif.be/auth/refnis2019/93022> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/93000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "93022";
+  skos:prefLabel "Florennes"@de, "Florennes"@fr, "Florennes"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2798277/>, <http://www.wikidata.org/entity/Q720429>,
+    <http://vocab.belgif.be/auth/refnis1995/93022>, <http://vocab.belgif.be/auth/refnis2025/93022> .
+
+<http://vocab.belgif.be/auth/refnis2019/93056> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/93000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "93056";
+  skos:prefLabel "Philippeville"@de, "Philippeville"@fr, "Philippeville"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2789017/>, <http://www.wikidata.org/entity/Q650239>,
+    <http://vocab.belgif.be/auth/refnis1995/93056>, <http://vocab.belgif.be/auth/refnis2025/93056> .
+
+<http://vocab.belgif.be/auth/refnis2019/93088> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/93000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "93088";
+  skos:prefLabel "Walcourt"@de, "Walcourt"@fr, "Walcourt"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2784190/>, <http://www.wikidata.org/entity/Q497565>,
+    <http://vocab.belgif.be/auth/refnis1995/93088>, <http://vocab.belgif.be/auth/refnis2025/93088> .
+
+<http://vocab.belgif.be/auth/refnis2019/93090> a skos:Concept;
+  skos:broader <http://vocab.belgif.be/auth/refnis2019/93000>;
+  skos:inScheme <http://vocab.belgif.be/auth/refnis2019>;
+  skos:notation "93090";
+  skos:prefLabel "Viroinval"@de, "Viroinval"@fr, "Viroinval"@nl;
+  schemas:startDate "2019-01-01T00:00:00.000+01:00"^^xsd:dateTime;
+  schemas:endDate "9999-12-31T00:00:00.000+01:00"^^xsd:dateTime;
+  skos:exactMatch <https://sws.geonames.org/2799225/>, <http://www.wikidata.org/entity/Q650261>,
+    <http://vocab.belgif.be/auth/refnis1995/93090>, <http://vocab.belgif.be/auth/refnis2025/93090> .
+
+<http://vocab.belgif.be/void#refnis2019> a void:Dataset;
+  dcterms:title "REFNIS-2019"@nl, "REFNIS-2019"@fr, "REFNIS-2019"@de, "REFNIS-2019"@en,
+    "Statbel open data licentie"@nl, "Statbel licence open data"@fr, "Statbel open data license"@en,
+    "Statbel open data lizenz"@de;
+  dcterms:description "REFNIS (vanaf 2019): de administratieve indeling gebeurt aan de hand van vier territoriale eenheden: gewesten, provincies, bestuurlijke arrondissementen en gemeenten."@nl,
+    "REFNIS (à partir de 2019): la division administrative repose sur quatre unités territoriales : les régions, les provinces, les arrondissements administratifs et les communes."@fr,
+    "REFNIS (ab 2019)"@de, "REFNIS (starting in 2019)"@en;
+  dcterms:license <http://statbel.fgov.be/en/statistics/opendata/licence/>;
+  dcterms:source <https://economie.fgov.be/en/themes/enterprises/crossroads-bank-enterprises/services-administrations/tables-codes>,
+    <https://statbel.fgov.be/fr/propos-de-statbel/methodologie/classifications/geographie>;
+  dcterms:modified "2025-04-15T10:45:18.668Z"^^xsd:dateTime;
+  foaf:homepage <http://vocab.belgif.be/>;
+  void:dataDump <http://vocab.belgif.be/dataset/refnis2019>;
+  void:feature <http://www.w3.org/ns/formats/N-Triples>, <http://www.w3.org/ns/formats/Turtle>,
+    <http://www.w3.org/ns/formats/JSON-LD>;
+  void:uriLookupEndpoint <http://vocab.belgif.be/_ldf/refnis2019>, <http://vocab.belgif.be/_ldf>;
+  void:rootResource <http://vocab.belgif.be/auth/refnis2019>;
+  void:exampleResource <http://vocab.belgif.be/auth/refnis2019/1000>;
+  void:triples "8962"^^xsd:long;
+  void:uriSpace "http://vocab.belgif.be/auth/refnis2019";
+  void:vocabulary <http://www.w3.org/2004/02/skos/core#> .

--- a/config/migrations/2025/20250416181230-fix--refnis-2025/20250416182754-fix--update-refnis2019-end-dates.sparql
+++ b/config/migrations/2025/20250416181230-fix--refnis-2025/20250416182754-fix--update-refnis2019-end-dates.sparql
@@ -1,0 +1,21 @@
+PREFIX schemas: <https://schema.org/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?nis2019 schemas:endDate ?currentEndDate .
+  }
+} INSERT {
+    GRAPH <http://mu.semte.ch/graphs/public> {
+      ?nis2019 schemas:endDate ?newEndDate .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?nis2019 skos:inScheme <http://vocab.belgif.be/auth/refnis2019> ;
+             schemas:endDate ?currentEndDate .
+  }
+  GRAPH <http://mu.semte.ch/graphs/refnis2019-data-temp> {
+    ?nis2019 schemas:endDate ?newEndDate .
+  }
+  FILTER (?currentEndDate != ?newEndDate)
+}

--- a/config/migrations/2025/20250416181230-fix--refnis-2025/20250416184331-refnis2019-flush-temp-graph.sparql
+++ b/config/migrations/2025/20250416181230-fix--refnis-2025/20250416184331-refnis2019-flush-temp-graph.sparql
@@ -1,0 +1,1 @@
+CLEAR GRAPH <http://mu.semte.ch/graphs/refnis2019-data-temp>

--- a/config/migrations/2025/20250416181230-fix--refnis-2025/20250417080910-fix--update-narrowed-or-broadened-werkingsgebieden.sparql
+++ b/config/migrations/2025/20250416181230-fix--refnis-2025/20250417080910-fix--update-narrowed-or-broadened-werkingsgebieden.sparql
@@ -1,0 +1,18 @@
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/shared> {
+    ?werkingsgebied skos:exactMatch ?nis2019 .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/shared> {
+    ?werkingsgebied skos:exactMatch ?nis2025 .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/shared> {
+    ?werkingsgebied skos:exactMatch ?nis2019 .
+  }
+  VALUES (?nis2019 ?nis2025) {
+    (<http://vocab.belgif.be/auth/refnis2019/10000> <http://vocab.belgif.be/auth/refnis2025/10000>) # Antwerp province
+    (<http://vocab.belgif.be/auth/refnis2019/40000> <http://vocab.belgif.be/auth/refnis2025/40000>) # East Flanders province
+    (<http://vocab.belgif.be/auth/refnis2019/11002> <http://vocab.belgif.be/auth/refnis2025/11002>) # Antwerp municipality
+  }
+}


### PR DESCRIPTION
The NIS2025 codes were initially introduced in #490. This PR resolves two small oversights in that initial import.

## End dates NIS2019 codes
Several NIS2019 were given an actual end date to indicate that they are no longer valid after the 2025 municipality merger. This PR updates the relevant end dates based on the most recent version of the NIS2019 code list. This way we know which NIS codes are no longer valid.

The used migration essentially replaces all of OP's NIS2019 code end dates that differ from those on the most recent version code list, and replaces them by the latter. Note that this covers more than just the NIS2019 affected by the 2025 municipality mergers.

## Update werkingsgebieden for Antwerp and East Flanders
As part of the 2025 municipality mergers, the (former) municipality of Zwijndrecht changed province from Antwerp to East Flanders. This change is reflected in the NIS codes by relating their NIS2019 and NIS2025 with `skos:narrowMatch` and `skos:broadMatch` instead of `skos:exactMatch`. Similarly, the municipality of Antwerp changed due to the addition of Borsbeek as a new district. More concretely:

- [East Flanders](https://github.com/lblod/app-organization-portal/blob/development/config/migrations/2025/20250107100000-nis-codes-2025/20250107101800-refnis2025.ttl#L7698): `<http://vocab.belgif.be/auth/refnis2025/40000> skos:narrowMatch <http://vocab.belgif.be/auth/refnis2019/40000>`
- [Antwerp (province)](https://github.com/lblod/app-organization-portal/blob/539376c47c6cc8aef21c3e88721b9ce65049950b/config/migrations/2025/20250107100000-nis-codes-2025/20250107101800-refnis2025.ttl#L7490): `<http://vocab.belgif.be/auth/refnis2025/10000> skos:broadMatch <http://vocab.belgif.be/auth/refnis2019/10000>`
- [Antwerp (municipality)](https://github.com/lblod/app-organization-portal/blob/development/config/migrations/2025/20250107100000-nis-codes-2025/20250107101800-refnis2025.ttl#L31): `<http://vocab.belgif.be/auth/refnis2025/11002> skos:narrowMatch <http://vocab.belgif.be/auth/refnis2019/11002>`

Since the initial migration relied on a `skos:exactMatch` relation between NIS codes, these three instances were missed and the linked werkingsgebieden were not updated.

Note, a similar situation occurs in other werkingsgebieden, such as Hasselt, but these are not (correctly) matched to their NIS code. This will be further investigated and fixed in follow-up PRs focusing on the werkingsgebieden data.

## Related tickets
- OP-3566