### PR TITLE
Add migration to fix dev addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Add a service to manage organisation's their scope of operation [OP-3205]
 - datamodel: Allow a location to be within multiple other locations [OP-3205]
 - datafix: set scope of operation for worship administrative units [OP-3626]
-- Clean dev addresses linked to both sites and contact points of mandatarissen [DL-6701]
+- Clean addresses linked to both sites and contact points of mandatarissen and addresses that are in the wrong graph (admin unit graph but linked to a contact point in the worship graph) [DL-6701]
 ### Deploy notes
 ```
 drc pull scope-of-operation; drc up -d scope-of-operation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add a service to manage organisation's their scope of operation [OP-3205]
 - datamodel: Allow a location to be within multiple other locations [OP-3205]
 - datafix: set scope of operation for worship administrative units [OP-3626]
+- Clean dev addresses linked to both sites and contact points of mandatarissen [DL-6701]
 ### Deploy notes
 ```
 drc pull scope-of-operation; drc up -d scope-of-operation
@@ -32,7 +33,6 @@ drc restart migrations; drc logs -ft --tail=200 migrations
 - Add URI to resource's organization responses
 - Fix query for organizations report [OP-3636]
 - Bump report-generation-service to most recent version
-- Write migration to harmonize date formats of change events [OP-3559]
 ### Deploy notes
 ```
 drc pull deltanotifier; drc up -d deltanotifier

--- a/config/dev-migrations/20250708142100-fix-same-address-linked-to-both-site-and-contact-point.sparql
+++ b/config/dev-migrations/20250708142100-fix-same-address-linked-to-both-site-and-contact-point.sparql
@@ -1,0 +1,31 @@
+DELETE {
+  GRAPH ?h {
+    ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?oldAddressUri .
+  }
+} INSERT {
+  GRAPH ?g {
+    ?newAddressUri a <http://www.w3.org/ns/locn#Address> ;
+      <http://mu.semte.ch/vocabularies/core/uuid> ?newAddressUuid ;
+      ?p ?o .
+  }
+
+  GRAPH ?h {
+    ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?newAddressUri .
+  }
+} WHERE {
+  GRAPH ?g {
+    ?oldAddressUri a <http://www.w3.org/ns/locn#Address> ;
+      ?p ?o .
+
+    FILTER (?p NOT IN (<http://mu.semte.ch/vocabularies/core/uuid>))
+  }
+
+  ?mandatarisContact <http://www.w3.org/ns/locn#address> ?oldAddressUri .
+
+  GRAPH ?h {
+    ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?oldAddressUri .
+  }
+
+  BIND(MD5(CONCAT(?oldAddressUri,"OLD_ADDRESS")) AS ?newAddressUuid) .
+  BIND(IRI(CONCAT("http://data.lblod.info/id/adressen/", STR(?newAddressUuid))) AS ?newAddressUri) .
+}

--- a/config/migrations/2025/20250708142100-fix-same-address-linked-to-both-site-and-contact-point.sparql
+++ b/config/migrations/2025/20250708142100-fix-same-address-linked-to-both-site-and-contact-point.sparql
@@ -7,9 +7,7 @@ DELETE {
     ?newAddressUri a <http://www.w3.org/ns/locn#Address> ;
       <http://mu.semte.ch/vocabularies/core/uuid> ?newAddressUuid ;
       ?p ?o .
-  }
 
-  GRAPH ?h {
     ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?newAddressUri .
   }
 } WHERE {
@@ -23,9 +21,10 @@ DELETE {
   ?mandatarisContact <http://www.w3.org/ns/locn#address> ?oldAddressUri .
 
   GRAPH ?h {
-    ?site <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?oldAddressUri .
+    ?site a <http://www.w3.org/ns/org#Site>;
+     <https://data.vlaanderen.be/ns/organisatie#bestaatUit> ?oldAddressUri .
   }
 
-  BIND(MD5(CONCAT(?oldAddressUri,"OLD_ADDRESS")) AS ?newAddressUuid) .
+  BIND(MD5(CONCAT(?oldAddressUri,"NEW_ADDRESS")) AS ?newAddressUuid) .
   BIND(IRI(CONCAT("http://data.lblod.info/id/adressen/", STR(?newAddressUuid))) AS ?newAddressUri) .
 }

--- a/config/migrations/2025/20250722114200-fix-contact-addresses-being-in-wrong-graph.sparql
+++ b/config/migrations/2025/20250722114200-fix-contact-addresses-being-in-wrong-graph.sparql
@@ -1,0 +1,18 @@
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?address ?p ?o .
+  }
+} INSERT {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?address ?p ?o .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/worship-service> {
+    ?contactPoint a <http://schema.org/ContactPoint> ;
+      <http://www.w3.org/ns/locn#address> ?address .
+  }
+
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?address ?p ?o .
+  }
+}


### PR DESCRIPTION
# ID

[DL-6701]

# Description

On dev, some addresses are linked both to sites and to contact point of mandatarissen. It doesn't make any sense and I couldn't trace it back to the source. The issue did not affect other environments.

The migration should fix it by creating a dupe of the affected addresses and by linking those dupes to the sites. That way, sites and contact points have independent addresses. We update the link between site and address and not between mandataris and address because OP is master of the sites, which means we should then produce the correct data and forward it to consuming apps.