### PR TITLE
[DL-6732]: use acmidm for dashboard

### DIFF
--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -111,11 +111,9 @@ defmodule Acl.UserGroups.Config do
     %AccessByQuery{
       vars: [],
       query: "PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
-        PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
-        SELECT DISTINCT ?account WHERE {
-          <SESSION_ID> <http://mu.semte.ch/vocabularies/session/account> ?account.
-          ?account <http://mu.semte.ch/vocabularies/ext/sessionRole> ?session_role.
-          FILTER( ?session_role = \"dashboard-user\" )
+        SELECT DISTINCT ?session WHERE {
+          VALUES ?session { <SESSION_ID> }
+          ?session ext:sessionRole \"LoketLB-AdminDashboardOrganisatiePortaalGebruiker\" .
         }"
     }
   end
@@ -219,10 +217,10 @@ defmodule Acl.UserGroups.Config do
           }
         ]
       },
-      # // dashboard users
+      # // Dashboard admin
       %GroupSpec{
-        name: "dashboard-users",
-        useage: [:read],
+        name: "o-admin-rwf",
+        useage: [:read, :write, :read_for_write],
         access: can_access_dashboard(),
         graphs: [
           %GraphSpec{

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -306,7 +306,7 @@ defmodule Dispatcher do
   end
 
   match "/sessions/*path", %{ reverse_host: ["dashboard" | _rest] } do
-    Proxy.forward conn, path, "http://dashboard-login/sessions/"
+    Proxy.forward conn, path, "http://login-dashboard/sessions/"
   end
 
   match "/sessions/*path", %{accept: [:any], layer: :api} do

--- a/config/migrations/2025/20250904115406-add-dashboard-admin-role-to-mock-abb-user.sparql
+++ b/config/migrations/2025/20250904115406-add-dashboard-admin-role-to-mock-abb-user.sparql
@@ -1,0 +1,17 @@
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX ext:<http://mu.semte.ch/vocabularies/ext/>
+
+INSERT {
+  GRAPH ?g {
+    ?account ext:sessionRole "LoketLB-AdminDashboardOrganisatiePortaalGebruiker" .
+  }
+}
+WHERE {
+  VALUES ?account {
+    <http://data.lblod.info/id/account/3a91ff60-07c1-4136-ac5e-55cf401e0956>
+  }
+
+  GRAPH ?g {
+    ?account ext:sessionRole ?role .
+  }
+}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -40,6 +40,8 @@ services:
     restart: "no"
   login:
     restart: "no"
+  login-dashboard:
+    restart: "no"
   accountdetail:
     restart: "no"
   privacy-unit:
@@ -49,6 +51,10 @@ services:
   adressenregister:
     restart: "no"
   frontend:
+    restart: "no"
+  frontend-dashboard:
+    # environment:
+      # EMBER_LOGIN_ROUTE: "mock-login"
     restart: "no"
   uri-info:
     restart: "no"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,7 +122,7 @@ services:
     restart: always
     logging: *default-logging
   sink:
-    image: nginx:1.15.2
+    image: nginx:1.25.1
     volumes:
       - ./config/sink/sink.conf:/etc/nginx/conf.d/default.conf
     labels:
@@ -145,10 +145,17 @@ services:
     logging: *default-logging
     links:
       - db:database
-  dashboard-login:
-    image: semtech/mu-login-service:3.0.0
-    links:
-      - db:database
+  login-dashboard:
+    image: lblod/acmidm-login-service:0.12.0
+    environment:
+      LOG_SINK_URL: "http://sink"
+      MU_APPLICATION_AUTH_ROLE_CLAIM: "abb_organisatieportaal_rol_3d"
+      # MU_APPLICATION_AUTH_USERID_CLAIM: "sub" #TODO: check if needed?
+      # MU_APPLICATION_AUTH_ACCOUNTID_CLAIM: "sub"
+      MU_APPLICATION_AUTH_DISCOVERY_URL: "<ACM_IDM_AUTH_DISCOVERY_URL>"
+      MU_APPLICATION_AUTH_CLIENT_ID: "<ACM_IDM_AUTH_CLIENT_ID>"
+      MU_APPLICATION_AUTH_REDIRECT_URI: "<ACMIDM_AUTH_REDIRECT_URI>"
+      MU_APPLICATION_AUTH_CLIENT_SECRET: "<ACMIDM_AUTH_CLIENT_SECRET>"
     labels:
       - "logging=true"
     restart: always
@@ -209,7 +216,15 @@ services:
     restart: always
     logging: *default-logging
   frontend-dashboard:
-    image: lblod/frontend-dashboard:1.7.0
+    image: lblod/frontend-dashboard:1.9.0
+    environment:
+      EMBER_LOGIN_ROUTE: "acmidm-login"
+      EMBER_DISABLE_ERRORS: "true"
+      EMBER_ACMIDM_CLIENT_ID: "<CLIENT_ID>"
+      EMBER_ACMIDM_BASE_URL: "<BASE_URL>"
+      EMBER_ACMIDM_REDIRECT_URL: "<REDIRECT_URL>"
+      EMBER_ACMIDM_LOGOUT_URL: "<LOGOUT_URL>"
+      EMBER_ACMIDM_SCOPE: "openid vo profile abb_organisatieportaal"
     labels:
       - "logging=true"
     restart: always


### PR DESCRIPTION
## ID

DL-6732

## Description

Use acmidm for the dashboard login

**Test instructions**

1. Set up your `/etc/hosts`

Add the following line to the file:
```
127.0.0.1 dashboard.organisaties.abb.lblod.info
```

2. Set up Caddy in your app

Add the following to your `docker-compose.override.yml`:
```
  # use this to test acmidm
  tlsproxy:
    image: caddy:2
    ports:
      - "443:443"
    environment:
      APPLICATION_ADDRESS: "dashboard.organisaties.abb.lblod.info"
    volumes:
      - ./config/tlsproxy-mock/Caddyfile:/etc/caddy/Caddyfile
    restart: "no"
```

and the following file as config, names `config/tlsproxy-mock/Caddyfile`:

```
https://{$APPLICATION_ADDRESS} {
  reverse_proxy identifier:80
  tls internal
}
```
3. Add the QA ACM/IDM environment variables to the dashboard and dashboard-login services.

<details>
<summary>ACC Environment variables</summary>

```yml
# docker-compose.override.yml
  frontend-dashboard:
    environment:
      EMBER_ACMIDM_CLIENT_ID: "03382bf4-4886-4fb6-8602-945ad3080a7a"
      EMBER_ACMIDM_BASE_URL: "https://authenticatie-ti.vlaanderen.be/op/v1/auth"
      EMBER_ACMIDM_REDIRECT_URL: "https://dashboard.organisaties.abb.lblod.info/authorization/callback"
      EMBER_ACMIDM_LOGOUT_URL: "https://authenticatie-ti.vlaanderen.be/op/v1/logout"
      EMBER_ACMIDM_SCOPE: "openid vo profile abb_organisatieportaal"

  login-dashboard:
    environment:
      MU_APPLICATION_AUTH_DISCOVERY_URL: "https://authenticatie-ti.vlaanderen.be/op"
      MU_APPLICATION_AUTH_CLIENT_ID: "03382bf4-4886-4fb6-8602-945ad3080a7a"
      MU_APPLICATION_AUTH_REDIRECT_URI: "https://dashboard.organisaties.abb.lblod.info/authorization/callback"
      MU_APPLICATION_AUTH_CLIENT_SECRET: "snip" # see ticket for secret

```
</details>

4. You're ready to go :)

Going to `APPLICATION_ADDRESS` in your browser should now give an error when your stack is down, and should show the app when the stack is up. You should then be able to log in as if you were on qa.

> Firefox displays a security warning because of certificate issues, but you can ignore it and force it to continue