### PR TITLE
chore: cleanup location data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@
 - datafix: update NIS2019 end dates and link additional NIS2025 to werkingsgebieden [part of OP-3566]
 - datafix: correct date of change event of ckb olen [OP-3594]
 - datafix: move memberships from shared to administrative unit graph
-- datafix: move werkingsgebieden to public graph [OP-3566]
+- datafix: cleanup werkingsgbieden data [OP-3566]
+  + move werkingsgebieden to public graph
+  + link district werkingsgebieden to Antwerp municipality werkingsgebied
 ### Deploy Notes
 ```
 drc restart migrations; drc logs -ft --tail=200 migrations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@
 - datafix: correct date of change event of ckb olen [OP-3594]
 - datafix: move memberships from shared to administrative unit graph
 - datafix: cleanup werkingsgbieden data [OP-3566]
-  + move werkingsgebieden to public graph
-  + link district werkingsgebieden to Antwerp municipality werkingsgebied
+  + Move werkingsgebieden to public graph
+  + Link district werkingsgebieden to Antwerp municipality werkingsgebied
+  + Add missing werkingsgebied for Borsbeek district
 ### Deploy Notes
 ```
 drc restart migrations; drc logs -ft --tail=200 migrations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,16 @@
 - datafix: update NIS2019 end dates and link additional NIS2025 to werkingsgebieden [part of OP-3566]
 - datafix: correct date of change event of ckb olen [OP-3594]
 - datafix: move memberships from shared to administrative unit graph
+- datafix: move werkingsgebieden to public graph [OP-3566]
 ### Deploy Notes
 ```
 drc restart migrations; drc logs -ft --tail=200 migrations
 drc up -d kbo-data-sync
 drc exec kbo-data-sync curl -X POST http://localhost/sync-all-kbo-data
+
+drc restart delta-producer-publication-graph-maintainer
+drc exec delta-producer-background-jobs-initiator curl -X POST http://localhost/public/healing-jobs # or wait until nightly healing kicks in
+drc exec delta-producer-background-jobs-initiator curl -X POST http://localhost/organizations/healing-jobs # or wait until nightly healing kicks in
 ```
 
 ## v1.31.2 (2025-04-02)

--- a/config/delta-producer/organizations/export.json
+++ b/config/delta-producer/organizations/export.json
@@ -389,7 +389,7 @@
     {
       "type": "http://www.w3.org/ns/prov#Location",
       "graphsFilter": [
-        "http://mu.semte.ch/graphs/shared"
+        "http://mu.semte.ch/graphs/public"
       ],
       "properties": [
         "http://www.w3.org/2000/01/rdf-schema#label",

--- a/config/delta-producer/public/export.json
+++ b/config/delta-producer/public/export.json
@@ -628,8 +628,7 @@
     {
       "type": "http://www.w3.org/ns/prov#Location",
       "graphsFilter": [
-        "http://mu.semte.ch/graphs/shared",
-        "http://mu.semte.ch/graphs/administrative-unit"
+        "http://mu.semte.ch/graphs/public"
       ],
       "hasRegexGraphsFilter": false,
       "properties": [

--- a/config/migrations/2025/20250430130307-chore--cleanup-werkingsgebieden-data/20250430142110-chore--move-werkingsgebieden-to-public-graph.sparql
+++ b/config/migrations/2025/20250430130307-chore--cleanup-werkingsgebieden-data/20250430142110-chore--move-werkingsgebieden-to-public-graph.sparql
@@ -1,0 +1,22 @@
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+DELETE {
+  GRAPH ?sourceGraph {
+    ?werkingsgebied ?p ?o .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?werkingsgebied ?p ?o .
+  }
+} WHERE {
+  GRAPH ?sourceGraph {
+    ?werkingsgebied a prov:Location ;
+                    ext:werkingsgebiedNiveau ?level ;
+                    ?p ?o .
+  }
+  VALUES ?sourceGraph {
+    <http://mu.semte.ch/graphs/administrative-unit>
+    <http://mu.semte.ch/graphs/shared>
+  }
+}

--- a/config/migrations/2025/20250430130307-chore--cleanup-werkingsgebieden-data/20250430145904-fix--relate-district-location-to-municipality.sparql
+++ b/config/migrations/2025/20250430130307-chore--cleanup-werkingsgebieden-data/20250430145904-fix--relate-district-location-to-municipality.sparql
@@ -1,0 +1,17 @@
+PREFIX geo: <http://www.opengis.net/ont/geosparql#>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?districtLocation geo:sfWithin ?antwerpLocation .
+  }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?districtLocation a prov:Location ;
+                      ext:werkingsgebiedNiveau ?level .
+    FILTER (?level = "District")
+  }
+  # Hardcode the werkingsgbied for the Antwerp municipality as it is the only one with districts anyway.
+  BIND (<http://data.lblod.info/id/werkingsgebieden/3a9b09cbccb798c8f9d5bad3fce1476bce1ee014165ba243488b0af690d0f464> AS ?antwerpLocation)
+}

--- a/config/migrations/2025/20250430130307-chore--cleanup-werkingsgebieden-data/20250430153558-feat--add-werkingsgbied-for-borsbeek-district.sparql
+++ b/config/migrations/2025/20250430130307-chore--cleanup-werkingsgebieden-data/20250430153558-feat--add-werkingsgbied-for-borsbeek-district.sparql
@@ -1,0 +1,24 @@
+PREFIX geo: <http://www.opengis.net/ont/geosparql#>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?borsbeekLocation a prov:Location;
+                      mu:uuid ?uuid ;
+                      rdfs:label "Borsbeek" ;
+                      ext:werkingsgebiedNiveau "District" ;
+                      geo:sfWithin ?antwerpLocation .
+  }
+  # Also link this new werkingsgbied to the actual district
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+   ?borsbeekDistrict besluit:werkingsgebied ?borsbeekLocation .
+  }
+} WHERE {
+  BIND(SHA256(CONCAT("Werkingsgebied for the district of Borsbeek")) AS ?uuid)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/werkingsgebieden/", STR(?uuid))) AS ?borsbeekLocation)
+
+BIND (<http://data.lblod.info/id/werkingsgebieden/3a9b09cbccb798c8f9d5bad3fce1476bce1ee014165ba243488b0af690d0f464> AS ?antwerpLocation)
+  BIND (<http://data.lblod.info/id/bestuurseenheden/4b44e6f1-113b-4692-b149-44a889b215f2> AS ?borsbeekDistrict)
+}

--- a/config/migrations/2025/20250430130307-chore--cleanup-werkingsgebieden-data/20250430180050-feat--relate-werkingsgebieden-for-municipalities-and-provinces.sparql
+++ b/config/migrations/2025/20250430130307-chore--cleanup-werkingsgebieden-data/20250430180050-feat--relate-werkingsgebieden-for-municipalities-and-provinces.sparql
@@ -1,0 +1,26 @@
+PREFIX geo: <http://www.opengis.net/ont/geosparql#>
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?municipalityLocation geo:sfWithin ?provinceLocation .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/shared> {
+    ?municipality a besluit:Bestuurseenheid ;
+                  org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001> .
+    ?province a besluit:Bestuurseenheid ;
+              org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000000> .
+  }
+
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?membership a org:Membership ;
+                org:member ?municipality ;
+                org:organization ?province .
+
+    ?municipality besluit:werkingsgebied ?municipalityLocation .
+    ?province besluit:werkingsgebied ?provinceLocation .
+  }
+
+}


### PR DESCRIPTION
This PR cleans up the existing location (*nl. werkingsgebieden*) data in preparation for adding functionality to view and edit them in OP. More specifically the migrations do the following:

1. Move all existing locations to the `public` graph. Previously the locations were largely duplicated in the `shared` and `adminsitrative-unit` graphs. I opted to put them in the `public` graph instead of in the `shared` graph as the existing locations are essentially a "standard" set that should not change over time. (Except in rather rare circumstances such as municipality mergers.)
2. Add the missing location for the district of Borsbeek. This was overlooked when creating the new district in #445
3. Add `geo:sfWithin` relations between the different location levels:
   a. Link all district locations to the location for the municipality of Antwerp
   b. Link all municipality locations the location of the province they are located in

## Notes
- When writing the last migration I noticed some issues concerning the placement of the memberships relating districts, municipalities, and provinces. For this migration to work correctly the migration proposed in #541 should be executed first. (Which is also why the target branch of the current PR is not development the branch from that PR.)

## Related ticket
- OP-3566