### PR TITLE
Hotfix/remove suborganization from inactive ckb deinze

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Changelog
+## v1.31.3 (2025-05-08)
+### Backend
+ - Migrate active organizations linked to inactive CKB to the active one. [DL-6604]
+### Deploy notes
+```
+drc restart migrations-triggering-indexing && drc logs -ft --tail=200 migrations-triggering-indexing
+```
+
 ## v1.31.2 (2025-04-02)
 ### Backend
 - Extend the public producer to include: [CLBV-980]
@@ -61,7 +69,7 @@ Before we can generate a user we need to add an application salt to the server. 
 
 Once this is done you can generate a user by running `mu script project-scripts generate-dashboard-login` and following the prompts. A new local migration will be generated which can be run by restarting the migrations service and which will insert the new user into the database.
 
-Store the login credentials as a comment in the docker-compose.override.yml file. 
+Store the login credentials as a comment in the docker-compose.override.yml file.
 
 ##### 3. (Re)start the needed services
 `drc up -d frontend-dashboard dashboard-login identifier; drc restart dispatcher resource db`

--- a/config/migrations-triggering-indexing/2025/20250429103515-remove-has-suborganization-from-inactive-ckb-deinze.sparql
+++ b/config/migrations-triggering-indexing/2025/20250429103515-remove-has-suborganization-from-inactive-ckb-deinze.sparql
@@ -1,0 +1,55 @@
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?activeOrg
+      <http://www.w3.org/ns/org#hasSubOrganization> ?sub .
+
+    ?membership a org:Membership ;
+      mu:uuid ?uuid ;
+      org:organization ?activeOrg ;
+      org:member ?sub ;
+      org:role <http://data.lblod.info/id/rollen/4ec7d5c39bdc4e84b4174379b9e22ad8> .
+  }
+}
+WHERE {
+  BIND(<http://data.lblod.info/id/centraleBesturenVanDeEredienst/643ddbd9448ca43828702527af7bfbb8> AS ?inactiveOrg)
+  BIND(<http://data.lblod.info/id/centraleBesturenVanDeEredienst/7f5475cfb202d12f54779f046441c9e1> AS ?activeOrg)
+
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?inactiveOrg
+      <http://www.w3.org/ns/org#hasSubOrganization> ?sub .
+  }
+
+  FILTER NOT EXISTS {
+   ?activeOrg
+     <http://www.w3.org/ns/org#hasSubOrganization> ?sub .
+  }
+
+  BIND(SHA1(CONCAT(STR(?activeOrg), STR(?sub), "sub organization")) as ?uuid)
+  BIND(IRI(CONCAT("http://data.lblod.info/id/lidmaatschap/", ?uuid)) AS ?membership)
+}
+
+;
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?inactiveOrg
+      <http://www.w3.org/ns/org#hasSubOrganization> ?sub .
+
+    ?membership ?membershipP ?membershipO .
+  }
+}
+WHERE {
+  BIND(<http://data.lblod.info/id/centraleBesturenVanDeEredienst/643ddbd9448ca43828702527af7bfbb8> AS ?inactiveOrg)
+
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?inactiveOrg
+      <http://www.w3.org/ns/org#hasSubOrganization> ?sub .
+
+    ?membership a org:Membership ;
+      org:organization ?inactiveOrg ;
+      ?membershipP ?membershipO .
+  }
+}


### PR DESCRIPTION
## Ticket ID

DL-6604

## Ticket Description

There is a 'double' instance of CKB Deinze in the database. One is active, and the other is inactive. This confuses systems, and it doesn't make sense that active organizations are linked (almost managed) by an inactive organization.