### PR TITLE
chore: move memberships from shared to administrative-unit graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Fix KBO statuses not being displayed [OP-3584]
 - datafix: update NIS2019 end dates and link additional NIS2025 to werkingsgebieden [part of OP-3566]
 - datafix: correct date of change event of ckb olen [OP-3594]
+- datafix: move memberships from shared to administrative unit graph
 ### Deploy Notes
 ```
 drc restart migrations; drc logs -ft --tail=200 migrations

--- a/config/migrations/2025/20250430174011-chore--move-memberships-from-shared-to-administrative-unit-graph.sparql
+++ b/config/migrations/2025/20250430174011-chore--move-memberships-from-shared-to-administrative-unit-graph.sparql
@@ -1,0 +1,16 @@
+PREFIX org: <http://www.w3.org/ns/org#>
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/shared> {
+    ?membership ?p ?o .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?membership ?p ?o .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/shared> {
+    ?membership a org:Membership ;
+                ?p ?o .
+  }
+}


### PR DESCRIPTION
These memberships can be edited by users via the related organizations page. If
this data is kept in the, read-only, shared graph it leads to unexpected
behaviour when users (try to) remove such a membership. More specifically, as
the user has no write acces to the graph the request will be silently ignored
and the "removed" data will simply reappear after saving the data.

Furthermore, when a user adds similar memberships via the frontend they will be
added to the administrative-unit graph. Over time this can lead to an unexpected
and confusing distribution of memberships over graphs.