### PR TITLE
chore: remove deprecated version from docker compose configurations

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,5 +1,3 @@
-version: "3.4"
-
 services:
   identifier:
     restart: "no"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.4"
-
 x-logging: &default-logging
   driver: "json-file"
   options:


### PR DESCRIPTION
The version property has been deprecated for a while. Now that the servers are on a recent version of docker compose these can be removed from our configurations. This avoids that the warnings are shown each time. The version property should also be removed from the `docker-compose.override.yml` files on the individual environments. 

Additionally, the `networks` entry in each environment's override file can be changed from

```yml
networks:
  proxy:
    external:
      name: letsencrypt_default
```
to its equivalent

```yml
networks:
  proxy:
    name: letsencrypt_default
    external: true
```

This gets rid of the other deprecation warning we receive.