### PR TITLE
Hotfix/remove has suborganization from inactive ckb deinze

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Changelog
+## Unreleased
+### Backend
+- Extend the public producer to include NIS codes and more info in representative organs (sites, status) [CLBV-980]
+### Deploy notes
+```
+drc restart delta-producer-publication-graph-maintainer
+```
+
 ## v1.31.1 (2025-04-01)
 ### Backend
 - Removal of change events of 8 ckb's + update of their status [OP-3562]
@@ -7,6 +15,7 @@
 drc restart migrations-triggering-indexing; drc logs -ft --tail=200 migrations-triggering-indexing
 drc restart migrations; drc logs -ft --tail=200 migrations
 ```
+
 ## v1.31.0 (2025-03-27)
 ### Frontend
 - Bump to version [v1.30.0](https://github.com/lblod/frontend-organization-portal/blob/v1.30.0/CHANGELOG.md#v1300-2025-03-27)
@@ -18,14 +27,12 @@ drc restart migrations; drc logs -ft --tail=200 migrations
 - Set up the dashboard app [OP-3103]
 - Datafix: correct date of change event of kerkfabriek st petrus [OP-3555]
 - Update OCMWv to VVMW [OP-3565] and back. It's technically a nil-operation. But you should run the migrations nevertheless.
-- Extend the public producer to include NIS codes and more info in representative organs (sites, status) [CLBV-980]
 ### Deploy notes
 ```
 drc restart migrations-triggering-indexing
 drc restart migrations; drc logs -ft --tail=200 migrations
 drc pull frontend; drc up -d frontend
 drc up -d mandatarissen-consumer leidinggevenden-consumer worship-services-main-info-consumer worship-services-private-info-consumer
-drc restart delta-producer-publication-graph-maintainer
 ```
 #### For upgrade databases
 [This README](https://github.com/Riadabd/upgrade-virtuoso) provides the necessary steps for upgrading the database. **NOTE**: This will involve shutting down the app for small period of time (around 30 minutes).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Changelog
 ## Unreleased
 ### Backend
-- Extend the public producer to include NIS codes and more info in representative organs (sites, status) [CLBV-980]
+- Extend the public producer to include: [CLBV-980]
+  - NIS codes
+  - Sites and statuses of representative organs
+  - Secondary sites with their contacts and addresses
+  - Site descriptions
+
 ### Deploy notes
 ```
 drc restart delta-producer-publication-graph-maintainer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-## Unreleased
+## v1.31.2 (2025-04-02)
 ### Backend
 - Extend the public producer to include: [CLBV-980]
   - NIS codes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Changelog
+## v1.31.3 (2025-04-02)
+### Backend
+ - Migrate active organizations linked to inactive CKB [DL-6604]
+### Deploy notes
+```
+drc restart migrations-triggering-indexing;
+```
+
 ## v1.31.2 (2025-04-02)
 ### Backend
 - Extend the public producer to include: [CLBV-980]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
-## v1.31.3 (2025-04-02)
+## v1.31.3 (2025-05-08)
 ### Backend
  - Migrate active organizations linked to inactive CKB [DL-6604]
 ### Deploy notes
 ```
-drc restart migrations-triggering-indexing;
+drc restart migrations-triggering-indexing && drc logs -ft --tail=200 migrations-triggering-indexing
 ```
 
 ## v1.31.2 (2025-04-02)
@@ -69,7 +69,7 @@ Before we can generate a user we need to add an application salt to the server. 
 
 Once this is done you can generate a user by running `mu script project-scripts generate-dashboard-login` and following the prompts. A new local migration will be generated which can be run by restarting the migrations service and which will insert the new user into the database.
 
-Store the login credentials as a comment in the docker-compose.override.yml file. 
+Store the login credentials as a comment in the docker-compose.override.yml file.
 
 ##### 3. (Re)start the needed services
 `drc up -d frontend-dashboard dashboard-login identifier; drc restart dispatcher resource db`

--- a/config/delta-producer/public/export.json
+++ b/config/delta-producer/public/export.json
@@ -211,6 +211,25 @@
       ]
     },
     {
+      "type": "http://www.w3.org/ns/org#Site",
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/shared",
+        "http://mu.semte.ch/graphs/worship-service",
+        "http://mu.semte.ch/graphs/administrative-unit"
+      ],
+      "pathToConceptScheme": [
+        "^http://www.w3.org/ns/org#hasSite",
+        "http://www.w3.org/ns/org#classification",
+        "http://www.w3.org/2004/02/skos/core#inScheme"
+      ],
+      "properties": [
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://www.w3.org/ns/org#siteAddress",
+        "https://data.vlaanderen.be/ns/organisatie#bestaatUit",
+        "http://data.lblod.info/vocabularies/erediensten/vestigingstype"
+      ]
+    },
+    {
       "type": "http://www.w3.org/ns/locn#Address",
       "graphsFilter": [
         "http://mu.semte.ch/graphs/shared",

--- a/config/delta-producer/public/export.json
+++ b/config/delta-producer/public/export.json
@@ -257,6 +257,33 @@
       ]
     },
     {
+      "type": "http://www.w3.org/ns/locn#Address",
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/shared",
+        "http://mu.semte.ch/graphs/worship-service",
+        "http://mu.semte.ch/graphs/administrative-unit"
+      ],
+      "pathToConceptScheme": [
+        "^https://data.vlaanderen.be/ns/organisatie#bestaatUit",
+        "^http://www.w3.org/ns/org#hasSite",
+        "http://www.w3.org/ns/org#classification",
+        "http://www.w3.org/2004/02/skos/core#inScheme"
+      ],
+      "properties": [
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "https://data.vlaanderen.be/ns/adres#Adresvoorstelling.huisnummer",
+        "https://data.vlaanderen.be/ns/adres#Adresvoorstelling.busnummer",
+        "http://www.w3.org/ns/locn#thoroughfare",
+        "http://www.w3.org/ns/locn#postCode",
+        "https://data.vlaanderen.be/ns/adres#gemeentenaam",
+        "http://www.w3.org/ns/locn#adminUnitL2",
+        "https://data.vlaanderen.be/ns/adres#land",
+        "http://www.w3.org/ns/locn#fullAddress",
+        "https://data.vlaanderen.be/ns/adres#verwijstNaar",
+        "http://purl.org/dc/terms/source"
+      ]
+    },
+    {
       "type": "http://schema.org/ContactPoint",
       "graphsFilter": [
         "http://mu.semte.ch/graphs/shared",
@@ -266,6 +293,30 @@
       "pathToConceptScheme": [
         "^http://www.w3.org/ns/org#siteAddress",
         "^http://www.w3.org/ns/org#hasPrimarySite",
+        "http://www.w3.org/ns/org#classification",
+        "http://www.w3.org/2004/02/skos/core#inScheme"
+      ],
+      "properties": [
+        "http://mu.semte.ch/vocabularies/core/uuid",
+        "http://www.w3.org/ns/locn#address",
+        "http://xmlns.com/foaf/0.1/page",
+        "http://schema.org/faxNumber",
+        "http://schema.org/contactType",
+        "http://xmlns.com/foaf/0.1/page",
+        "http://schema.org/email",
+        "http://schema.org/telephone"
+      ]
+    },
+    {
+      "type": "http://schema.org/ContactPoint",
+      "graphsFilter": [
+        "http://mu.semte.ch/graphs/shared",
+        "http://mu.semte.ch/graphs/worship-service",
+        "http://mu.semte.ch/graphs/administrative-unit"
+      ],
+      "pathToConceptScheme": [
+        "^http://www.w3.org/ns/org#siteAddress",
+        "^http://www.w3.org/ns/org#hasSite",
         "http://www.w3.org/ns/org#classification",
         "http://www.w3.org/2004/02/skos/core#inScheme"
       ],

--- a/config/delta-producer/public/export.json
+++ b/config/delta-producer/public/export.json
@@ -207,7 +207,8 @@
         "http://mu.semte.ch/vocabularies/core/uuid",
         "http://www.w3.org/ns/org#siteAddress",
         "https://data.vlaanderen.be/ns/organisatie#bestaatUit",
-        "http://data.lblod.info/vocabularies/erediensten/vestigingstype"
+        "http://data.lblod.info/vocabularies/erediensten/vestigingstype",
+        "http://purl.org/dc/terms/description"
       ]
     },
     {
@@ -226,7 +227,8 @@
         "http://mu.semte.ch/vocabularies/core/uuid",
         "http://www.w3.org/ns/org#siteAddress",
         "https://data.vlaanderen.be/ns/organisatie#bestaatUit",
-        "http://data.lblod.info/vocabularies/erediensten/vestigingstype"
+        "http://data.lblod.info/vocabularies/erediensten/vestigingstype",
+        "http://purl.org/dc/terms/description"
       ]
     },
     {

--- a/config/migrations-triggering-indexing/2025/20250429103515-remove-has-suborganization-from-inactive-ckb-deinze.sparql
+++ b/config/migrations-triggering-indexing/2025/20250429103515-remove-has-suborganization-from-inactive-ckb-deinze.sparql
@@ -1,0 +1,55 @@
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?activeOrg
+      <http://www.w3.org/ns/org#hasSubOrganization> ?sub .
+
+    ?membership a org:Membership ;
+      mu:uuid ?uuid ;
+      org:organization ?activeOrg ;
+      org:member ?sub ;
+      org:role <http://data.lblod.info/id/rollen/4ec7d5c39bdc4e84b4174379b9e22ad8> .
+  }
+}
+WHERE {
+  BIND(<http://data.lblod.info/id/centraleBesturenVanDeEredienst/643ddbd9448ca43828702527af7bfbb8> AS ?inactiveOrg)
+  BIND(<http://data.lblod.info/id/centraleBesturenVanDeEredienst/7f5475cfb202d12f54779f046441c9e1> AS ?activeOrg)
+
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?inactiveOrg
+      <http://www.w3.org/ns/org#hasSubOrganization> ?sub .
+  }
+
+  FILTER NOT EXISTS {
+   ?activeOrg
+     <http://www.w3.org/ns/org#hasSubOrganization> ?sub .
+  }
+
+  BIND(SHA1(CONCAT(STR(?activeOrg), STR(?sub), "sub organization")) as ?uuid)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/lidmaatschap/", ?uuid)) AS ?membership)
+}
+
+;
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?inactiveOrg
+      <http://www.w3.org/ns/org#hasSubOrganization> ?sub .
+
+    ?membership ?membershipP ?membershipO .
+  }
+}
+WHERE {
+  BIND(<http://data.lblod.info/id/centraleBesturenVanDeEredienst/643ddbd9448ca43828702527af7bfbb8> AS ?inactiveOrg)
+
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?inactiveOrg
+      <http://www.w3.org/ns/org#hasSubOrganization> ?sub .
+
+    ?membership a org:Membership ;
+      org:organization ?inactiveOrg ;
+      ?membershipP ?membershipO .
+  }
+}


### PR DESCRIPTION
For context, see [DL-6604].

There is a 'double' instance of CKB Deinze in the database. One is active, and the other is inactive. This confuses systems, and it doesn't make sense that active organizations are linked (almost managed) by an inactive organization.

This commit fixes this issue