### PR TITLE
add migration to cleanup general memberships if specific ones exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add a service to manage organisation's their scope of operation [OP-3205]
 - datamodel: Allow a location to be within multiple other locations [OP-3205]
 - datafix: set scope of operation for worship administrative units [OP-3626]
+- datafix: cleanup of general memberships if specific ones exist [OP-3640]
 ### Deploy notes
 ```
 drc pull scope-of-operation; drc up -d scope-of-operation

--- a/config/migrations/2025/20250718132455-remove-general-memberships-if-specifics-exists.sparql
+++ b/config/migrations/2025/20250718132455-remove-general-memberships-if-specifics-exists.sparql
@@ -1,0 +1,33 @@
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+DELETE {
+  GRAPH ?g {
+    ?membership ?p ?o .
+  }
+}
+WHERE {
+  GRAPH ?g {
+    # Find memberships that use the general 'gerelateerd' role
+    ?membership a org:Membership ;
+                org:role <http://data.lblod.info/id/rollen/4ec7d5c39bdc4e84b4174379b9e22ad8> ;
+                org:member ?orgMember ;
+                org:organization ?organization .
+
+    # Only delete if there's a specific role for the inverse membership
+    FILTER EXISTS {
+      ?specific_membership a org:Membership ;
+                           org:member ?organization ;
+                           org:organization ?orgMember ;
+                           org:role ?specificRole .
+
+      VALUES ?specificRole {
+        <http://data.lblod.info/id/rollen/2152eb830b1143bfb97a7dd9596d6c63> # participant
+        <http://data.lblod.info/id/rollen/73d5e1cf250d42fab15926771f07505a> # stichtend lid
+      }
+    }
+
+    ?membership ?p ?o .
+  }
+}


### PR DESCRIPTION
## ID

OP-3640

## Description

Cleanup of some 'duplicate data', we want to remove the general memberships if a specific one exists.

## Test instructions

See the test case of 'gemeente nijlen' and 'AGB nijlen' in dev data, described in the ticket. After the migration the general membership `http://data.lblod.info/id/lidmaatschap/9325e28ae5685a69d55ded6e9a44d1ab269a07f6` should be removed in favor of the specific memberships `http://data.lblod.info/id/lidmaatschap/c4d82c8d813311b657fe19b54accb4d2d81e7889` and `http://data.lblod.info/id/lidmaatschap/f93959561fa4a15e6e8ab5eb96f770b66be87f19`.