### PR TITLE
fix: insert location relations in the correct graph

### DIFF
--- a/config/migrations/2025/20250430130307-chore--cleanup-werkingsgebieden-data/20250430180050-feat--relate-werkingsgebieden-for-municipalities-and-provinces.sparql
+++ b/config/migrations/2025/20250430130307-chore--cleanup-werkingsgebieden-data/20250430180050-feat--relate-werkingsgebieden-for-municipalities-and-provinces.sparql
@@ -3,7 +3,7 @@ PREFIX org: <http://www.w3.org/ns/org#>
 PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
 
 INSERT {
-  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+  GRAPH <http://mu.semte.ch/graphs/public> {
     ?municipalityLocation geo:sfWithin ?provinceLocation .
   }
 } WHERE {

--- a/config/migrations/2025/20250430130307-chore--cleanup-werkingsgebieden-data/20250521102551-fix--move-location-triples-from-shared-to-public.sparql
+++ b/config/migrations/2025/20250430130307-chore--cleanup-werkingsgebieden-data/20250521102551-fix--move-location-triples-from-shared-to-public.sparql
@@ -1,0 +1,24 @@
+PREFIX geo: <http://www.opengis.net/ont/geosparql#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/shared> {
+    ?s ?p ?o .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s ?p ?o .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/shared> {
+    ?s ?p ?o .
+    VALUES ?p {
+      geo:sfWithin
+      skos:exactMatch
+    }
+  }
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?s a prov:Location .
+  }
+}


### PR DESCRIPTION
In #542 the data related to locations was (supposed to be) moved to the `public` graph. Yet the migrations in the original PR contained two errors.

First, the migration[^1] adding the link between municipality and province locations incorrectly inserted the new data in the `administrative-unit` graph. This migration is fixed as part of the current PR.

The initial migration was already executed on DEV, so that environment will require executing an additional local migration to correct the data. I opted to modify the original migration instead of adding a new one so that on QA and PROD the data is immediately inserted in the correct graph.

``` sparql
PREFIX geo: <http://www.opengis.net/ont/geosparql#>
PREFIX prov: <http://www.w3.org/ns/prov#>

DELETE {
  GRAPH ?g {
    ?s geo:sfWithin ?o .
  }
} INSERT {
  GRAPH <http://mu.semte.ch/graphs/public> {
    ?s geo:sfWithin ?o .
  }
} WHERE {
  GRAPH ?g {
    ?s geo:sfWithin ?o .
  }
  VALUES ?g {
    <http://mu.semte.ch/graphs/administrative-unit>
  }
  GRAPH <http://mu.semte.ch/graphs/public> {
    ?s a prov:Location .
    ?o a prov:Location .
  }
}
```


Second, the migration[^2] moving location data from the `administrative-unit` and `shared` graphs to public failed to match some triples in the `shared` graph. In #442 the some new municipalities were introduced. While the migrations added the relevant new `prov:Location` resources to the `administrative-unit` graph, the `geo:sfWithin` triples were inserted in the `shared` graph. Furthermore, in #490 the `skos:exactMatch` triples for these locations were also inserted in the `shared` graph.
The `WHERE` clause in the migration assumes the type and `ext:ext:werkingsgebiedNiveau` triples are in the same `sourceGraph` as all moved triples, for the cases above that is not case.


## How to test
0. When using DEV data, first add a local migration containing the above query. When using QA or PROD data that is not necessary.
1. Restart the migrations service to execute the necessary migrations
2. All triples with a `prov:Location` resource as subject should be located in the `public` graph afterwards. (With the exception of any triples in producer and consumer graphs.) A query that can be used to check this:

``` sparql
PREFIX prov: <http://www.w3.org/ns/prov#>

SELECT DISTINCT ?g
WHERE {
  GRAPH ?g {
    ?s ?p ?o .
  }
  ?s a prov:Location .
}
```

## Related tickets
- OP-3566


[^1]: `20250430180050-feat--relate-werkingsgebieden-for-municipalities-and-provinces.sparql`
[^2]: `20250430130307-chore--cleanup-werkingsgebieden-data/20250430142110-chore--move-werkingsgebieden-to-public-graph.sparql`