### PR TITLE
fix: update label for locations to match their merged municipality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 ## Unreleased
+
+## v1.33.2 (2025-06-20)
+### Backend
+- datafix: correct name for locations whose municipalities kept their URI in the 2025 mergers
+### Deploy notes
+```
+drc restart migrations-triggering-indexing && drc logs -ft --tail=200
+```
+
 ## v1.33.1 (2025-06-16)
 ### Backend
 - Added Vlaams Parlement as bestuurseenheid. [DL-6686]

--- a/config/migrations-triggering-indexing/2025/20250619113048-fix--rename-locations-merged-municipalities-that-kept-uri.sparql
+++ b/config/migrations-triggering-indexing/2025/20250619113048-fix--rename-locations-merged-municipalities-that-kept-uri.sparql
@@ -1,0 +1,22 @@
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?scope rdfs:label ?oldLabel .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?scope rdfs:label ?newLabel .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?scope a prov:Location ;
+           rdfs:label ?oldLabel .
+    VALUES (?scope ?newLabel) {
+      (<http://data.lblod.info/id/werkingsgebieden/1f5dd7043ad54d07751da8689d5b47ad9ae0e52dccce8f00cc8debab35f8e2b2> "Bilzen-Hoeselt")
+      (<http://data.lblod.info/id/werkingsgebieden/fc34bb0a1dbf157ac5e5f8e657dd774210f03d2efa21370dd3b9a6342906c7ab> "Tessenderlo-Ham")
+      (<http://data.lblod.info/id/werkingsgebieden/fabec9e745fc9efa32afadd8b7268938805b9679dcf3b032c9b9a9a3530d6b59> "Tongeren-Borgloon")
+    }
+  }
+}


### PR DESCRIPTION
As part of the 2025 municipality mergers, three municipalities kept their URI
but were renamed. This updates the labels for their scope of
operation (nl. werkingsgebied) locations accordingly. This way the label of the
location resources matches the name of the municipality administrative unit.

## Notes
- I added this as a migration triggering indexing such that the appropriate deltas are created and the changes can be propagated to consuming apps with having to wait (or trigger) a healing job.