### PR TITLE
feat: set initial scope of operation for worship administrative units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,20 @@
 ### Backend
 - Add a service to manage organisation's their scope of operation [OP-3205]
 - datamodel: Allow a location to be within multiple other locations [OP-3205]
+- datafix: set scope of operation for worship administrative units [OP-3626]
 ### Deploy notes
 ```
 drc pull scope-of-operation; drc up -d scope-of-operation
 drc restart db resource dispatcher
 drc pull frontend; drc up -d frontend
+drc restart migrations; drc compose logs -ft --tail=200 migrations
+```
+
+The labels for new location resources created when setting the scope of operation for worship services are not necessarily alphabetically sorted. To correct this run the `correct-location-labels` project script using [mu-cli](https://github.com/mu-semtech/mu-cli) and restart the migrations service once more to execute the generated local migrations.
+
+```
+mu script project-scripts correct-location-labels
+drc restart migrations; drc compose logs -ft --tail=200 migrations
 ```
 
 ## v1.34.0 (2025-07-11)

--- a/config/migrations/2025/20250707132349-feat--add-scope-for-operation-worship-organisations/20250707132349-chore--extract-scopes-for-worship-organisations.sparql
+++ b/config/migrations/2025/20250707132349-feat--add-scope-for-operation-worship-organisations/20250707132349-chore--extract-scopes-for-worship-organisations.sparql
@@ -1,0 +1,112 @@
+PREFIX ere: <http://data.lblod.info/vocabularies/erediensten/>
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+
+# This migration extracts the relations between (central) worship services and
+# their locations according to the rules provided by business. These links are
+# inserted into a temporary graph for further processing.
+
+# Worship services
+## Municipality organised
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/temp-for-worship-organizations-scope> {
+    ?ws besluit:werkingsgebied ?scope .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?ws a ere:BestuurVanDeEredienst ;
+        ere:typeEredienst ?worshipType .
+    VALUES ?worshipType {
+      <http://lblod.data.gift/concepts/99536dd6eb0d2ef38a89efafb17e7389> # Anglicaans
+      <http://lblod.data.gift/concepts/1a1abeafc973d27cebcb2d7a15b2d823> # Israëlitisch
+      <http://lblod.data.gift/concepts/e8cba1540b35a32e9cb45126c38c03c6> # Protestants
+      <http://lblod.data.gift/concepts/b13d1d623626bc1ee75c7d20bc60e3c0> # Rooms-Katholiek
+    }
+
+    ?involvement a ere:BetrokkenLokaleBesturen ;
+                 org:organization ?ws ;
+                 ere:typebetrokkenheid ?involvementType .
+    VALUES ?involvementType {
+      <http://lblod.data.gift/concepts/86fcbbbff764f1cba4c7e10dbbae578e> # Mede-financierend
+      <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1> # Toezichthoudend
+    }
+    ?org ere:betrokkenBestuur ?involvement .
+  }
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?org besluit:werkingsgebied ?scope .
+  }
+}
+;
+## Province organised
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/temp-for-worship-organizations-scope> {
+    ?ws besluit:werkingsgebied ?scope .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?ws a ere:BestuurVanDeEredienst ;
+        ere:typeEredienst ?worshipType .
+    VALUES ?worshipType {
+      <http://lblod.data.gift/concepts/9d8bd472a00bf0a5c7b7186606365a52> # Islamitisch
+      <http://lblod.data.gift/concepts/84bcd6896f575bae4857ff8d2764bed8> # Orthodox
+    }
+
+    ?involvement a ere:BetrokkenLokaleBesturen ;
+                 org:organization ?ws ;
+                 ere:typebetrokkenheid ?involvementType .
+    VALUES ?involvementType {
+      <http://lblod.data.gift/concepts/0f845f00ee76099c89518cbaf6a7b77f> # Adviserend
+    }
+    ?org ere:betrokkenBestuur ?involvement .
+  }
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?org besluit:werkingsgebied ?scope .
+  }
+}
+;
+# Central worship services
+## Municipality organised
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/temp-for-worship-organizations-scope> {
+    ?ws besluit:werkingsgebied ?scope .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?ws a ere:CentraalBestuurVanDeEredienst ;
+        ere:typeEredienst ?worshipType .
+    VALUES ?worshipType {
+      <http://lblod.data.gift/concepts/b13d1d623626bc1ee75c7d20bc60e3c0> # Rooms-Katholiek
+    }
+
+    ?involvement a ere:BetrokkenLokaleBesturen ;
+                 org:organization ?ws ;
+                 ere:typebetrokkenheid ?involvementType .
+    VALUES ?involvementType {
+      <http://lblod.data.gift/concepts/ac400cc9f135ac7873fb3e551ec738c1> # Toezichthoudend
+    }
+    ?org ere:betrokkenBestuur ?involvement .
+  }
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?org besluit:werkingsgebied ?scope .
+  }
+}
+;
+## Province organised
+## Note: Business requested to use the location for the municipality of Ghent as
+## default value. They will update it manually afterwards.
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/temp-for-worship-organizations-scope> {
+    ?ws besluit:werkingsgebied ?locationGhent .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?ws a ere:CentraalBestuurVanDeEredienst ;
+        ere:typeEredienst ?worshipType .
+    VALUES ?worshipType {
+      <http://lblod.data.gift/concepts/9d8bd472a00bf0a5c7b7186606365a52> # Islamitisch
+      <http://lblod.data.gift/concepts/84bcd6896f575bae4857ff8d2764bed8> # Orthodox
+    }
+
+    BIND(URI("http://data.lblod.info/id/werkingsgebieden/ce94eeae827cdc5c00f3f2f4276ff628580edefb3aa5861e4669b0c5d93adc57") AS ?locationGhent)
+  }
+}

--- a/config/migrations/2025/20250707132349-feat--add-scope-for-operation-worship-organisations/20250709140704-feat--set-scope-for-worship-organisations-with-single-location.sparql
+++ b/config/migrations/2025/20250707132349-feat--add-scope-for-operation-worship-organisations/20250709140704-feat--set-scope-for-worship-organisations-with-single-location.sparql
@@ -1,0 +1,24 @@
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+
+# This migration sets the scope of operation for worship organisations that have
+# single, already existing, location as scope. This migration depends on
+# `20250707132349-chore--extract-scopes-for-worship-organisations` being
+# executed first, as it uses the data created by the migration.
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?ws besluit:werkingsgebied ?scope .
+  }
+} WHERE {
+  {
+    SELECT DISTINCT ?ws (count(DISTINCT ?scope) as ?count)
+    WHERE {
+      GRAPH <http://mu.semte.ch/graphs/temp-for-worship-organizations-scope> {
+        ?ws besluit:werkingsgebied ?scope .
+      }
+    }
+  }
+  FILTER (?count = 1)
+  GRAPH <http://mu.semte.ch/graphs/temp-for-worship-organizations-scope> {
+    ?ws besluit:werkingsgebied ?scope .
+  }
+}

--- a/config/migrations/2025/20250707132349-feat--add-scope-for-operation-worship-organisations/20250709160017-feat--set-scope-for-worship-organisations-with-multiple-locations.sparql
+++ b/config/migrations/2025/20250707132349-feat--add-scope-for-operation-worship-organisations/20250709160017-feat--set-scope-for-worship-organisations-with-multiple-locations.sparql
@@ -1,0 +1,49 @@
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX geo: <http://www.opengis.net/ont/geosparql#>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+# This migration sets the scope of operation for worship organisations that have
+# multiple location as scope. It creates new aggregate locations to contain the
+# already existing municipality/province level ones.  This migration depends on
+# `20250707132349-chore--extract-scopes-for-worship-organisations` being
+# executed first, as it uses the data created by the migration.
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?location a prov:Location ;
+              mu:uuid ?locationUuid ;
+              rdfs:label ?scopeLabel ;
+              ext:werkingsgebiedNiveau """Samengesteld werkingsgebied""" .
+    ?scope geo:sfWithin ?location .
+  }
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?ws besluit:werkingsgebied ?location .
+  }
+} WHERE {
+  {
+    SELECT DISTINCT ?ws (count(DISTINCT ?scope) AS ?count) (GROUP_CONCAT(?uuid," ") AS ?scopeUuids) (GROUP_CONCAT(?label,", ") AS ?scopeLabel)
+    WHERE {
+      GRAPH <http://mu.semte.ch/graphs/temp-for-worship-organizations-scope> {
+        ?ws besluit:werkingsgebied ?scope .
+      }
+      GRAPH <http://mu.semte.ch/graphs/public> {
+        ?scope mu:uuid ?uuid ;
+               rdfs:label ?label .
+      }
+    }
+  }
+  FILTER (?count > 1)
+  GRAPH <http://mu.semte.ch/graphs/temp-for-worship-organizations-scope> {
+    ?ws besluit:werkingsgebied ?scope .
+  }
+  # NOTE (10/07/2025): The SPARQL specification does not specify any order for
+  # `GROUP_CONCAT`. But virtuoso does seem to concatenate elements always in the
+  # same order. Therefore, this way of generating a UUID is a bit of a hack to
+  # ensure that new locations that contain the same locations will receive the
+  # same UUUID, which results in the same location resource being inserted
+  # twice.
+  BIND (STR(SHA256(?scopeUuids)) AS ?locationUuid)
+  BIND (URI(CONCAT("http://data.lblod.info/id/werkingsgebieden/", ?locationUuid)) AS ?location)
+}

--- a/config/migrations/2025/20250707132349-feat--add-scope-for-operation-worship-organisations/20250710095207-chore--clear-temp-graph-worship-scopes.sparql
+++ b/config/migrations/2025/20250707132349-feat--add-scope-for-operation-worship-organisations/20250710095207-chore--clear-temp-graph-worship-scopes.sparql
@@ -1,0 +1,1 @@
+CLEAR GRAPH <http://mu.semte.ch/graphs/temp-for-worship-organizations-scope>

--- a/scripts/project/config.json
+++ b/scripts/project/config.json
@@ -19,6 +19,22 @@
     },
     {
       "documentation": {
+        "command": "correct-location-labels",
+        "description": "generate migrations to correct the labels of aggregated locations",
+        "arguments": []
+      },
+      "environment": {
+        "image": "nvdk/ruby-semantic-works-cli",
+        "interactive": true,
+        "script": "correct-location-labels/run.rb",
+        "join_networks": true
+      },
+      "mounts": {
+        "app": "/app/"
+      }
+    },
+    {
+      "documentation": {
         "command": "mu-search-delta",
         "description": "produce delta for mu-search",
         "arguments": []

--- a/scripts/project/correct-location-labels/run.rb
+++ b/scripts/project/correct-location-labels/run.rb
@@ -1,0 +1,106 @@
+#!/usr/bin/env ruby
+require 'date'
+require 'rdf/turtle'
+require 'fileutils'
+
+$stdout.sync = true
+ENV['LOG_SPARQL_ALL']='false'
+ENV['MU_SPARQL_ENDPOINT']='http://triplestore:8890/sparql'
+ENV['MU_SPARQL_TIMEOUT']='180'
+require 'mu/auth-sudo'
+
+def ensure_dir(path)
+ unless Dir.exist?(path)
+   FileUtils.mkdir_p(path)
+ end
+end
+
+def sparql_escape_uri(value)
+  '<' + value.to_s.gsub(/[\\"<>]/) { |s| '\\' + s } + '>'
+end
+
+def sparql_escape_string(str)
+  '"""' + str.gsub(/[\\"]/) { |s| '\\' + s } + '"""'
+end
+
+def get_locations()
+  query = <<~EOF
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+SELECT DISTINCT ?location ?label
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?location a prov:Location ;
+              rdfs:label ?label ;
+              ext:werkingsgebiedNiveau """Samengesteld werkingsgebied""" .
+  }
+}
+EOF
+  Mu::AuthSudo.query(query)
+end
+
+def sort_literal(literal)
+  literal
+    .humanize
+    .split(", ")
+    .sort
+    .join(", ")
+end
+
+# Create output directory
+timestamp=`date +%Y%0m%0d%0H%0M%0S`.strip.to_i
+output_dir = "/app/config/migrations/local/2025/#{timestamp}-correct-labels-aggregate-locations/"
+ensure_dir(output_dir)
+
+
+# Generate SPARQL migration to remove existing labels
+path = File.join(output_dir, "#{timestamp}-remove-labels-aggregate-locations.sparql")
+File.open(path, 'w') do |file|
+  file.write <<EOF
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?location rdfs:label ?label
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?location a prov:Location ;
+              rdfs:label ?label ;
+              ext:werkingsgebiedNiveau """Samengesteld werkingsgebied""" .
+  }
+}
+EOF
+end
+
+
+# Generate TTL migration to insert alphabetically sorted labels
+timestamp += 1
+filename = "#{timestamp}-insert-labels-aggregate-locations"
+
+path = File.join(output_dir, "#{filename}.graph")
+File.open(path, 'w') do |file|
+  file.write <<EOF
+http://mu.semte.ch/graphs/public
+EOF
+end
+
+path = File.join(output_dir, "#{filename}.ttl")
+File.open(path, 'w') do |file|
+  file.write <<EOF
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+EOF
+end
+
+locations = get_locations()
+locations.each do |location|
+  File.open(path, 'a') do |file|
+    file.write <<EOF
+    #{sparql_escape_uri(location[:location])} rdfs:label "#{(sort_literal(location[:label]))}" .
+EOF
+  end
+end


### PR DESCRIPTION
Worship administrative units are so far not linked to a location as their scope of operation. Since this will become a mandatory field for administrative units, we already set some initial scope of operation for (central) worship services. This way users are not blocked from editing worship administrative units.

## Business rules
Business provided rules on which locations can be set as initial scope of operations. In general a worship administrative unit should be linked to locations matching a subset of it local involvements. The following table is adapted from the linked ticket. The first row, for example, means "for worship services of type Islamitisch or Orthodox, use the locations for the locally involvement advisory municipalities as scope of operation."

|                         | Types                                                  | Local involvement role                        |
|-------------------------|--------------------------------------------------------|-----------------------------------------------|
| Worship service         | Islamitisch, Orthodox                                  | Adviserend                                    |
| Worship service         | Anglicaans, Israëlitisch, Protestants, Rooms-Katholiek | Toezichthoudend, Mede-financierend            |
| Central worship service | Rooms-Katholiek                                        | Toezichthoudend                               |
| Central worship service | Islamitisch, Orthodox                                  | None, use location for Ghent as default value[^1] |

## Approach
The added migrations work in several steps, and should thus be executed in the order specified by their timestamps.

1. The first migration extracts the necessary relations between worship administrative units and their location according to the rules provided by business. The extract data is inserted into a temporary graph as triples with the `besluit:werkingsgebied` predicate.
2. For worship administrative units with only one linked location, the second migration copies the triples from the temporary graph to the worship-service graph.
3. For worship administrative units linked to more than 1 location, the third migration creates new `prov:Location` resources that aggregate all linked locations, and then sets this new location as scope of operation for the worship administrative unit. This is necessary because an administrative unit can be linked to at most 1 location as scope of operation in the data model.
4. Clear the created temporary graph.

Note, that for the newly created locations their labels are the concatenation of the labels of their contained locations in some, seemingly, random order. As these labels will be displayed to the users it was requested to order the elements in the concatenated alphabetically. The service added in #550 does this automatically when it creates new aggregate location resources. But I was unable to achieve this using SPARQL. Therefore, I added a project script `correct-location-labels` which generates **local** migrations that allow to update the labels of all created location resources.

## How to test
Follow the instructions form the changelog, the relevant part is copied below. Note, you can ignore the frontend part of the instructions, just build a local fronted for the branch in [#680](https://github.com/lblod/frontend-organization-portal/pull/680).

> ``` shell
> drc pull scope-of-operation; drc up -d scope-of-operation
> drc restart db resource dispatcher
> drc pull frontend; drc up -d frontend
> ```
> The labels for new location resources created when setting the scope of operation for worship services are not necessarily alphabetically sorted. To correct this run the `correct-location-labels` project script using [mu-cli](https://github.com/mu-semtech/mu-cli) and restart the migrations service once more to execute the generated local migrations.

> ```
> mu script project-scripts correct-location-labels
> drc restart migrations; drc compose logs -ft --tail=200 migrations
> ```

Afterwards, most worship administrative units should be assigned a scope of operation via the `besluit:werkingsgebied` predicate. If none is set, check the local involvements for the worship administrative unit with respect to the business rules above.

Note, don't forget to remove the generated local migrations once you are done with this PR. Otherwise you might experience some unexpected data in the future.

## Related tickets
- OP-3626


[^1]: Business will set this to the correct value manually.