### PR TITLE
feat: include URI in responses for organisations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Add Brussels Hoofdstedelijk Gewest as province and location, update province of addresses in Brussel's area, update resource config to add `skos:note` on organizations [OP-3624]
 - Add Brussel as a municipality [OP-3628]
 - Bump delta-notifier service to most recent version [OP-3190]
+- Add URI to resource's organization responses
 
 ### Deploy notes
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@
 - Add Brussel as a municipality [OP-3628]
 - Bump delta-notifier service to most recent version [OP-3190]
 - Add URI to resource's organization responses
-
 ### Deploy notes
 ```
 drc pull deltanotifier; drc up -d deltanotifier
 drc restart migrations-triggering-indexing resource
+drc pull frontend; drc up -d frontend
 ```
 
 ## v1.33.2 (2025-06-20)

--- a/config/resources/domain.json
+++ b/config/resources/domain.json
@@ -473,6 +473,7 @@
           "inverse": true
         }
       },
+      "features": ["include-uri"],
       "new-resource-base": "http://data.lblod.info/id/organisaties/"
     },
     "administrative-units": {


### PR DESCRIPTION
This includes an organisation's URI in the response from the resource
service. This allows to easily get the URI for an organisation without having to
determine it based to UUID and classification and/or explicitly querying the
triplestore.

This is mostly a convenience for developers, but can be leveraged to add a link
to Centrale Vindplaats in the frontend.

## Related PRs
- Should be tested and deployed with this [frontend PR](https://github.com/lblod/frontend-organization-portal/pull/682)

## TODO
- [ ] Extend deploy instructions to include frontend bump