### PR TITLE
fix: datafix of 3 orgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
   + Link district werkingsgebieden to Antwerp municipality werkingsgebied
   + Add missing werkingsgebied for Borsbeek district
 - Write migration to extract from existing primary sites the province URI [OP-3597]
+- datafix: update status kerkfabriek weelde [OP-3598]
+- datafix: delete change event and update status protestantse kerk oostende [OP-3604]
+- datafix: update change event date islamic assocation [OP-3602]
 ### Deploy Notes
 ```
 drc restart migrations; drc logs -ft --tail=200 migrations
@@ -20,6 +23,8 @@ drc restart delta-producer-publication-graph-maintainer
 drc exec delta-producer-background-jobs-initiator curl -X POST http://localhost/public/healing-jobs # or wait until nightly healing kicks in
 drc exec delta-producer-background-jobs-initiator curl -X POST http://localhost/organizations/healing-jobs # or wait until nightly healing kicks in
 drc exec db-cleanup curl -X POST "http://localhost/cleanup"
+
+drc restart migrations-triggering-indexing && drc logs -ft --tail=200 migrations-triggering-indexing
 ```
 
 ## v1.31.3 (2025-05-08)

--- a/config/migrations-triggering-indexing/2025/20250520103521-update-status-kerkfabriek-weelde.sparql
+++ b/config/migrations-triggering-indexing/2025/20250520103521-update-status-kerkfabriek-weelde.sparql
@@ -1,0 +1,17 @@
+PREFIX regorg: <http://www.w3.org/ns/regorg#>
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?s regorg:orgStatus ?activeStatus.
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?s regorg:orgStatus ?notActiveStatus.
+  }
+} WHERE {
+  VALUES ?s {
+    <http://data.lblod.info/id/besturenVanDeEredienst/b1dbb9effdedef39bc4f0c8d96197cfd>
+  }
+  BIND (<http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311> AS ?notActiveStatus)
+  BIND (<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> AS ?activeStatus)
+}

--- a/config/migrations-triggering-indexing/2025/20250520110719-update-status-protestantse-kerk-oostende.sparql
+++ b/config/migrations-triggering-indexing/2025/20250520110719-update-status-protestantse-kerk-oostende.sparql
@@ -1,0 +1,17 @@
+PREFIX regorg: <http://www.w3.org/ns/regorg#>
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?s regorg:orgStatus ?notActiveStatus.
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?s regorg:orgStatus ?activeStatus.
+  }
+} WHERE {
+  VALUES ?s {
+    <http://data.lblod.info/id/besturenVanDeEredienst/45596b602140f031237b0ec26a8d4718>
+  }
+  BIND (<http://lblod.data.gift/concepts/d02c4e12bf88d2fdf5123b07f29c9311> AS ?notActiveStatus)
+  BIND (<http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> AS ?activeStatus)
+}

--- a/config/migrations/2025/20250520105233-delete-change-event-oostende.sparql
+++ b/config/migrations/2025/20250520105233-delete-change-event-oostende.sparql
@@ -1,0 +1,32 @@
+PREFIX core: <http://mu.semte.ch/vocabularies/core/>
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX lblodorg: <http://lblod.data.gift/vocabularies/organisatie/>
+PREFIX euro: <http://data.europa.eu/m8g/>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?event ?ep ?eo .
+
+    ?result ?rp ?ro .
+
+    ?decision ?de ?do .
+  }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?event a org:ChangeEvent ;
+           core:uuid "6824418BD4DB18EC8BA95940" ;
+           lblodorg:veranderingsgebeurtenisResultaat ?result ;
+           ?ep ?eo .
+
+    ?result a lblodorg:VeranderingsgebeurtenisResultaat ;
+            ?rp ?ro .
+
+    OPTIONAL {
+      ?event euro:hasFormalFramework ?decision .
+      ?decision a besluit:Besluit ;
+                ?de ?do .
+    }
+  }
+}

--- a/config/migrations/2025/20250520110017-update-date-change-event-islamic-association.sparql
+++ b/config/migrations/2025/20250520110017-update-date-change-event-islamic-association.sparql
@@ -1,0 +1,15 @@
+PREFIX dct: <http://purl.org/dc/terms/>
+
+DELETE {
+  GRAPH ?g {
+    <http://data.lblod.info/id/veranderingsgebeurtenissen/682443E0D4DB18EC8BA95945> dct:date ?oldDate .
+  }
+} INSERT {
+  GRAPH ?g {
+    <http://data.lblod.info/id/veranderingsgebeurtenissen/682443E0D4DB18EC8BA95945> dct:date "2021-06-18"^^xsd:date .
+  }
+} WHERE {
+  GRAPH ?g {
+    <http://data.lblod.info/id/veranderingsgebeurtenissen/682443E0D4DB18EC8BA95945> dct:date ?oldDate .
+  }
+}


### PR DESCRIPTION
## ID
OP-3602, OP-3604 and OP-3598

## Description

This PR bundles the datafix of 3 different orgs/tickets for PROD data:
- update status kerkfabriek weelde [OP-3598]
- delete change event and update status protestantse kerk oostende [OP-3604]
- update change event date islamic assocation [OP-3602]

## How to test

Setup stack with prod data, verify for each ticket that the desired change is done