### PR TITLE
Migration - harmonize date formats of change events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,14 @@
 - Add URI to resource's organization responses
 - Fix query for organizations report [OP-3636]
 - Bump report-generation-service to most recent version
+- Write migration to harmonize date formats of change events [OP-3559]
 ### Deploy notes
 ```
 drc pull deltanotifier; drc up -d deltanotifier
 drc restart migrations-triggering-indexing resource
 drc pull frontend; drc up -d frontend
 drc pull report-generation; drc up -d report-generation
+drc restart migrations; drc logs -ft --tail=200 migrations
 ```
 
 ## v1.33.3 (2025-07-04)

--- a/config/migrations/2025/20250708140355-fix-changeevent-dates.sparql
+++ b/config/migrations/2025/20250708140355-fix-changeevent-dates.sparql
@@ -1,0 +1,26 @@
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+DELETE {
+  GRAPH ?g {
+    ?s dcterms:date ?oldDate .
+  }
+}
+INSERT {
+  GRAPH ?g {
+    ?s dcterms:date ?newDate .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?s a org:ChangeEvent ;
+        dcterms:date ?oldDate .
+    FILTER(DATATYPE(?oldDate) != xsd:date)
+    FILTER(?g IN (
+      <http://mu.semte.ch/graphs/administrative-unit>,
+      <http://mu.semte.ch/graphs/worship-service>,
+    ))
+    BIND(STRDT(SUBSTR(STR(?oldDate), 1, 10), xsd:date) AS ?newDate)
+  }
+}

--- a/config/migrations/2025/20250708140355-fix-changeevent-dates.sparql
+++ b/config/migrations/2025/20250708140355-fix-changeevent-dates.sparql
@@ -19,7 +19,7 @@ WHERE {
     FILTER(DATATYPE(?oldDate) != xsd:date)
     FILTER(?g IN (
       <http://mu.semte.ch/graphs/administrative-unit>,
-      <http://mu.semte.ch/graphs/worship-service>,
+      <http://mu.semte.ch/graphs/worship-service>
     ))
     BIND(STRDT(SUBSTR(STR(?oldDate), 1, 10), xsd:date) AS ?newDate)
   }


### PR DESCRIPTION
### ID

[OP-3559](https://binnenland.atlassian.net/browse/OP-3559)

### Description
Adds a migration that corrects inconsistent dcterms:date values used in org:ChangeEvent resources. 