### PR TITLE
add duplicate memberships cleanup migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fix query for organizations report [OP-3636]
 - Bump report-generation-service to most recent version
 - Write migration to harmonize date formats of change events [OP-3559]
+- datafix: cleanup of duplicate memberships [OP-3634]
 ### Deploy notes
 ```
 drc pull deltanotifier; drc up -d deltanotifier

--- a/config/migrations/2025/20250725120411-fix-reversed-memberships-ocmw-municipality.sparql
+++ b/config/migrations/2025/20250725120411-fix-reversed-memberships-ocmw-municipality.sparql
@@ -1,0 +1,40 @@
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?membership org:organization ?ocmw ;
+                org:member ?municipality .
+  }
+}
+INSERT {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?membership org:organization ?municipality ;
+                org:member ?ocmw .
+  }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?membership a org:Membership ;
+      org:organization ?ocmw ;
+      org:member ?municipality ;
+      org:role <http://data.lblod.info/id/rollen/4ec7d5c39bdc4e84b4174379b9e22ad8> .
+  }
+
+  GRAPH ?graphMunicipality {
+    ?municipality org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001> .
+  }
+
+  GRAPH ?graphOCMW {
+    ?ocmw org:classification <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000002> .
+  }
+
+  FILTER NOT EXISTS {
+    GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+      ?correctMembership a org:Membership ;
+        org:organization ?municipality ;
+        org:member ?ocmw ;
+        org:role <http://data.lblod.info/id/rollen/4ec7d5c39bdc4e84b4174379b9e22ad8> .
+    }
+  }
+}

--- a/config/migrations/2025/20250725120522-remove-duplicate-memberships-ocmw-municipality.sparql
+++ b/config/migrations/2025/20250725120522-remove-duplicate-memberships-ocmw-municipality.sparql
@@ -20,14 +20,14 @@ DELETE {
       org:role <http://data.lblod.info/id/rollen/4ec7d5c39bdc4e84b4174379b9e22ad8> .
   }
 
-  GRAPH ?graphMunicipality {
+  GRAPH <http://mu.semte.ch/graphs/shared> {
     ?municipality org:classification ?municipalityClassification .
   }
 
-  GRAPH ?graphOCMW {
-    ?ocmw org:classification ?ocmwClassificiation .
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?ocmw org:classification ?ocmwClassification .
   }
 
   FILTER(?municipalityClassification = <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001>)
-  FILTER(?ocmwClassificiation = <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000002>)
+  FILTER(?ocmwClassification = <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000002>)
 }

--- a/config/migrations/2025/20250725120522-remove-duplicate-memberships-ocmw-municipality.sparql
+++ b/config/migrations/2025/20250725120522-remove-duplicate-memberships-ocmw-municipality.sparql
@@ -8,26 +8,26 @@ DELETE {
 } WHERE {
   GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
     ?duplicateMembership a org:Membership ;
-      org:organization ?orgB ; # OCMW
-      org:member ?orgA ; # Municipality
+      org:organization ?ocmw ;
+      org:member ?municipality ;
       org:role <http://data.lblod.info/id/rollen/4ec7d5c39bdc4e84b4174379b9e22ad8> ;
       ?p ?o .
 
     # Find the other memberships with swapped organizations
     ?correctMembership a org:Membership ;
-      org:organization ?orgA ; # Municipality
-      org:member ?orgB ; # OCMW
+      org:organization ?municipality ;
+      org:member ?ocmw ;
       org:role <http://data.lblod.info/id/rollen/4ec7d5c39bdc4e84b4174379b9e22ad8> .
   }
 
-  GRAPH ?gA {
-    ?orgA org:classification ?classA .
+  GRAPH ?graphMunicipality {
+    ?municipality org:classification ?municipalityClassification .
   }
 
-  GRAPH ?gB {
-    ?orgB org:classification ?classB .
+  GRAPH ?graphOCMW {
+    ?ocmw org:classification ?ocmwClassificiation .
   }
 
-  FILTER(?classA = <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001>)
-  FILTER(?classB = <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000002>)
+  FILTER(?municipalityClassification = <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001>)
+  FILTER(?ocmwClassificiation = <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000002>)
 }

--- a/config/migrations/2025/20250725120522-remove-duplicate-memberships-ocmw-municipality.sparql
+++ b/config/migrations/2025/20250725120522-remove-duplicate-memberships-ocmw-municipality.sparql
@@ -1,0 +1,33 @@
+PREFIX org: <http://www.w3.org/ns/org#>
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+
+DELETE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?duplicateMembership ?p ?o .
+  }
+} WHERE {
+  GRAPH <http://mu.semte.ch/graphs/administrative-unit> {
+    ?duplicateMembership a org:Membership ;
+      org:organization ?orgB ; # OCMW
+      org:member ?orgA ; # Municipality
+      org:role <http://data.lblod.info/id/rollen/4ec7d5c39bdc4e84b4174379b9e22ad8> ;
+      ?p ?o .
+
+    # Find the other memberships with swapped organizations
+    ?correctMembership a org:Membership ;
+      org:organization ?orgA ; # Municipality
+      org:member ?orgB ; # OCMW
+      org:role <http://data.lblod.info/id/rollen/4ec7d5c39bdc4e84b4174379b9e22ad8> .
+  }
+
+  GRAPH ?gA {
+    ?orgA org:classification ?classA .
+  }
+
+  GRAPH ?gB {
+    ?orgB org:classification ?classB .
+  }
+
+  FILTER(?classA = <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001>)
+  FILTER(?classB = <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000002>)
+}


### PR DESCRIPTION
## ID

OP-3634

## Description

Following the conclusion of the analysis (see ticket), the solution of the duplicate memberships should be to remove the inverse membership where the municipality is linked with `org:member` and the ocmw is linked with `org:organization`.

## Testing

Using op dev data, the query should remove all the inverse/duplicate memberships. For example of 'gemeente affligem' it should only have 1 membership with 'ocmw affligem'. The same membership should show up for 'ocmw affligem' as well.